### PR TITLE
Always show synced section; fold unknown/no-remote into it

### DIFF
--- a/components/Dashboard.tsx
+++ b/components/Dashboard.tsx
@@ -25,7 +25,8 @@ function groupFor(repo: RepoView): GroupKind | null {
   if (s === "behind") return "pull";
   if (s === "dirty") return "dirty";
   if (s === "clean") return "clean";
-  return null; // no-upstream, unknown — hidden in main view (only shown when filtering)
+  if (s === "no-upstream" || s === "unknown") return "untracked";
+  return null;
 }
 
 function buildGroups(repos: RepoView[]): { kind: GroupKind; headline: string; body: string; repos: RepoView[]; defaultCollapsed: boolean }[] {
@@ -38,9 +39,11 @@ function buildGroups(repos: RepoView[]): { kind: GroupKind; headline: string; bo
     buckets.set(g, arr);
   }
 
-  const ordered: GroupKind[] = ["attention", "diverged", "push", "pull", "dirty", "clean"];
+  const ordered: GroupKind[] = ["attention", "diverged", "push", "pull", "dirty", "untracked", "clean"];
+  // "clean" always renders (with an empty-state placeholder when count = 0)
+  // "untracked" defaults to collapsed since it's noise, not actionable
   return ordered
-    .filter((k) => (buckets.get(k) ?? []).length > 0)
+    .filter((k) => k === "clean" || (buckets.get(k) ?? []).length > 0)
     .map((kind) => {
       const list = (buckets.get(kind) ?? []).slice();
       list.sort((a, b) => a.displayName.localeCompare(b.displayName));
@@ -49,7 +52,7 @@ function buildGroups(repos: RepoView[]): { kind: GroupKind; headline: string; bo
         headline: headlineFor(kind, list.length),
         body: bodyFor(kind, list.length),
         repos: list,
-        defaultCollapsed: false,
+        defaultCollapsed: kind === "untracked",
       };
     });
 }
@@ -62,7 +65,12 @@ function headlineFor(kind: GroupKind, n: number): string {
     case "push": return `${plural === "repo" ? "wants" : "want"} to be pushed`;
     case "pull": return `${plural === "repo" ? "has" : "have"} incoming changes`;
     case "dirty": return `${plural === "repo" ? "has" : "have"} unsaved changes`;
-    case "clean": return `${plural === "repo" ? "is" : "are"} all synced`;
+    case "untracked": return n === 0
+      ? "no GitHub link"
+      : `${plural === "repo" ? "is" : "are"} not linked to GitHub`;
+    case "clean": return n === 0
+      ? "are all synced"
+      : `${plural === "repo" ? "is" : "are"} all synced`;
   }
 }
 
@@ -73,7 +81,8 @@ function bodyFor(kind: GroupKind, _n: number): string {
     case "push": return "You've committed work locally that GitHub doesn't have yet. Hit the button to send it up.";
     case "pull": return "Someone (possibly another machine of yours) pushed commits to GitHub. Download them to catch up.";
     case "dirty": return "Files you've edited but haven't committed. Click Open folder to see what changed and commit from your editor. Gitdash doesn't commit for you.";
-    case "clean": return "Nothing to do here. Click to peek at the list.";
+    case "untracked": return "These repos either have no GitHub remote configured, or gitdash hasn't been able to compare them with GitHub yet. To publish a local-only repo, see the roadmap.";
+    case "clean": return "Repos that match GitHub exactly. Nothing to do here.";
   }
 }
 
@@ -125,7 +134,10 @@ export function Dashboard({ initialRepos, csrfToken }: Props) {
   const groups = useMemo(() => buildGroups(filtered), [filtered]);
 
   const actionableCount = useMemo(
-    () => groups.filter((g) => g.kind !== "clean" && g.kind !== "dirty").reduce((n, g) => n + g.repos.length, 0),
+    () =>
+      groups
+        .filter((g) => g.kind !== "clean" && g.kind !== "dirty" && g.kind !== "untracked")
+        .reduce((n, g) => n + g.repos.length, 0),
     [groups],
   );
 

--- a/components/Dashboard.tsx
+++ b/components/Dashboard.tsx
@@ -66,8 +66,8 @@ function headlineFor(kind: GroupKind, n: number): string {
     case "pull": return `${plural === "repo" ? "has" : "have"} incoming changes`;
     case "dirty": return `${plural === "repo" ? "has" : "have"} unsaved changes`;
     case "untracked": return n === 0
-      ? "no GitHub link"
-      : `${plural === "repo" ? "is" : "are"} not linked to GitHub`;
+      ? "status unknown"
+      : `${plural === "repo" ? "has" : "have"} an unknown status`;
     case "clean": return n === 0
       ? "are all synced"
       : `${plural === "repo" ? "is" : "are"} all synced`;
@@ -81,7 +81,7 @@ function bodyFor(kind: GroupKind, _n: number): string {
     case "push": return "You've committed work locally that GitHub doesn't have yet. Hit the button to send it up.";
     case "pull": return "Someone (possibly another machine of yours) pushed commits to GitHub. Download them to catch up.";
     case "dirty": return "Files you've edited but haven't committed. Click Open folder to see what changed and commit from your editor. Gitdash doesn't commit for you.";
-    case "untracked": return "These repos either have no GitHub remote configured, or gitdash hasn't been able to compare them with GitHub yet. To publish a local-only repo, see the roadmap.";
+    case "untracked": return "Gitdash hasn't been able to determine sync state for these repos. They might have no GitHub remote configured, or the comparison call to GitHub silently failed (a known bug — see issue #17). Try the Fetch button in a row's ⋯ menu to re-check.";
     case "clean": return "Repos that match GitHub exactly. Nothing to do here.";
   }
 }

--- a/components/Dashboard.tsx
+++ b/components/Dashboard.tsx
@@ -17,16 +17,19 @@ interface Group {
   defaultCollapsed?: boolean;
 }
 
-function groupFor(repo: RepoView): GroupKind | null {
+function groupFor(repo: RepoView): GroupKind {
   const s = repo.derivedState;
   if (s === "weird") return "attention";
   if (s === "diverged") return "diverged";
   if (s === "ahead") return "push";
   if (s === "behind") return "pull";
   if (s === "dirty") return "dirty";
-  if (s === "clean") return "clean";
-  if (s === "no-upstream" || s === "unknown") return "untracked";
-  return null;
+  // Everything else (clean, no-upstream, unknown) → "no updates needed".
+  // Comparison failures and missing remotes default to clean rather than
+  // surfacing an "unknown" bucket the user can't act on. If the comparison
+  // is truly stale and a real divergence is hiding, the user'll find out
+  // when they hit Fetch in the row's ⋯ menu.
+  return "clean";
 }
 
 function buildGroups(repos: RepoView[]): { kind: GroupKind; headline: string; body: string; repos: RepoView[]; defaultCollapsed: boolean }[] {
@@ -39,9 +42,8 @@ function buildGroups(repos: RepoView[]): { kind: GroupKind; headline: string; bo
     buckets.set(g, arr);
   }
 
-  const ordered: GroupKind[] = ["attention", "diverged", "push", "pull", "dirty", "untracked", "clean"];
+  const ordered: GroupKind[] = ["attention", "diverged", "push", "pull", "dirty", "clean"];
   // "clean" always renders (with an empty-state placeholder when count = 0)
-  // "untracked" defaults to collapsed since it's noise, not actionable
   return ordered
     .filter((k) => k === "clean" || (buckets.get(k) ?? []).length > 0)
     .map((kind) => {
@@ -52,7 +54,7 @@ function buildGroups(repos: RepoView[]): { kind: GroupKind; headline: string; bo
         headline: headlineFor(kind, list.length),
         body: bodyFor(kind, list.length),
         repos: list,
-        defaultCollapsed: kind === "untracked",
+        defaultCollapsed: false,
       };
     });
 }
@@ -65,12 +67,9 @@ function headlineFor(kind: GroupKind, n: number): string {
     case "push": return `${plural === "repo" ? "wants" : "want"} to be pushed`;
     case "pull": return `${plural === "repo" ? "has" : "have"} incoming changes`;
     case "dirty": return `${plural === "repo" ? "has" : "have"} unsaved changes`;
-    case "untracked": return n === 0
-      ? "status unknown"
-      : `${plural === "repo" ? "has" : "have"} an unknown status`;
     case "clean": return n === 0
-      ? "are all synced"
-      : `${plural === "repo" ? "is" : "are"} all synced`;
+      ? "no updates needed"
+      : `${plural === "repo" ? "needs" : "need"} no updates`;
   }
 }
 
@@ -81,8 +80,7 @@ function bodyFor(kind: GroupKind, _n: number): string {
     case "push": return "You've committed work locally that GitHub doesn't have yet. Hit the button to send it up.";
     case "pull": return "Someone (possibly another machine of yours) pushed commits to GitHub. Download them to catch up.";
     case "dirty": return "Files you've edited but haven't committed. Click Open folder to see what changed and commit from your editor. Gitdash doesn't commit for you.";
-    case "untracked": return "Gitdash hasn't been able to determine sync state for these repos. They might have no GitHub remote configured, or the comparison call to GitHub silently failed (a known bug — see issue #17). Try the Fetch button in a row's ⋯ menu to re-check.";
-    case "clean": return "Repos that match GitHub exactly. Nothing to do here.";
+    case "clean": return "These repos are in sync — nothing to push or pull. If a comparison is stale or you suspect the data is wrong, hit Fetch in the row's ⋯ menu to re-check.";
   }
 }
 
@@ -136,7 +134,7 @@ export function Dashboard({ initialRepos, csrfToken }: Props) {
   const actionableCount = useMemo(
     () =>
       groups
-        .filter((g) => g.kind !== "clean" && g.kind !== "dirty" && g.kind !== "untracked")
+        .filter((g) => g.kind !== "clean" && g.kind !== "dirty")
         .reduce((n, g) => n + g.repos.length, 0),
     [groups],
   );

--- a/components/RepoCard.tsx
+++ b/components/RepoCard.tsx
@@ -17,7 +17,7 @@ import {
   TerminalSquare,
 } from "lucide-react";
 
-export type GroupKind = "push" | "pull" | "diverged" | "attention" | "dirty" | "untracked" | "clean";
+export type GroupKind = "push" | "pull" | "diverged" | "attention" | "dirty" | "clean";
 
 export const ROW_GRID =
   "grid-cols-[minmax(180px,1.4fr)_120px_150px_minmax(200px,1.6fr)_80px_148px_36px]";
@@ -36,7 +36,6 @@ function primaryAction(
     if (hasRemote) return { label: "Commit & push", action: "commit-push" };
     return { label: "Open", action: "open-editor" };
   }
-  if (kind === "untracked") return { label: "Open folder", action: "open-editor" };
   return { label: "", action: null };
 }
 
@@ -133,8 +132,6 @@ export function RepoCard({ repo, kind, csrfToken }: Props) {
                 "border-accent-attention/35 bg-accent-attention/10 text-accent-attention hover:border-accent-attention/55 hover:bg-accent-attention/20",
               kind === "dirty" &&
                 "border-accent-dirty/35 bg-accent-dirty/10 text-accent-dirty hover:border-accent-dirty/55 hover:bg-accent-dirty/20",
-              kind === "untracked" &&
-                "border-fg-dim/30 bg-fg-dim/10 text-fg-muted hover:border-fg-dim/50 hover:bg-fg-dim/20",
             )}
           >
             {button.label}

--- a/components/RepoCard.tsx
+++ b/components/RepoCard.tsx
@@ -17,7 +17,7 @@ import {
   TerminalSquare,
 } from "lucide-react";
 
-export type GroupKind = "push" | "pull" | "diverged" | "attention" | "dirty" | "clean";
+export type GroupKind = "push" | "pull" | "diverged" | "attention" | "dirty" | "untracked" | "clean";
 
 export const ROW_GRID =
   "grid-cols-[minmax(180px,1.4fr)_120px_150px_minmax(200px,1.6fr)_80px_148px_36px]";
@@ -36,6 +36,7 @@ function primaryAction(
     if (hasRemote) return { label: "Commit & push", action: "commit-push" };
     return { label: "Open", action: "open-editor" };
   }
+  if (kind === "untracked") return { label: "Open folder", action: "open-editor" };
   return { label: "", action: null };
 }
 
@@ -132,6 +133,8 @@ export function RepoCard({ repo, kind, csrfToken }: Props) {
                 "border-accent-attention/35 bg-accent-attention/10 text-accent-attention hover:border-accent-attention/55 hover:bg-accent-attention/20",
               kind === "dirty" &&
                 "border-accent-dirty/35 bg-accent-dirty/10 text-accent-dirty hover:border-accent-dirty/55 hover:bg-accent-dirty/20",
+              kind === "untracked" &&
+                "border-fg-dim/30 bg-fg-dim/10 text-fg-muted hover:border-fg-dim/50 hover:bg-fg-dim/20",
             )}
           >
             {button.label}

--- a/components/RepoGroup.tsx
+++ b/components/RepoGroup.tsx
@@ -21,6 +21,7 @@ const TINT: Record<GroupKind, string> = {
   diverged: "tint-diverged",
   attention: "tint-attention",
   dirty: "tint-dirty",
+  untracked: "bg-bg-elevated/40",
   clean: "tint-clean",
 };
 
@@ -30,7 +31,12 @@ const ACCENT: Record<GroupKind, string> = {
   diverged: "text-accent-diverged",
   attention: "text-accent-attention",
   dirty: "text-accent-dirty",
+  untracked: "text-fg-dim",
   clean: "text-accent-clean",
+};
+
+const EMPTY_COPY: Partial<Record<GroupKind, string>> = {
+  clean: "Nothing in sync yet. Push or commit something to land a repo here.",
 };
 
 export function RepoGroup({
@@ -42,8 +48,11 @@ export function RepoGroup({
   defaultCollapsed = false,
 }: Props) {
   const [collapsed, setCollapsed] = useState(defaultCollapsed);
+  const isEmpty = repos.length === 0;
+  const emptyCopy = EMPTY_COPY[kind];
 
-  if (repos.length === 0) return null;
+  // Hide empty sections unless we have explicit empty-state copy for this kind.
+  if (isEmpty && !emptyCopy) return null;
 
   return (
     <section
@@ -53,12 +62,17 @@ export function RepoGroup({
       )}
     >
       <header
-        className="flex cursor-pointer items-start gap-5 px-6 pb-4 pt-6"
-        onClick={() => setCollapsed((v) => !v)}
-        role="button"
-        tabIndex={0}
-        onKeyDown={(e) =>
-          (e.key === "Enter" || e.key === " ") && setCollapsed((v) => !v)
+        className={cn(
+          "flex items-start gap-5 px-6 pb-4 pt-6",
+          !isEmpty && "cursor-pointer",
+        )}
+        onClick={isEmpty ? undefined : () => setCollapsed((v) => !v)}
+        role={isEmpty ? undefined : "button"}
+        tabIndex={isEmpty ? undefined : 0}
+        onKeyDown={
+          isEmpty
+            ? undefined
+            : (e) => (e.key === "Enter" || e.key === " ") && setCollapsed((v) => !v)
         }
       >
         <div
@@ -75,15 +89,23 @@ export function RepoGroup({
           <p className="mt-1 text-[13px] text-fg-muted">{body}</p>
         </div>
 
-        <ChevronRight
-          className={cn(
-            "mt-3 h-4 w-4 shrink-0 text-fg-dim transition-transform",
-            !collapsed && "rotate-90",
-          )}
-        />
+        {!isEmpty && (
+          <ChevronRight
+            className={cn(
+              "mt-3 h-4 w-4 shrink-0 text-fg-dim transition-transform",
+              !collapsed && "rotate-90",
+            )}
+          />
+        )}
       </header>
 
-      {!collapsed && (
+      {isEmpty && emptyCopy && (
+        <div className="border-t border-border-subtle px-6 py-5 text-[13px] italic text-fg-dim">
+          {emptyCopy}
+        </div>
+      )}
+
+      {!isEmpty && !collapsed && (
         <div className="border-t border-border-subtle">
           <div
             className={cn(

--- a/components/RepoGroup.tsx
+++ b/components/RepoGroup.tsx
@@ -21,7 +21,6 @@ const TINT: Record<GroupKind, string> = {
   diverged: "tint-diverged",
   attention: "tint-attention",
   dirty: "tint-dirty",
-  untracked: "bg-bg-elevated/40",
   clean: "tint-clean",
 };
 
@@ -31,12 +30,11 @@ const ACCENT: Record<GroupKind, string> = {
   diverged: "text-accent-diverged",
   attention: "text-accent-attention",
   dirty: "text-accent-dirty",
-  untracked: "text-fg-dim",
   clean: "text-accent-clean",
 };
 
 const EMPTY_COPY: Partial<Record<GroupKind, string>> = {
-  clean: "Nothing in sync yet. Push or commit something to land a repo here.",
+  clean: "No repos here yet. As soon as one is in sync with GitHub, it'll appear in this list.",
 };
 
 export function RepoGroup({


### PR DESCRIPTION
## Summary

Originally this PR added a separate "untracked / status unknown" section. User pushback (correctly): if gitdash can't determine state, just default to "no updates needed" rather than surfacing an opaque "unknown" bucket. Architectural simplification — one less category, no UI cliff for users.

Final behaviour:

- "all synced" section always renders (even with 0 repos), with empty-state placeholder
- `derivedState ∈ {clean, no-upstream, unknown}` → all map to clean section
- Section reads "X need no updates" / empty: "no updates needed"
- Body copy points users at the row's ⋯ menu Fetch action when they suspect data is stale

The deeper bug (why ~36% of repos are stuck at `derivedState: "unknown"` despite valid remotes) is tracked separately in #17.

Closes #15. Refs #17.

## Test plan

- [ ] Hard-refresh
- [ ] "all synced" section renders even when count = 0, with placeholder text
- [ ] No "untracked" / "status unknown" section visible
- [ ] Repos that previously showed as "unknown" (gitdash itself, plus ~13 others) now appear in the synced section
- [ ] Total visible repos = total in DB
- [ ] No regression on push/pull/diverged/dirty/attention sections

🤖 Generated with [Claude Code](https://claude.com/claude-code)