### PR TITLE
Round 1 UX cleanup + Refresh fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,255 +1,117 @@
-# gitdash
+# 🚀 gitdash
 
-A local dashboard that shows every git repo on your machine and tells you, in plain English, what to do with it: push, pull, commit, merge, or nothing. One button per repo. No bulk operations, no surprises.
+> A local dashboard for every git repo on your machine. Tells you what to do — push, pull, commit, or nothing — in plain English. One button per repo.
 
-**Designed for Claude Code users who hop between machines** and want to know — at a glance — which repos are out of sync with GitHub, where their unsaved work is, and whether anyone (including past-you on a different computer) pushed something they need to pull down.
+**Built for Claude Code users who hop between machines** and want to know, at a glance, what's out of sync with GitHub.
 
-> Linux only for now. macOS/Windows support is on the roadmap.
-
----
-
-## What you'll need before installing
-
-You can copy-paste each block. Skip any tool you already have.
-
-### 1. Node.js 20 or newer
-
-Check: `node --version` → should print `v20.x.x` or higher.
-
-If not installed, the easiest path is [nvm](https://github.com/nvm-sh/nvm):
-
-```bash
-curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.0/install.sh | bash
-exec $SHELL                  # reload your shell so nvm is on PATH
-nvm install 20
-nvm use 20
-```
-
-### 2. Git
-
-Check: `git --version`
-
-If not installed:
-- **Ubuntu/Debian:** `sudo apt install git`
-- **Fedora/RHEL:** `sudo dnf install git`
-- **Arch:** `sudo pacman -S git`
-
-### 3. GitHub CLI (`gh`)
-
-This is how gitdash compares your local repos with GitHub.
-
-Check: `gh --version`
-
-If not installed:
-- **Ubuntu/Debian:** [official install instructions](https://github.com/cli/cli/blob/trunk/docs/install_linux.md#debian-ubuntu-linux-raspberry-pi-os-apt)
-- **Fedora/RHEL:** `sudo dnf install gh`
-- **Arch:** `sudo pacman -S github-cli`
-
-### 4. Sign `gh` in to your GitHub account
-
-This is the part most beginners get stuck on. Run this once:
-
-```bash
-gh auth login
-```
-
-Choose, in order:
-1. **GitHub.com**
-2. **HTTPS** (easier than SSH for first-timers)
-3. **Yes** (authenticate Git with your GitHub credentials)
-4. **Login with a web browser**
-
-Copy the one-time code it shows you, press Enter, and your browser will open. Paste the code, click Authorize, and come back to the terminal. You should see `✓ Authentication complete`.
-
-Verify it worked:
-
-```bash
-gh auth status
-```
-
-Should show `✓ Logged in to github.com account <your-username>`.
+> 🐧 Linux only right now. macOS + Windows on the way ([#21](https://github.com/imwebdev/gitdash/issues/21)).
 
 ---
 
-## Install gitdash
+## ⚡ Install in 30 seconds
+
+Copy and paste this:
 
 ```bash
-git clone https://github.com/imwebdev/gitdash.git
-cd gitdash
-./install.sh
+git clone https://github.com/imwebdev/gitdash.git && cd gitdash && ./install.sh
 ```
 
-That's it. The installer will:
+That's it. The installer prints a URL when it's done — open it in your browser.
 
-1. Verify all the above prereqs
-2. Install node dependencies and build
-3. Generate a persistent CSRF token (so your browser doesn't get logged out on every restart)
-4. Install a systemd user service so gitdash auto-restarts on crash
-5. Optionally enable lingering (so it survives logout and reboot — asks for `sudo`)
-
-When it finishes you'll see something like:
-
-```
-  gitdash installed and running
-
-  Open in browser:
-    http://127.0.0.1:7420
-    http://192.168.1.6:7420  (other devices on your network)
-```
-
-**Open the URL** and you should see your repos sorted into actionable groups:
-
-- 🔴 **Need attention** — merge or rebase mid-flight
-- 🟠 **Diverged from GitHub** — both you and GitHub have new commits
-- 🟢 **Want to be pushed** — you've committed locally
-- 🔵 **Have incoming changes** — GitHub has new commits
-- 🟡 **Have unsaved changes** — files edited but not committed
-- ✅ **All synced** — nothing to do
+> ❓ **Don't have `git`, `node 20+`, or `gh` installed yet?** Skip down to [Prereqs](#-prereqs).
 
 ---
 
-## Using gitdash
+## 🎨 What you'll see
 
-### "I just sat down at a different computer"
+Every repo on your machine, sorted by what it needs:
 
-1. Look for the **blue "Pull"** buttons. Click each — they download the new commits.
-2. Look for the **yellow "Commit & push"** buttons. Click them, type a quick message, and your work goes to GitHub.
+| | Section | What it means |
+|---|---|---|
+| 🔴 | **Need attention** | Mid-flight merge or rebase — finish what you started |
+| 🟠 | **Diverged from GitHub** | Both you and GitHub have new commits — needs a merge |
+| 🟢 | **Want to be pushed** | You've committed locally — click **Push** |
+| 🔵 | **Have incoming changes** | GitHub has new commits — click **Pull** |
+| 🟡 | **Have unsaved changes** | Files edited, not committed — click **Commit & push** |
+| ✅ | **Need no updates** | In sync, nothing to do |
 
-### "I don't know what 'commit' means"
-
-In gitdash, "Commit & push" does this in one step:
-1. Stages every changed file in the repo (`git add -A`)
-2. Wraps them up with the message you type (`git commit`)
-3. Sends them to GitHub (`git push`)
-
-Before it runs, gitdash shows you exactly which files will be sent and **warns you in red if any of them look like secrets** (`.env`, `*.key`, `*.pem`, anything matching `credentials`/`secrets`) or are over 10MB. You can cancel.
-
-### Per-row `⋯` menu
-
-Each repo row has a dot-dot-dot button on the right. Click it for:
-
-- **Fetch from GitHub** — refresh remote state without pulling
-- **Open in editor** — opens VS Code (override with `GITDASH_EDITOR=...`)
-- **Open in terminal** — opens a terminal in the repo directory
-- **Open on GitHub** — jumps to the repo in your browser
-- **Copy clone URL** — handy when setting up a new machine
+**Each row has at most three buttons:** the colored primary action (Push / Pull / Merge / Commit & push), a 🔄 refresh icon, and an ↗ icon to open the repo on GitHub. Nothing else.
 
 ---
 
-## Daily commands
+## 🔄 Update gitdash
 
 ```bash
-systemctl --user status gitdash       # is it running?
-systemctl --user restart gitdash      # restart (after editing ~/.config/gitdash/env)
-systemctl --user stop gitdash         # stop
-systemctl --user start gitdash        # start
-journalctl --user -u gitdash -f       # live logs (Ctrl+C to exit)
+cd /path/to/gitdash && git pull && ./install.sh
 ```
 
-## Updating gitdash
+Re-running the installer is safe — it stops, rebuilds, and restarts cleanly.
+
+---
+
+## 🗑️ Remove gitdash
 
 ```bash
-cd /path/to/gitdash
-git pull
-./install.sh                          # re-runnable; rebuilds and restarts
+cd /path/to/gitdash && ./uninstall.sh           # service only
+cd /path/to/gitdash && ./uninstall.sh --purge   # also wipe the database
 ```
 
-## Uninstalling
+The repo files stay where they are — delete them yourself if you want.
+
+---
+
+## 🆘 Help — something broke
+
+| Symptom | Fix |
+|---|---|
+| `forbidden host` in browser | Use `127.0.0.1:7420` or your LAN IP, not a public domain |
+| `Application error: client-side exception` | Hard-refresh your browser (Ctrl/Cmd+Shift+R) |
+| Repos all show "no updates needed" but you suspect they shouldn't | Click the 🔄 on any row to refresh manually. The classifier defaults to "no updates" when it can't reach GitHub |
+| Push fails with `repository scope` error | Run `gh auth refresh -s repo` |
+| Port 7420 in use | Edit `~/.config/gitdash/env`, change `GITDASH_PORT`, then `systemctl --user restart gitdash` |
+| Service not running | `systemctl --user status gitdash` shows what's wrong; `journalctl --user -u gitdash -n 50` shows recent logs |
+| Anything else | `journalctl --user -u gitdash -f` and reproduce |
+
+---
+
+## 📦 Prereqs
+
+You need these three tools before running `install.sh`:
+
+- **Node.js 20+** — install via [nvm](https://github.com/nvm-sh/nvm) (recommended) or [from nodejs.org](https://nodejs.org)
+- **git** — `apt install git` / `dnf install git` / `pacman -S git`
+- **GitHub CLI (`gh`)** — [official install](https://github.com/cli/cli#installation), then run **`gh auth login`** and follow the prompts (choose GitHub.com → HTTPS → login with browser)
+
+The installer's preflight check tells you exactly which one is missing if any.
+
+---
+
+## ⚙️ Daily commands
 
 ```bash
-./uninstall.sh                        # remove the service, keep config + database
-./uninstall.sh --purge                # also delete ~/.config/gitdash and ~/.local/state/gitdash
+systemctl --user status gitdash        # is it running?
+systemctl --user restart gitdash       # restart
+systemctl --user stop gitdash          # stop
+journalctl --user -u gitdash -f        # live logs (Ctrl+C to exit)
 ```
 
 ---
 
-## Configuration
+## 🛠️ Configuration (optional)
 
-The installer creates `~/.config/gitdash/env`. Edit it to override defaults:
+Edit `~/.config/gitdash/env` to override defaults:
 
 ```bash
-GITDASH_CSRF_TOKEN=…             # auto-generated; keep secret
-GITDASH_PORT=7420                # change if 7420 is taken
-GITDASH_BIND=0.0.0.0             # 127.0.0.1 to lock to localhost only
-# GITDASH_EDITOR=code            # default; try `nvim`, `subl`, `idea` etc.
-# GITDASH_TERMINAL=x-terminal-emulator   # try `kitty`, `gnome-terminal`, `alacritty`
-# GITDASH_DB=/custom/path/gitdash.sqlite
+GITDASH_PORT=7420                      # change if 7420 is taken
+GITDASH_BIND=0.0.0.0                   # use 127.0.0.1 to lock to localhost only
 ```
 
-After changing, restart: `systemctl --user restart gitdash`.
+Then `systemctl --user restart gitdash`.
 
-To control which folders gitdash scans, drop a `~/.config/gitdash/config.json`:
-
-```json
-{
-  "roots": ["/home/you/code", "/home/you/work"],
-  "maxDepth": 6,
-  "excludePatterns": ["node_modules", ".cache", "vendor"]
-}
-```
+For folder-scan rules and editor/terminal overrides see [`CLAUDE.md`](./CLAUDE.md).
 
 ---
 
-## Troubleshooting
+## 📜 License
 
-**Browser shows "forbidden host"**
-Your browser is hitting gitdash on a hostname/IP that isn't in the allowlist (loopback, RFC1918, link-local, or 100.64/10 CGNAT). Use `127.0.0.1` or your LAN IP, not a public domain.
-
-**`Application error: a client-side exception has occurred`**
-Hard-refresh your browser (Ctrl/Cmd+Shift+R). Stale client JS is the #1 cause after an update.
-
-**Repos show as "unknown" with nothing happening**
-You probably haven't run `gh auth login`. Check with `gh auth status`. If it fails, re-run `gh auth login`.
-
-**`Repository scope` error or push fails with auth error**
-Your `gh` token is missing the `repo` scope. Fix:
-```bash
-gh auth refresh -s repo
-```
-
-**Port 7420 is already in use**
-Edit `~/.config/gitdash/env`, set `GITDASH_PORT=7421` (or whatever's free), then `systemctl --user restart gitdash`.
-
-**Service won't start — check logs**
-```bash
-journalctl --user -u gitdash -n 50 --no-pager
-```
-
-**"Open in editor" doesn't open my preferred editor**
-Set `GITDASH_EDITOR` in `~/.config/gitdash/env` to the binary name (must be on `PATH`). Restart the service.
-
-**It worked yesterday but now nothing loads**
-The first thing to check is whether the service is running and the build is current:
-```bash
-systemctl --user status gitdash
-cd /path/to/gitdash && git log -1 --format='%h %s'
-```
-If you pulled new code, re-run `./install.sh` to rebuild.
-
----
-
-## Architecture (briefly)
-
-- **Next.js 15 + React 19**, server-side rendered, single page (`app/page.tsx`).
-- **SQLite** (`better-sqlite3`) for persistence at `~/.local/state/gitdash/gitdash.sqlite`. Stores repo discovery, snapshots, action history, and the GitHub API ETag cache.
-- **Background scheduler** runs three loops: directory discovery (10 min), local `git status` snapshots (on-demand + post-action), and remote comparison via `gh api` (staggered, ETag-cached).
-- **Live updates** stream from server to browser via Server-Sent Events.
-- **Action pipeline** — every push/pull/commit-push spawns a real `git` subprocess (no `bash -c`, no shell injection), streams stdout to the browser, and refreshes that one repo afterward.
-- **Security** — host header allowlist (private nets only), CSRF on all mutating routes, no shell, action whitelist.
-
-For more detail see [`CLAUDE.md`](./CLAUDE.md).
-
----
-
-## Roadmap
-
-Track in [GitHub Issues](https://github.com/imwebdev/gitdash/issues). Next up:
-
-- Click-to-expand row detail (recent commits + actions) — #8
-- "GitHub not connected" onboarding banner — #9
-- Section for "Local only — no GitHub remote" repos — #10
-- Status pills replacing arrows — #11
-
-## License
-
-MIT — see `LICENSE` if/when added.
+MIT (see `LICENSE` if/when added).

--- a/app/api/repos/[id]/refresh/route.ts
+++ b/app/api/repos/[id]/refresh/route.ts
@@ -1,0 +1,55 @@
+import { NextResponse } from "next/server";
+import { bootstrap } from "@/lib/bootstrap";
+import { validateCsrf } from "@/lib/security/csrf";
+import { getRepoById } from "@/lib/db/repos";
+import { getScheduler } from "@/lib/scan/scheduler";
+
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
+
+/**
+ * Lightweight "re-check this repo against GitHub" endpoint.
+ *
+ * Triggers the scheduler's collectOne() which uses gh api (the same
+ * code path the background classifier uses). Does NOT run `git fetch`
+ * — that requires SSH/HTTPS auth on the local remote, fails with
+ * "Permission denied (publickey)" for repos using SSH URLs without
+ * an SSH key configured on the host.
+ *
+ * Backs the per-row 🔄 Refresh icon button (no modal, no streaming).
+ */
+export async function POST(
+  req: Request,
+  ctx: { params: Promise<{ id: string }> },
+) {
+  await bootstrap();
+
+  const csrf = req.headers.get("x-csrf-token");
+  if (!validateCsrf(csrf)) {
+    return NextResponse.json({ error: "invalid csrf" }, { status: 403 });
+  }
+
+  const { id } = await ctx.params;
+  const repoId = Number(id);
+  if (!Number.isInteger(repoId) || repoId <= 0) {
+    return NextResponse.json({ error: "invalid repo id" }, { status: 400 });
+  }
+
+  const repo = getRepoById(repoId);
+  if (!repo || repo.deletedAt !== null) {
+    return NextResponse.json({ error: "repo not found" }, { status: 404 });
+  }
+
+  const scheduler = getScheduler();
+  if (!scheduler) {
+    return NextResponse.json({ error: "scheduler not running" }, { status: 503 });
+  }
+
+  try {
+    await scheduler.collectOne(repoId);
+  } catch (err) {
+    return NextResponse.json({ error: String(err) }, { status: 500 });
+  }
+
+  return NextResponse.json({ ok: true });
+}

--- a/components/RepoCard.tsx
+++ b/components/RepoCard.tsx
@@ -129,7 +129,8 @@ export function RepoCard({ repo, kind, csrfToken }: Props) {
 
         <RowIcons
           ghUrl={ghUrl}
-          onFetch={() => setModalAction("fetch")}
+          repoId={repo.id}
+          csrfToken={csrfToken}
         />
       </div>
 
@@ -252,20 +253,59 @@ function PrCell({ count, url }: { count: number; url: string | null }) {
 
 function RowIcons({
   ghUrl,
-  onFetch,
+  repoId,
+  csrfToken,
 }: {
   ghUrl: string | null;
-  onFetch: () => void;
+  repoId: number;
+  csrfToken: string;
 }) {
+  const [refreshState, setRefreshState] = useState<"idle" | "spinning" | "error">("idle");
+
+  const onRefresh = async () => {
+    if (refreshState === "spinning") return;
+    setRefreshState("spinning");
+    try {
+      const res = await fetch(`/api/repos/${repoId}/refresh`, {
+        method: "POST",
+        headers: { "x-csrf-token": csrfToken },
+      });
+      if (!res.ok) {
+        setRefreshState("error");
+        setTimeout(() => setRefreshState("idle"), 1500);
+      } else {
+        setRefreshState("idle");
+      }
+    } catch {
+      setRefreshState("error");
+      setTimeout(() => setRefreshState("idle"), 1500);
+    }
+  };
+
   return (
     <div className="flex items-center justify-end gap-1">
-      <IconButton
-        title="Refresh sync state with GitHub"
-        ariaLabel="Refresh"
-        onClick={onFetch}
+      <button
+        type="button"
+        onClick={onRefresh}
+        title={
+          refreshState === "error"
+            ? "Refresh failed — see server logs"
+            : "Re-check this repo against GitHub"
+        }
+        aria-label="Refresh"
+        disabled={refreshState === "spinning"}
+        className={cn(
+          "inline-flex h-7 w-7 items-center justify-center rounded-full transition-colors",
+          refreshState === "error"
+            ? "text-accent-attention"
+            : "text-fg-dim hover:bg-bg-hover hover:text-fg",
+          refreshState === "spinning" && "cursor-wait",
+        )}
       >
-        <RefreshCw className="h-3.5 w-3.5" />
-      </IconButton>
+        <RefreshCw
+          className={cn("h-3.5 w-3.5", refreshState === "spinning" && "animate-spin")}
+        />
+      </button>
       {ghUrl ? (
         <a
           href={ghUrl}
@@ -278,34 +318,13 @@ function RowIcons({
           <ExternalLink className="h-3.5 w-3.5" />
         </a>
       ) : (
-        <span className="inline-flex h-7 w-7 items-center justify-center text-fg-dim opacity-30" title="No GitHub remote">
+        <span
+          className="inline-flex h-7 w-7 items-center justify-center text-fg-dim opacity-30"
+          title="No GitHub remote"
+        >
           <ExternalLink className="h-3.5 w-3.5" />
         </span>
       )}
     </div>
-  );
-}
-
-function IconButton({
-  children,
-  onClick,
-  title,
-  ariaLabel,
-}: {
-  children: React.ReactNode;
-  onClick: () => void;
-  title: string;
-  ariaLabel: string;
-}) {
-  return (
-    <button
-      type="button"
-      onClick={onClick}
-      title={title}
-      aria-label={ariaLabel}
-      className="inline-flex h-7 w-7 items-center justify-center rounded-full text-fg-dim transition-colors hover:bg-bg-hover hover:text-fg"
-    >
-      {children}
-    </button>
   );
 }

--- a/components/RepoCard.tsx
+++ b/components/RepoCard.tsx
@@ -3,24 +3,19 @@
 import { cn } from "@/lib/utils";
 import type { RepoView } from "@/lib/state/store";
 import { ActionModal } from "./ActionModal";
-import { useEffect, useRef, useState, type ReactNode } from "react";
+import { useState } from "react";
 import {
   ArrowDown,
   ArrowUp,
-  Check,
-  Copy,
   ExternalLink,
-  FileCode2,
   GitPullRequest,
-  MoreHorizontal,
   RefreshCw,
-  TerminalSquare,
 } from "lucide-react";
 
 export type GroupKind = "push" | "pull" | "diverged" | "attention" | "dirty" | "clean";
 
 export const ROW_GRID =
-  "grid-cols-[minmax(180px,1.4fr)_120px_150px_minmax(200px,1.6fr)_80px_148px_36px]";
+  "grid-cols-[minmax(180px,1.4fr)_120px_150px_minmax(200px,1.6fr)_80px_148px_72px]";
 
 function primaryAction(
   kind: GroupKind,
@@ -30,12 +25,12 @@ function primaryAction(
   if (kind === "push") return { label: "Push", action: "push" };
   if (kind === "pull") return { label: "Pull", action: "pull" };
   if (kind === "diverged") return { label: "Merge", action: "merge" };
-  if (kind === "attention") return { label: "Open", action: "open-editor" };
-  if (kind === "dirty") {
-    if (hasConflicts) return { label: "Resolve", action: "open-editor" };
-    if (hasRemote) return { label: "Commit & push", action: "commit-push" };
-    return { label: "Open", action: "open-editor" };
+  if (kind === "dirty" && !hasConflicts && hasRemote) {
+    return { label: "Commit & push", action: "commit-push" };
   }
+  // No primary button for: attention, dirty+conflicts, dirty+no-remote, clean.
+  // User handles those externally; the icon buttons (Refresh + Open on GitHub)
+  // are still available in the actions column.
   return { label: "", action: null };
 }
 
@@ -84,7 +79,6 @@ export function RepoCard({ repo, kind, csrfToken }: Props) {
           ROW_GRID,
         )}
       >
-        {/* Repo name + branch */}
         <div className="flex min-w-0 flex-col">
           <h3 className="truncate text-[14px] font-medium tracking-tight text-fg">
             {repo.displayName}
@@ -96,10 +90,8 @@ export function RepoCard({ repo, kind, csrfToken }: Props) {
           </span>
         </div>
 
-        {/* Sync ↑n ↓n */}
         <SyncCell ahead={ahead} behind={behind} hasUpstream={!!snap?.upstream} kind={kind} />
 
-        {/* Local changes */}
         <LocalCell
           dirty={dirtyTotal}
           newFiles={newFiles}
@@ -107,16 +99,13 @@ export function RepoCard({ repo, kind, csrfToken }: Props) {
           kind={kind}
         />
 
-        {/* Last commit subject + time */}
         <LastCommitCell
           subject={snap?.lastCommitSubject ?? null}
           ts={snap?.lastCommitTs ?? null}
         />
 
-        {/* PRs */}
         <PrCell count={snap?.openPrCount ?? 0} url={ghPrUrl} />
 
-        {/* Primary action */}
         {button.action ? (
           <button
             onClick={() => setModalAction(button.action)}
@@ -128,8 +117,6 @@ export function RepoCard({ repo, kind, csrfToken }: Props) {
                 "border-accent-pull/35 bg-accent-pull/10 text-accent-pull hover:border-accent-pull/55 hover:bg-accent-pull/20",
               kind === "diverged" &&
                 "border-accent-diverged/35 bg-accent-diverged/10 text-accent-diverged hover:border-accent-diverged/55 hover:bg-accent-diverged/20",
-              kind === "attention" &&
-                "border-accent-attention/35 bg-accent-attention/10 text-accent-attention hover:border-accent-attention/55 hover:bg-accent-attention/20",
               kind === "dirty" &&
                 "border-accent-dirty/35 bg-accent-dirty/10 text-accent-dirty hover:border-accent-dirty/55 hover:bg-accent-dirty/20",
             )}
@@ -140,11 +127,9 @@ export function RepoCard({ repo, kind, csrfToken }: Props) {
           <span />
         )}
 
-        {/* ⋯ menu */}
-        <RowMenu
+        <RowIcons
           ghUrl={ghUrl}
-          remoteUrl={snap?.remoteUrl ?? null}
-          onModalAction={(a) => setModalAction(a)}
+          onFetch={() => setModalAction("fetch")}
         />
       </div>
 
@@ -265,139 +250,62 @@ function PrCell({ count, url }: { count: number; url: string | null }) {
   );
 }
 
-interface RowMenuProps {
+function RowIcons({
+  ghUrl,
+  onFetch,
+}: {
   ghUrl: string | null;
-  remoteUrl: string | null;
-  onModalAction: (action: string) => void;
-}
-
-function RowMenu({ ghUrl, remoteUrl, onModalAction }: RowMenuProps) {
-  const [open, setOpen] = useState(false);
-  const [copied, setCopied] = useState(false);
-  const containerRef = useRef<HTMLDivElement | null>(null);
-
-  useEffect(() => {
-    if (!open) return;
-    const onDoc = (e: MouseEvent) => {
-      if (!containerRef.current?.contains(e.target as Node)) setOpen(false);
-    };
-    const onKey = (e: KeyboardEvent) => {
-      if (e.key === "Escape") setOpen(false);
-    };
-    document.addEventListener("mousedown", onDoc);
-    document.addEventListener("keydown", onKey);
-    return () => {
-      document.removeEventListener("mousedown", onDoc);
-      document.removeEventListener("keydown", onKey);
-    };
-  }, [open]);
-
-  const copyClone = async () => {
-    if (!remoteUrl) return;
-    try {
-      await navigator.clipboard.writeText(remoteUrl);
-      setCopied(true);
-      setTimeout(() => {
-        setCopied(false);
-        setOpen(false);
-      }, 1200);
-    } catch {
-      // ignore — clipboard requires secure context; localhost is fine
-    }
-  };
-
+  onFetch: () => void;
+}) {
   return (
-    <div ref={containerRef} className="relative justify-self-end">
-      <button
-        type="button"
-        onClick={() => setOpen((v) => !v)}
-        className="inline-flex h-7 w-7 items-center justify-center rounded-full text-fg-dim opacity-0 transition-all hover:bg-bg-hover hover:text-fg group-hover:opacity-100 data-[open=true]:opacity-100"
-        data-open={open}
-        aria-label="More actions"
-        aria-haspopup="menu"
-        aria-expanded={open}
+    <div className="flex items-center justify-end gap-1">
+      <IconButton
+        title="Refresh sync state with GitHub"
+        ariaLabel="Refresh"
+        onClick={onFetch}
       >
-        <MoreHorizontal className="h-4 w-4" />
-      </button>
-
-      {open && (
-        <div
-          role="menu"
-          className="absolute right-0 top-full z-20 mt-1 w-56 overflow-hidden rounded-xl border border-border bg-bg-elevated shadow-2xl"
+        <RefreshCw className="h-3.5 w-3.5" />
+      </IconButton>
+      {ghUrl ? (
+        <a
+          href={ghUrl}
+          target="_blank"
+          rel="noopener noreferrer"
+          title="Open on GitHub"
+          aria-label="Open on GitHub"
+          className="inline-flex h-7 w-7 items-center justify-center rounded-full text-fg-dim transition-colors hover:bg-bg-hover hover:text-fg"
         >
-          <MenuItem
-            icon={<RefreshCw className="h-3.5 w-3.5" />}
-            label="Fetch from GitHub"
-            onClick={() => {
-              setOpen(false);
-              onModalAction("fetch");
-            }}
-          />
-          <MenuItem
-            icon={<FileCode2 className="h-3.5 w-3.5" />}
-            label="Open in editor"
-            onClick={() => {
-              setOpen(false);
-              onModalAction("open-editor");
-            }}
-          />
-          <MenuItem
-            icon={<TerminalSquare className="h-3.5 w-3.5" />}
-            label="Open in terminal"
-            onClick={() => {
-              setOpen(false);
-              onModalAction("open-terminal");
-            }}
-          />
-          <div className="my-1 h-px bg-border-subtle" />
-          <MenuItem
-            icon={<ExternalLink className="h-3.5 w-3.5" />}
-            label="Open on GitHub"
-            disabled={!ghUrl}
-            onClick={() => {
-              if (!ghUrl) return;
-              window.open(ghUrl, "_blank", "noopener,noreferrer");
-              setOpen(false);
-            }}
-          />
-          <MenuItem
-            icon={copied ? <Check className="h-3.5 w-3.5 text-accent-clean" /> : <Copy className="h-3.5 w-3.5" />}
-            label={copied ? "Copied!" : "Copy clone URL"}
-            disabled={!remoteUrl}
-            onClick={copyClone}
-          />
-        </div>
+          <ExternalLink className="h-3.5 w-3.5" />
+        </a>
+      ) : (
+        <span className="inline-flex h-7 w-7 items-center justify-center text-fg-dim opacity-30" title="No GitHub remote">
+          <ExternalLink className="h-3.5 w-3.5" />
+        </span>
       )}
     </div>
   );
 }
 
-function MenuItem({
-  icon,
-  label,
+function IconButton({
+  children,
   onClick,
-  disabled,
+  title,
+  ariaLabel,
 }: {
-  icon: ReactNode;
-  label: string;
+  children: React.ReactNode;
   onClick: () => void;
-  disabled?: boolean;
+  title: string;
+  ariaLabel: string;
 }) {
   return (
     <button
-      role="menuitem"
       type="button"
       onClick={onClick}
-      disabled={disabled}
-      className={cn(
-        "flex w-full items-center gap-2.5 px-3 py-2 text-left text-[12.5px] text-fg-muted transition-colors",
-        disabled
-          ? "cursor-not-allowed opacity-40"
-          : "hover:bg-bg-hover hover:text-fg",
-      )}
+      title={title}
+      aria-label={ariaLabel}
+      className="inline-flex h-7 w-7 items-center justify-center rounded-full text-fg-dim transition-colors hover:bg-bg-hover hover:text-fg"
     >
-      <span className="text-fg-dim">{icon}</span>
-      {label}
+      {children}
     </button>
   );
 }


### PR DESCRIPTION
## Summary

Two related cleanups bundled because they touch the same row UI:

### 1. Minimal row icons + visual README (issue #20)

User pushback on too-much-menu and too-dense README:
> "I want all the copy and paste shit gone. Click for this or go to the page. That is it."

- ⋯ overflow menu → **two inline icon buttons**: 🔄 Refresh and ↗ Open on GitHub.
- Removed Copy clone URL (clipboard), Open in editor, Open in terminal — all useless when gitdash is accessed remotely.
- README rewritten: 255 → 117 lines, emoji headers, install one-liner up top.

### 2. Refresh uses gh api, not git fetch (issue #23)

User clicked 🔄 and saw `git@github.com: Permission denied (publickey)`. Backend was running `git fetch --prune` which needs SSH/HTTPS auth on the local remote. That fails for repos with SSH URLs and no SSH key configured on the gitdash host. The classifier's existing `gh api` path works for the same repos.

- New `POST /api/repos/[id]/refresh` endpoint that calls `scheduler.collectOne()` (the same code path the background classifier uses).
- RowIcons.refresh now posts to that endpoint silently — no modal, no streaming. Spinner during request, brief error highlight on failure.
- The `fetch` backend git action stays in the whitelist (no UI surfaces it now).

## Closes

- Closes #20
- Closes #23

## Test plan

- [ ] Hard-refresh dashboard
- [ ] Click 🔄 on any repo (especially one with SSH remote like aibuildmastery): icon spins briefly, no modal opens, no SSH error
- [ ] Click ↗ on any repo with a remote: opens GitHub repo URL in new tab
- [ ] Repos without remote: ↗ icon visibly faded, not clickable
- [ ] Push/Pull/Commit & push primary buttons unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)