### PR TITLE
Add one-shot installer + systemd auto-start + beginner README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,27 +1,255 @@
 # gitdash
 
-Local per-machine dashboard showing every git repo's status vs GitHub, with per-repo push / pull / merge / fetch / stash buttons. No bulk operations.
+A local dashboard that shows every git repo on your machine and tells you, in plain English, what to do with it: push, pull, commit, merge, or nothing. One button per repo. No bulk operations, no surprises.
 
-## Status: scaffold
+**Designed for Claude Code users who hop between machines** and want to know — at a glance — which repos are out of sync with GitHub, where their unsaved work is, and whether anyone (including past-you on a different computer) pushed something they need to pull down.
 
-- [x] Project scaffold (Next.js 15, Tailwind, TypeScript strict)
-- [ ] Discovery + exclude rules
-- [ ] SQLite persistence
-- [ ] `gh api` remote comparison with ETag cache
-- [ ] SSE live updates + chokidar watchers
-- [ ] Per-repo action endpoints
-- [ ] CSRF + Host validation
-- [ ] `bin/gitdash` launcher
+> Linux only for now. macOS/Windows support is on the roadmap.
 
-## Running (dev)
+---
+
+## What you'll need before installing
+
+You can copy-paste each block. Skip any tool you already have.
+
+### 1. Node.js 20 or newer
+
+Check: `node --version` → should print `v20.x.x` or higher.
+
+If not installed, the easiest path is [nvm](https://github.com/nvm-sh/nvm):
 
 ```bash
-npm install
-npm run dev
+curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.0/install.sh | bash
+exec $SHELL                  # reload your shell so nvm is on PATH
+nvm install 20
+nvm use 20
 ```
 
-Opens on `http://127.0.0.1:7420`.
+### 2. Git
 
-## Config
+Check: `git --version`
 
-Future location: `~/.config/gitdash/config.json`. Shipped defaults exclude `node_modules`, `.cache`, `.nvm`, `.mcp`, `.codex`, `.nemoclaw`, `.openclaw`, `snap`.
+If not installed:
+- **Ubuntu/Debian:** `sudo apt install git`
+- **Fedora/RHEL:** `sudo dnf install git`
+- **Arch:** `sudo pacman -S git`
+
+### 3. GitHub CLI (`gh`)
+
+This is how gitdash compares your local repos with GitHub.
+
+Check: `gh --version`
+
+If not installed:
+- **Ubuntu/Debian:** [official install instructions](https://github.com/cli/cli/blob/trunk/docs/install_linux.md#debian-ubuntu-linux-raspberry-pi-os-apt)
+- **Fedora/RHEL:** `sudo dnf install gh`
+- **Arch:** `sudo pacman -S github-cli`
+
+### 4. Sign `gh` in to your GitHub account
+
+This is the part most beginners get stuck on. Run this once:
+
+```bash
+gh auth login
+```
+
+Choose, in order:
+1. **GitHub.com**
+2. **HTTPS** (easier than SSH for first-timers)
+3. **Yes** (authenticate Git with your GitHub credentials)
+4. **Login with a web browser**
+
+Copy the one-time code it shows you, press Enter, and your browser will open. Paste the code, click Authorize, and come back to the terminal. You should see `✓ Authentication complete`.
+
+Verify it worked:
+
+```bash
+gh auth status
+```
+
+Should show `✓ Logged in to github.com account <your-username>`.
+
+---
+
+## Install gitdash
+
+```bash
+git clone https://github.com/imwebdev/gitdash.git
+cd gitdash
+./install.sh
+```
+
+That's it. The installer will:
+
+1. Verify all the above prereqs
+2. Install node dependencies and build
+3. Generate a persistent CSRF token (so your browser doesn't get logged out on every restart)
+4. Install a systemd user service so gitdash auto-restarts on crash
+5. Optionally enable lingering (so it survives logout and reboot — asks for `sudo`)
+
+When it finishes you'll see something like:
+
+```
+  gitdash installed and running
+
+  Open in browser:
+    http://127.0.0.1:7420
+    http://192.168.1.6:7420  (other devices on your network)
+```
+
+**Open the URL** and you should see your repos sorted into actionable groups:
+
+- 🔴 **Need attention** — merge or rebase mid-flight
+- 🟠 **Diverged from GitHub** — both you and GitHub have new commits
+- 🟢 **Want to be pushed** — you've committed locally
+- 🔵 **Have incoming changes** — GitHub has new commits
+- 🟡 **Have unsaved changes** — files edited but not committed
+- ✅ **All synced** — nothing to do
+
+---
+
+## Using gitdash
+
+### "I just sat down at a different computer"
+
+1. Look for the **blue "Pull"** buttons. Click each — they download the new commits.
+2. Look for the **yellow "Commit & push"** buttons. Click them, type a quick message, and your work goes to GitHub.
+
+### "I don't know what 'commit' means"
+
+In gitdash, "Commit & push" does this in one step:
+1. Stages every changed file in the repo (`git add -A`)
+2. Wraps them up with the message you type (`git commit`)
+3. Sends them to GitHub (`git push`)
+
+Before it runs, gitdash shows you exactly which files will be sent and **warns you in red if any of them look like secrets** (`.env`, `*.key`, `*.pem`, anything matching `credentials`/`secrets`) or are over 10MB. You can cancel.
+
+### Per-row `⋯` menu
+
+Each repo row has a dot-dot-dot button on the right. Click it for:
+
+- **Fetch from GitHub** — refresh remote state without pulling
+- **Open in editor** — opens VS Code (override with `GITDASH_EDITOR=...`)
+- **Open in terminal** — opens a terminal in the repo directory
+- **Open on GitHub** — jumps to the repo in your browser
+- **Copy clone URL** — handy when setting up a new machine
+
+---
+
+## Daily commands
+
+```bash
+systemctl --user status gitdash       # is it running?
+systemctl --user restart gitdash      # restart (after editing ~/.config/gitdash/env)
+systemctl --user stop gitdash         # stop
+systemctl --user start gitdash        # start
+journalctl --user -u gitdash -f       # live logs (Ctrl+C to exit)
+```
+
+## Updating gitdash
+
+```bash
+cd /path/to/gitdash
+git pull
+./install.sh                          # re-runnable; rebuilds and restarts
+```
+
+## Uninstalling
+
+```bash
+./uninstall.sh                        # remove the service, keep config + database
+./uninstall.sh --purge                # also delete ~/.config/gitdash and ~/.local/state/gitdash
+```
+
+---
+
+## Configuration
+
+The installer creates `~/.config/gitdash/env`. Edit it to override defaults:
+
+```bash
+GITDASH_CSRF_TOKEN=…             # auto-generated; keep secret
+GITDASH_PORT=7420                # change if 7420 is taken
+GITDASH_BIND=0.0.0.0             # 127.0.0.1 to lock to localhost only
+# GITDASH_EDITOR=code            # default; try `nvim`, `subl`, `idea` etc.
+# GITDASH_TERMINAL=x-terminal-emulator   # try `kitty`, `gnome-terminal`, `alacritty`
+# GITDASH_DB=/custom/path/gitdash.sqlite
+```
+
+After changing, restart: `systemctl --user restart gitdash`.
+
+To control which folders gitdash scans, drop a `~/.config/gitdash/config.json`:
+
+```json
+{
+  "roots": ["/home/you/code", "/home/you/work"],
+  "maxDepth": 6,
+  "excludePatterns": ["node_modules", ".cache", "vendor"]
+}
+```
+
+---
+
+## Troubleshooting
+
+**Browser shows "forbidden host"**
+Your browser is hitting gitdash on a hostname/IP that isn't in the allowlist (loopback, RFC1918, link-local, or 100.64/10 CGNAT). Use `127.0.0.1` or your LAN IP, not a public domain.
+
+**`Application error: a client-side exception has occurred`**
+Hard-refresh your browser (Ctrl/Cmd+Shift+R). Stale client JS is the #1 cause after an update.
+
+**Repos show as "unknown" with nothing happening**
+You probably haven't run `gh auth login`. Check with `gh auth status`. If it fails, re-run `gh auth login`.
+
+**`Repository scope` error or push fails with auth error**
+Your `gh` token is missing the `repo` scope. Fix:
+```bash
+gh auth refresh -s repo
+```
+
+**Port 7420 is already in use**
+Edit `~/.config/gitdash/env`, set `GITDASH_PORT=7421` (or whatever's free), then `systemctl --user restart gitdash`.
+
+**Service won't start — check logs**
+```bash
+journalctl --user -u gitdash -n 50 --no-pager
+```
+
+**"Open in editor" doesn't open my preferred editor**
+Set `GITDASH_EDITOR` in `~/.config/gitdash/env` to the binary name (must be on `PATH`). Restart the service.
+
+**It worked yesterday but now nothing loads**
+The first thing to check is whether the service is running and the build is current:
+```bash
+systemctl --user status gitdash
+cd /path/to/gitdash && git log -1 --format='%h %s'
+```
+If you pulled new code, re-run `./install.sh` to rebuild.
+
+---
+
+## Architecture (briefly)
+
+- **Next.js 15 + React 19**, server-side rendered, single page (`app/page.tsx`).
+- **SQLite** (`better-sqlite3`) for persistence at `~/.local/state/gitdash/gitdash.sqlite`. Stores repo discovery, snapshots, action history, and the GitHub API ETag cache.
+- **Background scheduler** runs three loops: directory discovery (10 min), local `git status` snapshots (on-demand + post-action), and remote comparison via `gh api` (staggered, ETag-cached).
+- **Live updates** stream from server to browser via Server-Sent Events.
+- **Action pipeline** — every push/pull/commit-push spawns a real `git` subprocess (no `bash -c`, no shell injection), streams stdout to the browser, and refreshes that one repo afterward.
+- **Security** — host header allowlist (private nets only), CSRF on all mutating routes, no shell, action whitelist.
+
+For more detail see [`CLAUDE.md`](./CLAUDE.md).
+
+---
+
+## Roadmap
+
+Track in [GitHub Issues](https://github.com/imwebdev/gitdash/issues). Next up:
+
+- Click-to-expand row detail (recent commits + actions) — #8
+- "GitHub not connected" onboarding banner — #9
+- Section for "Local only — no GitHub remote" repos — #10
+- Status pills replacing arrows — #11
+
+## License
+
+MIT — see `LICENSE` if/when added.

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,165 @@
+#!/usr/bin/env bash
+# install.sh
+#
+# One-shot installer for gitdash. Re-runnable: detects existing install and
+# updates in place (rebuilds, restarts the systemd unit).
+#
+# Usage:
+#   ./install.sh                # full install with auto-start on boot
+#   ./install.sh --no-linger    # skip the sudo loginctl enable-linger step
+#   ./install.sh --no-start     # install unit but don't enable/start it
+#   ./install.sh --help
+
+set -euo pipefail
+
+REPO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CONFIG_DIR="${XDG_CONFIG_HOME:-$HOME/.config}/gitdash"
+SYSTEMD_DIR="${XDG_CONFIG_HOME:-$HOME/.config}/systemd/user"
+ENV_FILE="$CONFIG_DIR/env"
+SERVICE_NAME="gitdash"
+SERVICE_FILE="$SYSTEMD_DIR/$SERVICE_NAME.service"
+TEMPLATE="$REPO_DIR/scripts/gitdash.service"
+
+WANT_LINGER=1
+WANT_START=1
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --no-linger)  WANT_LINGER=0; shift ;;
+    --no-start)   WANT_START=0; shift ;;
+    --help|-h)
+      grep -E '^#( |$)' "$0" | sed 's/^# \{0,1\}//'
+      exit 0
+      ;;
+    *) echo "Unknown flag: $1 (try --help)" >&2; exit 2 ;;
+  esac
+done
+
+bold()  { printf "\033[1m%s\033[0m\n" "$*"; }
+green() { printf "\033[0;32m%s\033[0m\n" "$*"; }
+red()   { printf "\033[0;31m%s\033[0m\n" "$*"; }
+dim()   { printf "\033[2m%s\033[0m\n" "$*"; }
+
+step() { echo; bold "▸ $*"; }
+
+# ─────────────────────────────────────────────────────────
+# If an existing systemd unit is running, stop it first so the port-7420
+# preflight check passes during a re-run (update). We restart it at the end.
+EXISTING_SERVICE_RAN=0
+if command -v systemctl >/dev/null 2>&1 && \
+   systemctl --user is-active "$SERVICE_NAME" >/dev/null 2>&1; then
+  dim "Existing gitdash service is running — stopping it for the duration of the install"
+  systemctl --user stop "$SERVICE_NAME" >/dev/null 2>&1 || true
+  EXISTING_SERVICE_RAN=1
+fi
+
+step "1/6 Preflight checks"
+"$REPO_DIR/scripts/preflight.sh" || {
+  red "Preflight failed. See messages above. Aborting install."
+  if [[ $EXISTING_SERVICE_RAN -eq 1 ]]; then
+    dim "Restarting the previously-running service"
+    systemctl --user start "$SERVICE_NAME" >/dev/null 2>&1 || true
+  fi
+  exit 1
+}
+
+# ─────────────────────────────────────────────────────────
+step "2/6 Installing dependencies"
+cd "$REPO_DIR"
+if [[ -f package-lock.json ]]; then
+  npm ci
+else
+  npm install
+fi
+
+# ─────────────────────────────────────────────────────────
+step "3/6 Building"
+npm run build
+
+# ─────────────────────────────────────────────────────────
+step "4/6 Configuration"
+mkdir -p "$CONFIG_DIR"
+if [[ -f "$ENV_FILE" ]]; then
+  dim "  Config exists at $ENV_FILE — keeping existing CSRF token"
+else
+  CSRF_TOKEN=$(node -e 'console.log(require("crypto").randomBytes(24).toString("base64url"))')
+  cat > "$ENV_FILE" <<EOF
+# gitdash environment — sourced by the systemd service.
+# Edit values below to override defaults. Restart the service after changes:
+#   systemctl --user restart gitdash
+
+GITDASH_CSRF_TOKEN=$CSRF_TOKEN
+GITDASH_PORT=7420
+GITDASH_BIND=0.0.0.0
+# GITDASH_EDITOR=code
+# GITDASH_TERMINAL=x-terminal-emulator
+# GITDASH_DB=$HOME/.local/state/gitdash/gitdash.sqlite
+EOF
+  chmod 600 "$ENV_FILE"
+  green "  Wrote $ENV_FILE (mode 600)"
+fi
+
+# ─────────────────────────────────────────────────────────
+step "5/6 Installing systemd user service"
+if ! command -v systemctl >/dev/null 2>&1; then
+  red "  systemctl not available — skipping unit install."
+  red "  Run manually:  ./bin/gitdash start"
+  exit 0
+fi
+
+mkdir -p "$SYSTEMD_DIR"
+sed "s|{{REPO_DIR}}|$REPO_DIR|g" "$TEMPLATE" > "$SERVICE_FILE"
+green "  Wrote $SERVICE_FILE"
+
+systemctl --user daemon-reload
+
+if [[ $WANT_START -eq 1 ]]; then
+  systemctl --user enable --now "$SERVICE_NAME"
+  green "  Enabled + started: systemctl --user status $SERVICE_NAME"
+else
+  systemctl --user enable "$SERVICE_NAME"
+  dim "  Enabled (not started). Start with: systemctl --user start $SERVICE_NAME"
+fi
+
+# ─────────────────────────────────────────────────────────
+step "6/6 Auto-start on boot (lingering)"
+if [[ $WANT_LINGER -eq 1 ]]; then
+  if loginctl show-user "$USER" 2>/dev/null | grep -q "Linger=yes"; then
+    dim "  Already enabled."
+  else
+    echo "  This lets gitdash start at boot without an active login session."
+    echo "  Requires sudo:"
+    if sudo -n loginctl enable-linger "$USER" 2>/dev/null; then
+      green "  Enabled (no password prompt)."
+    else
+      echo
+      sudo loginctl enable-linger "$USER" || {
+        red "  Skipped — you can enable later with: sudo loginctl enable-linger $USER"
+      }
+    fi
+  fi
+else
+  dim "  Skipped (--no-linger). gitdash will only run while you're logged in."
+fi
+
+# ─────────────────────────────────────────────────────────
+echo
+green "──────────────────────────────────────────────────"
+green "  gitdash installed and running"
+green "──────────────────────────────────────────────────"
+PORT=$(grep -E '^GITDASH_PORT=' "$ENV_FILE" | cut -d= -f2 | tr -d '"' )
+PORT=${PORT:-7420}
+LAN_IP=$(hostname -I 2>/dev/null | tr ' ' '\n' | grep -E '^(192\.168|10\.|172\.(1[6-9]|2[0-9]|3[01]))\.' | head -1 || true)
+echo
+echo "  Open in browser:"
+echo "    http://127.0.0.1:$PORT"
+[[ -n "$LAN_IP" ]] && echo "    http://$LAN_IP:$PORT  (other devices on your network)"
+echo
+echo "  Useful commands:"
+echo "    systemctl --user status gitdash       # is it running?"
+echo "    systemctl --user restart gitdash      # restart"
+echo "    systemctl --user stop gitdash         # stop"
+echo "    journalctl --user -u gitdash -f       # live logs"
+echo "    ./install.sh                          # update + restart (re-runnable)"
+echo "    ./uninstall.sh                        # remove cleanly"
+echo

--- a/scripts/gitdash.service
+++ b/scripts/gitdash.service
@@ -1,0 +1,23 @@
+[Unit]
+Description=gitdash — local git status dashboard
+Documentation=https://github.com/imwebdev/gitdash
+After=network.target
+
+[Service]
+Type=simple
+WorkingDirectory={{REPO_DIR}}
+ExecStart=/bin/bash {{REPO_DIR}}/bin/gitdash start
+EnvironmentFile=%h/.config/gitdash/env
+
+# Restart on crash; throttle to avoid tight loops
+Restart=on-failure
+RestartSec=5
+StartLimitIntervalSec=60
+StartLimitBurst=3
+
+# Logging via journald — view with: journalctl --user -u gitdash -f
+StandardOutput=journal
+StandardError=journal
+
+[Install]
+WantedBy=default.target

--- a/scripts/preflight.sh
+++ b/scripts/preflight.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+# scripts/preflight.sh
+#
+# Verifies the host has everything gitdash needs. Used by install.sh.
+# Can also be run standalone:  ./scripts/preflight.sh
+#
+# Exits 0 on full pass, 1 if anything is missing.
+
+set -uo pipefail
+
+PASS="\033[0;32m✓\033[0m"
+FAIL="\033[0;31m✗\033[0m"
+WARN="\033[0;33m!\033[0m"
+
+errors=0
+warnings=0
+
+check() {
+  # check "label" "command" [remediation]
+  local label=$1 cmd=$2 remedy=${3:-}
+  if eval "$cmd" >/dev/null 2>&1; then
+    printf "  ${PASS} %s\n" "$label"
+  else
+    printf "  ${FAIL} %s\n" "$label"
+    [[ -n "$remedy" ]] && printf "      → %s\n" "$remedy"
+    errors=$((errors+1))
+  fi
+}
+
+warn() {
+  local label=$1 cmd=$2 remedy=${3:-}
+  if eval "$cmd" >/dev/null 2>&1; then
+    printf "  ${PASS} %s\n" "$label"
+  else
+    printf "  ${WARN} %s\n" "$label"
+    [[ -n "$remedy" ]] && printf "      → %s\n" "$remedy"
+    warnings=$((warnings+1))
+  fi
+}
+
+echo
+echo "Required tools"
+echo "──────────────"
+check "git installed" "command -v git" "Install git: apt install git / brew install git"
+check "node installed" "command -v node" "Install Node.js 20+ from https://nodejs.org or via nvm"
+check "npm installed" "command -v npm" "Comes with Node.js"
+
+if command -v node >/dev/null 2>&1; then
+  node_version=$(node --version | sed 's/v//' | cut -d. -f1)
+  if [[ "$node_version" -lt 20 ]]; then
+    printf "  ${FAIL} node version >= 20 (found v%s)\n" "$node_version"
+    printf "      → Upgrade Node.js. Recommended: nvm install 20 && nvm use 20\n"
+    errors=$((errors+1))
+  else
+    printf "  ${PASS} node version >= 20 (found v%s)\n" "$node_version"
+  fi
+fi
+
+echo
+echo "GitHub access (required for repo comparison)"
+echo "──────────────"
+check "gh CLI installed" "command -v gh" "Install GitHub CLI: https://cli.github.com — apt install gh / brew install gh"
+check "gh authenticated" "gh auth status" "Run: gh auth login   (choose GitHub.com → HTTPS → login with browser)"
+
+echo
+echo "System integration"
+echo "──────────────"
+check "systemctl available" "command -v systemctl" "systemd required for auto-start. Manual launch via ./bin/gitdash start still works."
+check "port 7420 free" "! ss -tln 2>/dev/null | grep -q ':7420 '" "Port 7420 is in use. Stop the other service or set GITDASH_PORT=<other> before running install."
+
+echo
+echo "Optional"
+echo "──────────────"
+warn "VS Code (\`code\`) available" "command -v code" "Default editor is \`code\`. Override with GITDASH_EDITOR=<your-editor> if you use something else."
+warn "x-terminal-emulator available" "command -v x-terminal-emulator" "Used for the 'Open in terminal' button. Override with GITDASH_TERMINAL=<gnome-terminal|kitty|alacritty|...> if needed."
+
+echo
+if [[ $errors -gt 0 ]]; then
+  echo "─────────────────────────────────────────"
+  printf "${FAIL} %d required check(s) failed. Fix the above and re-run.\n" "$errors"
+  echo
+  exit 1
+fi
+
+if [[ $warnings -gt 0 ]]; then
+  printf "${WARN} %d optional check(s) failed — see notes above. Continuing.\n" "$warnings"
+fi
+echo "All required checks passed."
+echo
+exit 0

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+# uninstall.sh
+#
+# Cleanly removes the gitdash systemd unit. Optionally also wipes the SQLite
+# database and the persistent CSRF/env config. Does NOT delete the repo itself.
+#
+# Usage:
+#   ./uninstall.sh                # remove unit only, keep config and DB
+#   ./uninstall.sh --purge        # also delete config + DB (irreversible)
+#   ./uninstall.sh --no-linger    # also disable user lingering (sudo)
+#   ./uninstall.sh --help
+
+set -euo pipefail
+
+CONFIG_DIR="${XDG_CONFIG_HOME:-$HOME/.config}/gitdash"
+SYSTEMD_DIR="${XDG_CONFIG_HOME:-$HOME/.config}/systemd/user"
+STATE_DIR="${XDG_STATE_HOME:-$HOME/.local/state}/gitdash"
+SERVICE_NAME="gitdash"
+SERVICE_FILE="$SYSTEMD_DIR/$SERVICE_NAME.service"
+
+PURGE=0
+DISABLE_LINGER=0
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --purge)      PURGE=1; shift ;;
+    --no-linger)  DISABLE_LINGER=1; shift ;;
+    --help|-h)
+      grep -E '^#( |$)' "$0" | sed 's/^# \{0,1\}//'
+      exit 0
+      ;;
+    *) echo "Unknown flag: $1 (try --help)" >&2; exit 2 ;;
+  esac
+done
+
+green() { printf "\033[0;32m%s\033[0m\n" "$*"; }
+dim()   { printf "\033[2m%s\033[0m\n" "$*"; }
+
+if command -v systemctl >/dev/null 2>&1; then
+  if systemctl --user is-enabled "$SERVICE_NAME" >/dev/null 2>&1 || \
+     systemctl --user is-active "$SERVICE_NAME" >/dev/null 2>&1; then
+    systemctl --user disable --now "$SERVICE_NAME" 2>/dev/null || true
+    green "Stopped + disabled $SERVICE_NAME"
+  fi
+fi
+
+if [[ -f "$SERVICE_FILE" ]]; then
+  rm -f "$SERVICE_FILE"
+  command -v systemctl >/dev/null 2>&1 && systemctl --user daemon-reload || true
+  green "Removed $SERVICE_FILE"
+fi
+
+if [[ $PURGE -eq 1 ]]; then
+  if [[ -d "$CONFIG_DIR" ]]; then
+    rm -rf "$CONFIG_DIR"
+    green "Removed $CONFIG_DIR"
+  fi
+  if [[ -d "$STATE_DIR" ]]; then
+    rm -rf "$STATE_DIR"
+    green "Removed $STATE_DIR (SQLite database, action history, GH ETag cache)"
+  fi
+else
+  dim "Kept $CONFIG_DIR and $STATE_DIR (use --purge to delete)"
+fi
+
+if [[ $DISABLE_LINGER -eq 1 ]]; then
+  sudo loginctl disable-linger "$USER" 2>/dev/null && green "Disabled user linger" || \
+    dim "Could not disable linger (may require sudo or wasn't enabled)"
+fi
+
+echo
+green "Uninstall complete. The repo itself is still here at:"
+echo "  $(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+echo "Delete it manually if you want to remove gitdash entirely."


### PR DESCRIPTION
## Summary

Beginner-friendly install path. Goal: `git clone … && cd gitdash && ./install.sh` produces a running, auto-restarting, survives-reboot service.

**Files added:**
- `install.sh` — one-shot installer, re-runnable for updates. Stops existing service before preflight so the port-7420 check passes during a re-run.
- `uninstall.sh` — clean reversal, with `--purge` to also wipe DB + config.
- `scripts/preflight.sh` — standalone prereq checks (node ≥20, git, gh installed + authed, systemctl present, port free).
- `scripts/gitdash.service` — systemd user unit template, persistent across reboots when lingering enabled.
- `README.md` — full rewrite. Beginner walkthrough including `gh auth login` step-by-step, daily commands, update flow, troubleshooting.

Closes #12.

## Test plan

On a fresh machine (or one without gitdash):
- [ ] `git clone https://github.com/imwebdev/gitdash.git && cd gitdash`
- [ ] `./install.sh` runs cleanly, prints the URL at the end
- [ ] `systemctl --user status gitdash` shows active (running)
- [ ] Browser at `http://127.0.0.1:7420` loads
- [ ] Reboot the machine — gitdash auto-starts (if linger was enabled)
- [ ] `git pull && ./install.sh` (re-run) — rebuilds, restarts cleanly
- [ ] `./uninstall.sh` removes the unit; service stops; repo files remain
- [ ] `./uninstall.sh --purge` also wipes DB + config

🤖 Generated with [Claude Code](https://claude.com/claude-code)