### PR TITLE
Fix gh comparison silently failing on 304 cache hits

### DIFF
--- a/lib/gh/client.ts
+++ b/lib/gh/client.ts
@@ -40,8 +40,33 @@ function writeCache(key: string, etag: string, body: string, now: number): void 
 }
 
 /**
+ * Run `gh api --include` and ALWAYS return whatever stdout we got, even if
+ * the process exited non-zero. `gh` exits 1 on non-2xx HTTP responses
+ * (including 304 Not Modified for conditional requests), but the full
+ * response headers + body are still written to stdout. The previous
+ * implementation treated those exits as fatal failures and dropped the
+ * payload, which silently broke ETag caching — every cached repo got
+ * classified as remoteState="unknown" instead of using the cached SHA.
+ *
+ * Bug history: closes #17.
+ */
+async function runGhApiIncluded(
+  args: string[],
+  timeoutMs: number,
+): Promise<{ raw: string; thrownStderr: string }> {
+  try {
+    const res = await runGh(args, { timeoutMs });
+    return { raw: res.stdout, thrownStderr: "" };
+  } catch (err) {
+    const e = err as { stdout?: string; stderr?: string };
+    return { raw: e.stdout ?? "", thrownStderr: e.stderr ?? "" };
+  }
+}
+
+/**
  * Fetch remote tip SHA for a branch using `gh api` with ETag caching.
- * Returns null on auth/404/422 — logs to stderr. Rate-limit-aware via 304 caching.
+ * Returns null on auth / 404 / parse failure. 304 cache-hits use the
+ * cached body's SHA.
  */
 async function fetchRemoteSha(slug: GitHubSlug, branch: string): Promise<{ sha: string; fromCache: boolean } | null> {
   const key = cacheKey(slug, branch);
@@ -58,35 +83,27 @@ async function fetchRemoteSha(slug: GitHubSlug, branch: string): Promise<{ sha: 
     args.push("-H", `If-None-Match: ${cached.etag}`);
   }
 
-  let stdout: string;
-  try {
-    const res = await runGh(args, { timeoutMs: 15_000 });
-    stdout = res.stdout;
-  } catch (err) {
-    const e = err as { stderr?: string };
-    const stderr = e.stderr ?? "";
-    if (/404/.test(stderr)) return null;
-    if (/403/.test(stderr) && cached) {
-      try {
-        const parsed = JSON.parse(cached.body_json) as { sha?: string };
-        if (parsed.sha) return { sha: parsed.sha, fromCache: true };
-      } catch {
-        // fall through
-      }
-    }
+  const { raw, thrownStderr } = await runGhApiIncluded(args, 15_000);
+
+  // No payload at all → genuine failure (network, command not found, etc.)
+  if (!raw) {
+    if (/404/.test(thrownStderr)) return null;
+    console.error(`[gh] fetchRemoteSha empty payload for ${slug.owner}/${slug.name}@${branch}: ${thrownStderr.trim()}`);
     return null;
   }
 
-  const { statusCode, etag, body } = parseIncludedResponse(stdout);
+  const { statusCode, etag, body } = parseIncludedResponse(raw);
+
   if (statusCode === 304 && cached) {
     try {
       const parsed = JSON.parse(cached.body_json) as { sha?: string };
       if (parsed.sha) return { sha: parsed.sha, fromCache: true };
     } catch {
-      return null;
+      // cached body unparseable — fall through and treat as miss
     }
     return null;
   }
+
   if (statusCode >= 200 && statusCode < 300) {
     try {
       const parsed = JSON.parse(body) as { sha?: string };
@@ -95,6 +112,17 @@ async function fetchRemoteSha(slug: GitHubSlug, branch: string): Promise<{ sha: 
       return { sha: parsed.sha, fromCache: false };
     } catch {
       return null;
+    }
+  }
+
+  // 4xx/5xx → log and fall back to cached SHA if available, else null
+  console.error(`[gh] fetchRemoteSha ${statusCode} for ${slug.owner}/${slug.name}@${branch}`);
+  if (cached) {
+    try {
+      const parsed = JSON.parse(cached.body_json) as { sha?: string };
+      if (parsed.sha) return { sha: parsed.sha, fromCache: true };
+    } catch {
+      // fall through
     }
   }
   return null;
@@ -154,18 +182,29 @@ export async function compareWithRemote(
   ];
   if (cachedCmp) args.push("-H", `If-None-Match: ${cachedCmp.etag}`);
 
-  try {
-    const res = await runGh(args, { timeoutMs: 15_000 });
-    const parsed = parseIncludedResponse(res.stdout);
-    if (parsed.statusCode === 304 && cachedCmp) {
+  const { raw, thrownStderr } = await runGhApiIncluded(args, 15_000);
+  if (!raw) {
+    console.error(`[gh] compareWithRemote empty payload for ${slug.owner}/${slug.name}: ${thrownStderr.trim()}`);
+    return { state: "unknown", ahead: 0, behind: 0, remoteSha: remote.sha, localSha, checkedAt: now };
+  }
+
+  const parsed = parseIncludedResponse(raw);
+
+  if (parsed.statusCode === 304 && cachedCmp) {
+    try {
       const body = JSON.parse(cachedCmp.body_json) as {
         ahead_by?: number;
         behind_by?: number;
         status?: string;
       };
       return comparisonFromBody(body, remote.sha, localSha, now);
+    } catch {
+      // cached body unparseable — fall through to unknown
     }
-    if (parsed.statusCode >= 200 && parsed.statusCode < 300) {
+  }
+
+  if (parsed.statusCode >= 200 && parsed.statusCode < 300) {
+    try {
       const body = JSON.parse(parsed.body) as {
         ahead_by?: number;
         behind_by?: number;
@@ -173,9 +212,13 @@ export async function compareWithRemote(
       };
       if (parsed.etag) writeCache(compareKey, parsed.etag, parsed.body, now);
       return comparisonFromBody(body, remote.sha, localSha, now);
+    } catch {
+      // body parse fail → unknown
     }
-  } catch {
-    // fallthrough
+  }
+
+  if (parsed.statusCode >= 400) {
+    console.error(`[gh] compareWithRemote ${parsed.statusCode} for ${slug.owner}/${slug.name}`);
   }
   return { state: "unknown", ahead: 0, behind: 0, remoteSha: remote.sha, localSha, checkedAt: now };
 }


### PR DESCRIPTION
## Summary

Fixes the silent failure mode where every ETag-cached repo got classified as `remoteState="unknown"` instead of correctly using the cached SHA. Root cause: `gh api --include` exits non-zero on 304 Not Modified, but writes the full response (headers + body) to stdout. The catch blocks in `fetchRemoteSha` and `compareWithRemote` treated the process exit as fatal and dropped the payload.

## Changes

- New `runGhApiIncluded` helper captures stdout from BOTH success and error paths via `try/catch` on `runGh`. Always returns whatever payload gh actually wrote.
- `fetchRemoteSha` rewritten to parse the included response uniformly. 304 → use cached SHA. 200-299 → cache + return fresh SHA. 4xx/5xx → log + fall back to cached SHA if available.
- `compareWithRemote` rewritten with the same pattern: 304 cache-hit returns cached comparison; 2xx returns fresh comparison; 4xx/5xx logs and returns unknown.
- Genuine API failures now log to stderr (visible via `journalctl --user -u gitdash`) with `[gh]` prefix + slug + status code. No more silent classification breakage.

Closes #17.

## Verified live

Before fix: 35/36 repos = `remote_state: "unknown"`, 1/36 clean.
After fix (90s in, after one full remote tick cycle): 33/36 unknown, 2/36 clean, 1/36 ahead.

The 33 remaining "unknown" repos are mostly **legitimate 404/422 errors** — local branches that don't exist on remote (e.g. `feature/17-fix-gh-comparison` itself, before this branch was pushed). That's a separate problem — will file a follow-up issue for "fall back to default branch when local branch doesn't exist on remote".

Logs now show concrete failure reasons:
```
[gh] fetchRemoteSha 404 for imwebdev/ai-build-mastery@main
[gh] fetchRemoteSha 422 for imwebdev/gitdash@feature/17-fix-gh-comparison
[gh] compareWithRemote 404 for godagoo/claude-telegram-relay
```

## Test plan

- [ ] Check `journalctl --user -u gitdash | grep '\[gh\]'` — should show 4xx errors for repos with branch/repo issues, no errors for ones that work
- [ ] After 1-2 minutes (full remote tick cycle), `sqlite3 .../gitdash.sqlite "SELECT remote_state, COUNT(*) FROM snapshots GROUP BY remote_state"` — clean and ahead/behind counts should grow as comparisons succeed
- [ ] No regressions: existing clean/ahead/behind/diverged repos still classified correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)