### PR TITLE
Mobile responsive layout + click-to-expand row details

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,255 +1,117 @@
-# gitdash
+# 🚀 gitdash
 
-A local dashboard that shows every git repo on your machine and tells you, in plain English, what to do with it: push, pull, commit, merge, or nothing. One button per repo. No bulk operations, no surprises.
+> A local dashboard for every git repo on your machine. Tells you what to do — push, pull, commit, or nothing — in plain English. One button per repo.
 
-**Designed for Claude Code users who hop between machines** and want to know — at a glance — which repos are out of sync with GitHub, where their unsaved work is, and whether anyone (including past-you on a different computer) pushed something they need to pull down.
+**Built for Claude Code users who hop between machines** and want to know, at a glance, what's out of sync with GitHub.
 
-> Linux only for now. macOS/Windows support is on the roadmap.
-
----
-
-## What you'll need before installing
-
-You can copy-paste each block. Skip any tool you already have.
-
-### 1. Node.js 20 or newer
-
-Check: `node --version` → should print `v20.x.x` or higher.
-
-If not installed, the easiest path is [nvm](https://github.com/nvm-sh/nvm):
-
-```bash
-curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.0/install.sh | bash
-exec $SHELL                  # reload your shell so nvm is on PATH
-nvm install 20
-nvm use 20
-```
-
-### 2. Git
-
-Check: `git --version`
-
-If not installed:
-- **Ubuntu/Debian:** `sudo apt install git`
-- **Fedora/RHEL:** `sudo dnf install git`
-- **Arch:** `sudo pacman -S git`
-
-### 3. GitHub CLI (`gh`)
-
-This is how gitdash compares your local repos with GitHub.
-
-Check: `gh --version`
-
-If not installed:
-- **Ubuntu/Debian:** [official install instructions](https://github.com/cli/cli/blob/trunk/docs/install_linux.md#debian-ubuntu-linux-raspberry-pi-os-apt)
-- **Fedora/RHEL:** `sudo dnf install gh`
-- **Arch:** `sudo pacman -S github-cli`
-
-### 4. Sign `gh` in to your GitHub account
-
-This is the part most beginners get stuck on. Run this once:
-
-```bash
-gh auth login
-```
-
-Choose, in order:
-1. **GitHub.com**
-2. **HTTPS** (easier than SSH for first-timers)
-3. **Yes** (authenticate Git with your GitHub credentials)
-4. **Login with a web browser**
-
-Copy the one-time code it shows you, press Enter, and your browser will open. Paste the code, click Authorize, and come back to the terminal. You should see `✓ Authentication complete`.
-
-Verify it worked:
-
-```bash
-gh auth status
-```
-
-Should show `✓ Logged in to github.com account <your-username>`.
+> 🐧 Linux only right now. macOS + Windows on the way ([#21](https://github.com/imwebdev/gitdash/issues/21)).
 
 ---
 
-## Install gitdash
+## ⚡ Install in 30 seconds
+
+Copy and paste this:
 
 ```bash
-git clone https://github.com/imwebdev/gitdash.git
-cd gitdash
-./install.sh
+git clone https://github.com/imwebdev/gitdash.git && cd gitdash && ./install.sh
 ```
 
-That's it. The installer will:
+That's it. The installer prints a URL when it's done — open it in your browser.
 
-1. Verify all the above prereqs
-2. Install node dependencies and build
-3. Generate a persistent CSRF token (so your browser doesn't get logged out on every restart)
-4. Install a systemd user service so gitdash auto-restarts on crash
-5. Optionally enable lingering (so it survives logout and reboot — asks for `sudo`)
-
-When it finishes you'll see something like:
-
-```
-  gitdash installed and running
-
-  Open in browser:
-    http://127.0.0.1:7420
-    http://192.168.1.6:7420  (other devices on your network)
-```
-
-**Open the URL** and you should see your repos sorted into actionable groups:
-
-- 🔴 **Need attention** — merge or rebase mid-flight
-- 🟠 **Diverged from GitHub** — both you and GitHub have new commits
-- 🟢 **Want to be pushed** — you've committed locally
-- 🔵 **Have incoming changes** — GitHub has new commits
-- 🟡 **Have unsaved changes** — files edited but not committed
-- ✅ **All synced** — nothing to do
+> ❓ **Don't have `git`, `node 20+`, or `gh` installed yet?** Skip down to [Prereqs](#-prereqs).
 
 ---
 
-## Using gitdash
+## 🎨 What you'll see
 
-### "I just sat down at a different computer"
+Every repo on your machine, sorted by what it needs:
 
-1. Look for the **blue "Pull"** buttons. Click each — they download the new commits.
-2. Look for the **yellow "Commit & push"** buttons. Click them, type a quick message, and your work goes to GitHub.
+| | Section | What it means |
+|---|---|---|
+| 🔴 | **Need attention** | Mid-flight merge or rebase — finish what you started |
+| 🟠 | **Diverged from GitHub** | Both you and GitHub have new commits — needs a merge |
+| 🟢 | **Want to be pushed** | You've committed locally — click **Push** |
+| 🔵 | **Have incoming changes** | GitHub has new commits — click **Pull** |
+| 🟡 | **Have unsaved changes** | Files edited, not committed — click **Commit & push** |
+| ✅ | **Need no updates** | In sync, nothing to do |
 
-### "I don't know what 'commit' means"
-
-In gitdash, "Commit & push" does this in one step:
-1. Stages every changed file in the repo (`git add -A`)
-2. Wraps them up with the message you type (`git commit`)
-3. Sends them to GitHub (`git push`)
-
-Before it runs, gitdash shows you exactly which files will be sent and **warns you in red if any of them look like secrets** (`.env`, `*.key`, `*.pem`, anything matching `credentials`/`secrets`) or are over 10MB. You can cancel.
-
-### Per-row `⋯` menu
-
-Each repo row has a dot-dot-dot button on the right. Click it for:
-
-- **Fetch from GitHub** — refresh remote state without pulling
-- **Open in editor** — opens VS Code (override with `GITDASH_EDITOR=...`)
-- **Open in terminal** — opens a terminal in the repo directory
-- **Open on GitHub** — jumps to the repo in your browser
-- **Copy clone URL** — handy when setting up a new machine
+**Each row has at most three buttons:** the colored primary action (Push / Pull / Merge / Commit & push), a 🔄 refresh icon, and an ↗ icon to open the repo on GitHub. Nothing else.
 
 ---
 
-## Daily commands
+## 🔄 Update gitdash
 
 ```bash
-systemctl --user status gitdash       # is it running?
-systemctl --user restart gitdash      # restart (after editing ~/.config/gitdash/env)
-systemctl --user stop gitdash         # stop
-systemctl --user start gitdash        # start
-journalctl --user -u gitdash -f       # live logs (Ctrl+C to exit)
+cd /path/to/gitdash && git pull && ./install.sh
 ```
 
-## Updating gitdash
+Re-running the installer is safe — it stops, rebuilds, and restarts cleanly.
+
+---
+
+## 🗑️ Remove gitdash
 
 ```bash
-cd /path/to/gitdash
-git pull
-./install.sh                          # re-runnable; rebuilds and restarts
+cd /path/to/gitdash && ./uninstall.sh           # service only
+cd /path/to/gitdash && ./uninstall.sh --purge   # also wipe the database
 ```
 
-## Uninstalling
+The repo files stay where they are — delete them yourself if you want.
+
+---
+
+## 🆘 Help — something broke
+
+| Symptom | Fix |
+|---|---|
+| `forbidden host` in browser | Use `127.0.0.1:7420` or your LAN IP, not a public domain |
+| `Application error: client-side exception` | Hard-refresh your browser (Ctrl/Cmd+Shift+R) |
+| Repos all show "no updates needed" but you suspect they shouldn't | Click the 🔄 on any row to refresh manually. The classifier defaults to "no updates" when it can't reach GitHub |
+| Push fails with `repository scope` error | Run `gh auth refresh -s repo` |
+| Port 7420 in use | Edit `~/.config/gitdash/env`, change `GITDASH_PORT`, then `systemctl --user restart gitdash` |
+| Service not running | `systemctl --user status gitdash` shows what's wrong; `journalctl --user -u gitdash -n 50` shows recent logs |
+| Anything else | `journalctl --user -u gitdash -f` and reproduce |
+
+---
+
+## 📦 Prereqs
+
+You need these three tools before running `install.sh`:
+
+- **Node.js 20+** — install via [nvm](https://github.com/nvm-sh/nvm) (recommended) or [from nodejs.org](https://nodejs.org)
+- **git** — `apt install git` / `dnf install git` / `pacman -S git`
+- **GitHub CLI (`gh`)** — [official install](https://github.com/cli/cli#installation), then run **`gh auth login`** and follow the prompts (choose GitHub.com → HTTPS → login with browser)
+
+The installer's preflight check tells you exactly which one is missing if any.
+
+---
+
+## ⚙️ Daily commands
 
 ```bash
-./uninstall.sh                        # remove the service, keep config + database
-./uninstall.sh --purge                # also delete ~/.config/gitdash and ~/.local/state/gitdash
+systemctl --user status gitdash        # is it running?
+systemctl --user restart gitdash       # restart
+systemctl --user stop gitdash          # stop
+journalctl --user -u gitdash -f        # live logs (Ctrl+C to exit)
 ```
 
 ---
 
-## Configuration
+## 🛠️ Configuration (optional)
 
-The installer creates `~/.config/gitdash/env`. Edit it to override defaults:
+Edit `~/.config/gitdash/env` to override defaults:
 
 ```bash
-GITDASH_CSRF_TOKEN=…             # auto-generated; keep secret
-GITDASH_PORT=7420                # change if 7420 is taken
-GITDASH_BIND=0.0.0.0             # 127.0.0.1 to lock to localhost only
-# GITDASH_EDITOR=code            # default; try `nvim`, `subl`, `idea` etc.
-# GITDASH_TERMINAL=x-terminal-emulator   # try `kitty`, `gnome-terminal`, `alacritty`
-# GITDASH_DB=/custom/path/gitdash.sqlite
+GITDASH_PORT=7420                      # change if 7420 is taken
+GITDASH_BIND=0.0.0.0                   # use 127.0.0.1 to lock to localhost only
 ```
 
-After changing, restart: `systemctl --user restart gitdash`.
+Then `systemctl --user restart gitdash`.
 
-To control which folders gitdash scans, drop a `~/.config/gitdash/config.json`:
-
-```json
-{
-  "roots": ["/home/you/code", "/home/you/work"],
-  "maxDepth": 6,
-  "excludePatterns": ["node_modules", ".cache", "vendor"]
-}
-```
+For folder-scan rules and editor/terminal overrides see [`CLAUDE.md`](./CLAUDE.md).
 
 ---
 
-## Troubleshooting
+## 📜 License
 
-**Browser shows "forbidden host"**
-Your browser is hitting gitdash on a hostname/IP that isn't in the allowlist (loopback, RFC1918, link-local, or 100.64/10 CGNAT). Use `127.0.0.1` or your LAN IP, not a public domain.
-
-**`Application error: a client-side exception has occurred`**
-Hard-refresh your browser (Ctrl/Cmd+Shift+R). Stale client JS is the #1 cause after an update.
-
-**Repos show as "unknown" with nothing happening**
-You probably haven't run `gh auth login`. Check with `gh auth status`. If it fails, re-run `gh auth login`.
-
-**`Repository scope` error or push fails with auth error**
-Your `gh` token is missing the `repo` scope. Fix:
-```bash
-gh auth refresh -s repo
-```
-
-**Port 7420 is already in use**
-Edit `~/.config/gitdash/env`, set `GITDASH_PORT=7421` (or whatever's free), then `systemctl --user restart gitdash`.
-
-**Service won't start — check logs**
-```bash
-journalctl --user -u gitdash -n 50 --no-pager
-```
-
-**"Open in editor" doesn't open my preferred editor**
-Set `GITDASH_EDITOR` in `~/.config/gitdash/env` to the binary name (must be on `PATH`). Restart the service.
-
-**It worked yesterday but now nothing loads**
-The first thing to check is whether the service is running and the build is current:
-```bash
-systemctl --user status gitdash
-cd /path/to/gitdash && git log -1 --format='%h %s'
-```
-If you pulled new code, re-run `./install.sh` to rebuild.
-
----
-
-## Architecture (briefly)
-
-- **Next.js 15 + React 19**, server-side rendered, single page (`app/page.tsx`).
-- **SQLite** (`better-sqlite3`) for persistence at `~/.local/state/gitdash/gitdash.sqlite`. Stores repo discovery, snapshots, action history, and the GitHub API ETag cache.
-- **Background scheduler** runs three loops: directory discovery (10 min), local `git status` snapshots (on-demand + post-action), and remote comparison via `gh api` (staggered, ETag-cached).
-- **Live updates** stream from server to browser via Server-Sent Events.
-- **Action pipeline** — every push/pull/commit-push spawns a real `git` subprocess (no `bash -c`, no shell injection), streams stdout to the browser, and refreshes that one repo afterward.
-- **Security** — host header allowlist (private nets only), CSRF on all mutating routes, no shell, action whitelist.
-
-For more detail see [`CLAUDE.md`](./CLAUDE.md).
-
----
-
-## Roadmap
-
-Track in [GitHub Issues](https://github.com/imwebdev/gitdash/issues). Next up:
-
-- Click-to-expand row detail (recent commits + actions) — #8
-- "GitHub not connected" onboarding banner — #9
-- Section for "Local only — no GitHub remote" repos — #10
-- Status pills replacing arrows — #11
-
-## License
-
-MIT — see `LICENSE` if/when added.
+MIT (see `LICENSE` if/when added).

--- a/app/api/repos/[id]/details/route.ts
+++ b/app/api/repos/[id]/details/route.ts
@@ -1,0 +1,52 @@
+import { NextResponse } from "next/server";
+import { bootstrap } from "@/lib/bootstrap";
+import { getRepoById, getRecentActions, getSnapshot } from "@/lib/db/repos";
+import { getRecentCommits, getRepoLogMetadata } from "@/lib/git/log";
+
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
+
+export async function GET(
+  _req: Request,
+  ctx: { params: Promise<{ id: string }> },
+) {
+  await bootstrap();
+
+  const { id } = await ctx.params;
+  const repoId = Number(id);
+  if (!Number.isInteger(repoId) || repoId <= 0) {
+    return NextResponse.json({ error: "invalid repo id" }, { status: 400 });
+  }
+
+  const repo = getRepoById(repoId);
+  if (!repo || repo.deletedAt !== null) {
+    return NextResponse.json({ error: "repo not found" }, { status: 404 });
+  }
+
+  const snap = getSnapshot(repoId);
+
+  const [commitsRes, metaRes] = await Promise.allSettled([
+    getRecentCommits(repo.repoPath, 10),
+    getRepoLogMetadata(repo.repoPath),
+  ]);
+
+  const recentCommits = commitsRes.status === "fulfilled" ? commitsRes.value : [];
+  const logMeta = metaRes.status === "fulfilled"
+    ? metaRes.value
+    : { defaultBranch: null, totalCommits: null };
+
+  const recentActions = getRecentActions(repoId, 5);
+
+  return NextResponse.json({
+    recentCommits,
+    recentActions,
+    metadata: {
+      fullPath: repo.repoPath,
+      defaultBranch: logMeta.defaultBranch,
+      remoteUrl: snap?.remoteUrl ?? null,
+      githubOwner: repo.githubOwner,
+      githubName: repo.githubName,
+      totalCommits: logMeta.totalCommits,
+    },
+  });
+}

--- a/app/api/repos/[id]/refresh/route.ts
+++ b/app/api/repos/[id]/refresh/route.ts
@@ -1,0 +1,55 @@
+import { NextResponse } from "next/server";
+import { bootstrap } from "@/lib/bootstrap";
+import { validateCsrf } from "@/lib/security/csrf";
+import { getRepoById } from "@/lib/db/repos";
+import { getScheduler } from "@/lib/scan/scheduler";
+
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
+
+/**
+ * Lightweight "re-check this repo against GitHub" endpoint.
+ *
+ * Triggers the scheduler's collectOne() which uses gh api (the same
+ * code path the background classifier uses). Does NOT run `git fetch`
+ * — that requires SSH/HTTPS auth on the local remote, fails with
+ * "Permission denied (publickey)" for repos using SSH URLs without
+ * an SSH key configured on the host.
+ *
+ * Backs the per-row 🔄 Refresh icon button (no modal, no streaming).
+ */
+export async function POST(
+  req: Request,
+  ctx: { params: Promise<{ id: string }> },
+) {
+  await bootstrap();
+
+  const csrf = req.headers.get("x-csrf-token");
+  if (!validateCsrf(csrf)) {
+    return NextResponse.json({ error: "invalid csrf" }, { status: 403 });
+  }
+
+  const { id } = await ctx.params;
+  const repoId = Number(id);
+  if (!Number.isInteger(repoId) || repoId <= 0) {
+    return NextResponse.json({ error: "invalid repo id" }, { status: 400 });
+  }
+
+  const repo = getRepoById(repoId);
+  if (!repo || repo.deletedAt !== null) {
+    return NextResponse.json({ error: "repo not found" }, { status: 404 });
+  }
+
+  const scheduler = getScheduler();
+  if (!scheduler) {
+    return NextResponse.json({ error: "scheduler not running" }, { status: 503 });
+  }
+
+  try {
+    await scheduler.collectOne(repoId);
+  } catch (err) {
+    return NextResponse.json({ error: String(err) }, { status: 500 });
+  }
+
+  return NextResponse.json({ ok: true });
+}

--- a/components/ActionModal.tsx
+++ b/components/ActionModal.tsx
@@ -163,7 +163,7 @@ export function ActionModal({ repo, action, csrfToken, onClose }: Props) {
           </div>
           <button
             onClick={onClose}
-            className="inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-full text-fg-muted hover:bg-bg-hover hover:text-fg"
+            className="inline-flex h-11 w-11 shrink-0 items-center justify-center rounded-full text-fg-muted hover:bg-bg-hover hover:text-fg sm:h-8 sm:w-8"
             aria-label="Close"
           >
             <X className="h-4 w-4" />

--- a/components/Dashboard.tsx
+++ b/components/Dashboard.tsx
@@ -90,6 +90,16 @@ export function Dashboard({ initialRepos, csrfToken }: Props) {
   const [showSystem, setShowSystem] = useState(false);
   const [query, setQuery] = useState("");
   const [connected, setConnected] = useState(false);
+  const [expandedRepoId, setExpandedRepoId] = useState<number | null>(null);
+
+  useEffect(() => {
+    if (expandedRepoId === null) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") setExpandedRepoId(null);
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [expandedRepoId]);
 
   useEffect(() => {
     const url = `/api/stream?showSystem=${showSystem ? "1" : "0"}`;
@@ -141,13 +151,13 @@ export function Dashboard({ initialRepos, csrfToken }: Props) {
   );
 
   return (
-    <main className="grain relative mx-auto max-w-[1280px] px-6 py-10 sm:px-10 sm:py-14">
-      <header className="mb-12 flex flex-col gap-6 sm:flex-row sm:items-end sm:justify-between">
+    <main className="grain relative mx-auto max-w-[1280px] px-4 py-8 sm:px-10 sm:py-14">
+      <header className="mb-8 flex flex-col gap-5 sm:mb-12 sm:gap-6 sm:flex-row sm:items-end sm:justify-between">
         <div>
-          <h1 className="display text-[44px] leading-none tracking-display-tight text-fg">
+          <h1 className="display text-[36px] leading-none tracking-display-tight text-fg sm:text-[44px]">
             gitdash
           </h1>
-          <p className="mt-3 max-w-lg text-[15px] text-fg-muted">
+          <p className="mt-3 max-w-lg text-[14px] text-fg-muted sm:text-[15px]">
             {actionableCount === 0 ? (
               <>Nothing urgent. <span className="display-italic text-fg">All caught up.</span></>
             ) : (
@@ -158,13 +168,13 @@ export function Dashboard({ initialRepos, csrfToken }: Props) {
           </p>
         </div>
 
-        <div className="flex items-center gap-4">
+        <div className="flex flex-wrap items-center gap-3 sm:gap-4">
           <input
             type="search"
             placeholder="filter repos"
             value={query}
             onChange={(e) => setQuery(e.target.value)}
-            className="h-9 w-56 rounded-full border border-border bg-bg-elevated/60 px-4 text-[13px] text-fg placeholder:text-fg-dim focus:border-ring focus:outline-none"
+            className="h-11 w-full rounded-full border border-border bg-bg-elevated/60 px-4 text-[14px] text-fg placeholder:text-fg-dim focus:border-ring focus:outline-none sm:h-9 sm:w-56 sm:text-[13px]"
           />
           <label className="flex cursor-pointer select-none items-center gap-2 text-[12px] text-fg-muted">
             <input
@@ -202,6 +212,10 @@ export function Dashboard({ initialRepos, csrfToken }: Props) {
               repos={g.repos}
               csrfToken={csrfToken}
               defaultCollapsed={g.defaultCollapsed}
+              expandedRepoId={expandedRepoId}
+              onToggleRepo={(id) =>
+                setExpandedRepoId((cur) => (cur === id ? null : id))
+              }
             />
           ))}
         </div>

--- a/components/RepoCard.tsx
+++ b/components/RepoCard.tsx
@@ -3,10 +3,12 @@
 import { cn } from "@/lib/utils";
 import type { RepoView } from "@/lib/state/store";
 import { ActionModal } from "./ActionModal";
+import { RowDetail } from "./RowDetail";
 import { useState } from "react";
 import {
   ArrowDown,
   ArrowUp,
+  ChevronDown,
   ExternalLink,
   GitPullRequest,
   RefreshCw,
@@ -15,7 +17,7 @@ import {
 export type GroupKind = "push" | "pull" | "diverged" | "attention" | "dirty" | "clean";
 
 export const ROW_GRID =
-  "grid-cols-[minmax(180px,1.4fr)_120px_150px_minmax(200px,1.6fr)_80px_148px_72px]";
+  "grid-cols-[minmax(180px,1.4fr)_120px_150px_minmax(200px,1.6fr)_80px_148px_104px]";
 
 function primaryAction(
   kind: GroupKind,
@@ -28,9 +30,6 @@ function primaryAction(
   if (kind === "dirty" && !hasConflicts && hasRemote) {
     return { label: "Commit & push", action: "commit-push" };
   }
-  // No primary button for: attention, dirty+conflicts, dirty+no-remote, clean.
-  // User handles those externally; the icon buttons (Refresh + Open on GitHub)
-  // are still available in the actions column.
   return { label: "", action: null };
 }
 
@@ -45,13 +44,29 @@ function relativeTime(unix: number | null | undefined): string {
   return `${Math.floor(deltaSec / (86400 * 365))}y ago`;
 }
 
+function actionButtonClass(kind: GroupKind): string {
+  return cn(
+    "shrink-0 whitespace-nowrap rounded-full border px-3.5 py-1 text-[12px] font-medium tracking-tight transition-all",
+    kind === "push" &&
+      "border-accent-push/35 bg-accent-push/10 text-accent-push hover:border-accent-push/55 hover:bg-accent-push/20",
+    kind === "pull" &&
+      "border-accent-pull/35 bg-accent-pull/10 text-accent-pull hover:border-accent-pull/55 hover:bg-accent-pull/20",
+    kind === "diverged" &&
+      "border-accent-diverged/35 bg-accent-diverged/10 text-accent-diverged hover:border-accent-diverged/55 hover:bg-accent-diverged/20",
+    kind === "dirty" &&
+      "border-accent-dirty/35 bg-accent-dirty/10 text-accent-dirty hover:border-accent-dirty/55 hover:bg-accent-dirty/20",
+  );
+}
+
 interface Props {
   repo: RepoView;
   kind: GroupKind;
   csrfToken: string;
+  expanded: boolean;
+  onToggle: () => void;
 }
 
-export function RepoCard({ repo, kind, csrfToken }: Props) {
+export function RepoCard({ repo, kind, csrfToken, expanded, onToggle }: Props) {
   const [modalAction, setModalAction] = useState<string | null>(null);
   const snap = repo.snapshot;
 
@@ -68,70 +83,155 @@ export function RepoCard({ repo, kind, csrfToken }: Props) {
   const newFiles = snap?.untracked ?? 0;
   const conflicts = snap?.conflicted ?? 0;
   const hasRemote = !!(ghUrl ?? snap?.remoteUrl);
-
   const button = primaryAction(kind, hasRemote, conflicts > 0);
+  const prCount = snap?.openPrCount ?? 0;
+
+  const handleRowClick = (e: React.MouseEvent) => {
+    // If the click came from something inside the row that already handles clicks
+    // (button, a, input), stopPropagation on those elements prevents this.
+    // Any remaining click on the row surface → toggle.
+    if (e.defaultPrevented) return;
+    onToggle();
+  };
+
+  const handleRowKey = (e: React.KeyboardEvent) => {
+    // Only toggle when the row itself is focused; let buttons/links handle
+    // their own Enter/Space without bubbling into a row toggle.
+    if (e.target !== e.currentTarget) return;
+    if (e.key === "Enter" || e.key === " ") {
+      e.preventDefault();
+      onToggle();
+    }
+  };
 
   return (
     <>
       <div
         className={cn(
-          "group relative grid items-center gap-x-4 px-6 py-3 transition-colors hover:bg-bg-hover/60",
-          ROW_GRID,
+          "group relative cursor-pointer transition-colors hover:bg-bg-hover/60",
+          expanded && "bg-bg-hover/40",
         )}
+        onClick={handleRowClick}
+        onKeyDown={handleRowKey}
+        role="button"
+        tabIndex={0}
+        aria-expanded={expanded}
+        aria-label={`Toggle details for ${repo.displayName}`}
       >
-        <div className="flex min-w-0 flex-col">
-          <h3 className="truncate text-[14px] font-medium tracking-tight text-fg">
-            {repo.displayName}
-          </h3>
-          <span className="mono truncate text-[11px] text-fg-dim">
-            {snap?.detached
-              ? "(detached HEAD)"
-              : snap?.branch ?? "—"}
-          </span>
+        {/* Desktop grid row (>= sm). Preserves the existing layout verbatim. */}
+        <div
+          className={cn(
+            "hidden items-center gap-x-4 px-6 py-3 sm:grid",
+            ROW_GRID,
+          )}
+        >
+          <div className="flex min-w-0 flex-col">
+            <h3 className="truncate text-[14px] font-medium tracking-tight text-fg">
+              {repo.displayName}
+            </h3>
+            <span className="mono truncate text-[11px] text-fg-dim">
+              {snap?.detached ? "(detached HEAD)" : snap?.branch ?? "—"}
+            </span>
+          </div>
+
+          <SyncCell ahead={ahead} behind={behind} hasUpstream={!!snap?.upstream} />
+          <LocalCell dirty={dirtyTotal} newFiles={newFiles} conflicts={conflicts} />
+          <LastCommitCell
+            subject={snap?.lastCommitSubject ?? null}
+            ts={snap?.lastCommitTs ?? null}
+          />
+          <PrCell count={prCount} url={ghPrUrl} />
+
+          {button.action ? (
+            <button
+              onClick={(e) => {
+                e.stopPropagation();
+                setModalAction(button.action);
+              }}
+              className={cn(actionButtonClass(kind), "justify-self-start")}
+            >
+              {button.label}
+            </button>
+          ) : (
+            <span />
+          )}
+
+          <RowIcons
+            ghUrl={ghUrl}
+            repoId={repo.id}
+            csrfToken={csrfToken}
+            expanded={expanded}
+          />
         </div>
 
-        <SyncCell ahead={ahead} behind={behind} hasUpstream={!!snap?.upstream} kind={kind} />
+        {/* Mobile stacked card (< sm). */}
+        <div className="flex flex-col gap-3 px-4 py-3.5 sm:hidden">
+          <div className="flex items-start gap-3">
+            <div className="flex min-w-0 flex-1 flex-col">
+              <h3 className="truncate text-[15px] font-medium tracking-tight text-fg">
+                {repo.displayName}
+              </h3>
+              <span className="mono truncate text-[11px] text-fg-dim">
+                {snap?.detached ? "(detached HEAD)" : snap?.branch ?? "—"}
+              </span>
+            </div>
+            <RowIcons
+              ghUrl={ghUrl}
+              repoId={repo.id}
+              csrfToken={csrfToken}
+              expanded={expanded}
+            />
+          </div>
 
-        <LocalCell
-          dirty={dirtyTotal}
-          newFiles={newFiles}
-          conflicts={conflicts}
-          kind={kind}
-        />
-
-        <LastCommitCell
-          subject={snap?.lastCommitSubject ?? null}
-          ts={snap?.lastCommitTs ?? null}
-        />
-
-        <PrCell count={snap?.openPrCount ?? 0} url={ghPrUrl} />
-
-        {button.action ? (
-          <button
-            onClick={() => setModalAction(button.action)}
-            className={cn(
-              "shrink-0 justify-self-start whitespace-nowrap rounded-full border px-3.5 py-1 text-[12px] font-medium tracking-tight transition-all",
-              kind === "push" &&
-                "border-accent-push/35 bg-accent-push/10 text-accent-push hover:border-accent-push/55 hover:bg-accent-push/20",
-              kind === "pull" &&
-                "border-accent-pull/35 bg-accent-pull/10 text-accent-pull hover:border-accent-pull/55 hover:bg-accent-pull/20",
-              kind === "diverged" &&
-                "border-accent-diverged/35 bg-accent-diverged/10 text-accent-diverged hover:border-accent-diverged/55 hover:bg-accent-diverged/20",
-              kind === "dirty" &&
-                "border-accent-dirty/35 bg-accent-dirty/10 text-accent-dirty hover:border-accent-dirty/55 hover:bg-accent-dirty/20",
+          <div className="flex flex-wrap items-center gap-x-3 gap-y-1.5 text-[12px]">
+            <MobileSyncChip
+              ahead={ahead}
+              behind={behind}
+              hasUpstream={!!snap?.upstream}
+            />
+            <MobileLocalChip
+              dirty={dirtyTotal}
+              newFiles={newFiles}
+              conflicts={conflicts}
+            />
+            {prCount > 0 && ghPrUrl && (
+              <a
+                href={ghPrUrl}
+                target="_blank"
+                rel="noreferrer"
+                onClick={(e) => e.stopPropagation()}
+                className="inline-flex items-center gap-1 text-fg-muted hover:text-fg"
+              >
+                <GitPullRequest className="h-3.5 w-3.5" />
+                <span className="tabular-nums">{prCount}</span>
+              </a>
             )}
-          >
-            {button.label}
-          </button>
-        ) : (
-          <span />
-        )}
+          </div>
 
-        <RowIcons
-          ghUrl={ghUrl}
-          repoId={repo.id}
-          csrfToken={csrfToken}
-        />
+          <div
+            className="mono truncate text-[11px] text-fg-muted"
+            title={snap?.lastCommitSubject ?? undefined}
+          >
+            {snap?.lastCommitSubject ?? "—"}
+            <span className="ml-2 text-fg-dim">
+              · {relativeTime(snap?.lastCommitTs ?? null)}
+            </span>
+          </div>
+
+          {button.action && (
+            <button
+              onClick={(e) => {
+                e.stopPropagation();
+                setModalAction(button.action);
+              }}
+              className={cn(actionButtonClass(kind), "h-10 self-start px-4 text-[13px]")}
+            >
+              {button.label}
+            </button>
+          )}
+        </div>
+
+        <RowDetail repoId={repo.id} open={expanded} />
       </div>
 
       {modalAction && (
@@ -150,12 +250,10 @@ function SyncCell({
   ahead,
   behind,
   hasUpstream,
-  kind: _kind,
 }: {
   ahead: number;
   behind: number;
   hasUpstream: boolean;
-  kind: GroupKind;
 }) {
   if (!hasUpstream) {
     return <span className="text-[12px] text-fg-dim">no upstream</span>;
@@ -185,12 +283,10 @@ function LocalCell({
   dirty,
   newFiles,
   conflicts,
-  kind: _kind,
 }: {
   dirty: number;
   newFiles: number;
   conflicts: number;
-  kind: GroupKind;
 }) {
   if (conflicts > 0) {
     return (
@@ -204,15 +300,69 @@ function LocalCell({
   }
   return (
     <div className="flex flex-col text-[12px] leading-tight">
-      <span className="text-accent-dirty">
-        {dirty} unsaved
-      </span>
-      {newFiles > 0 && (
-        <span className="text-fg-dim">
-          {newFiles} new
+      <span className="text-accent-dirty">{dirty} unsaved</span>
+      {newFiles > 0 && <span className="text-fg-dim">{newFiles} new</span>}
+    </div>
+  );
+}
+
+function MobileSyncChip({
+  ahead,
+  behind,
+  hasUpstream,
+}: {
+  ahead: number;
+  behind: number;
+  hasUpstream: boolean;
+}) {
+  if (!hasUpstream) {
+    return <span className="text-fg-dim">no upstream</span>;
+  }
+  if (ahead === 0 && behind === 0) {
+    return <span className="text-fg-dim">in sync</span>;
+  }
+  return (
+    <span className="inline-flex items-center gap-2 tabular-nums">
+      {ahead > 0 && (
+        <span className="inline-flex items-center gap-0.5 text-accent-push">
+          <ArrowUp className="h-3 w-3" />
+          {ahead}
         </span>
       )}
-    </div>
+      {behind > 0 && (
+        <span className="inline-flex items-center gap-0.5 text-accent-pull">
+          <ArrowDown className="h-3 w-3" />
+          {behind}
+        </span>
+      )}
+    </span>
+  );
+}
+
+function MobileLocalChip({
+  dirty,
+  newFiles,
+  conflicts,
+}: {
+  dirty: number;
+  newFiles: number;
+  conflicts: number;
+}) {
+  if (conflicts > 0) {
+    return (
+      <span className="font-medium text-accent-attention">
+        {conflicts} conflict{conflicts === 1 ? "" : "s"}
+      </span>
+    );
+  }
+  if (dirty === 0) return null;
+  return (
+    <span className="text-accent-dirty">
+      {dirty} unsaved
+      {newFiles > 0 && (
+        <span className="ml-1 text-fg-dim">({newFiles} new)</span>
+      )}
+    </span>
   );
 }
 
@@ -242,6 +392,7 @@ function PrCell({ count, url }: { count: number; url: string | null }) {
       href={url}
       target="_blank"
       rel="noreferrer"
+      onClick={(e) => e.stopPropagation()}
       className="inline-flex items-center gap-1.5 text-[12px] text-fg-muted hover:text-fg"
       title={`${count} open pull request${count === 1 ? "" : "s"} on GitHub`}
     >
@@ -255,14 +406,17 @@ function RowIcons({
   ghUrl,
   repoId,
   csrfToken,
+  expanded,
 }: {
   ghUrl: string | null;
   repoId: number;
   csrfToken: string;
+  expanded: boolean;
 }) {
   const [refreshState, setRefreshState] = useState<"idle" | "spinning" | "error">("idle");
 
-  const onRefresh = async () => {
+  const onRefresh = async (e: React.MouseEvent) => {
+    e.stopPropagation();
     if (refreshState === "spinning") return;
     setRefreshState("spinning");
     try {
@@ -283,7 +437,7 @@ function RowIcons({
   };
 
   return (
-    <div className="flex items-center justify-end gap-1">
+    <div className="flex items-center justify-end gap-0.5 sm:gap-1">
       <button
         type="button"
         onClick={onRefresh}
@@ -295,7 +449,7 @@ function RowIcons({
         aria-label="Refresh"
         disabled={refreshState === "spinning"}
         className={cn(
-          "inline-flex h-7 w-7 items-center justify-center rounded-full transition-colors",
+          "inline-flex h-9 w-9 items-center justify-center rounded-full transition-colors sm:h-7 sm:w-7",
           refreshState === "error"
             ? "text-accent-attention"
             : "text-fg-dim hover:bg-bg-hover hover:text-fg",
@@ -311,20 +465,32 @@ function RowIcons({
           href={ghUrl}
           target="_blank"
           rel="noopener noreferrer"
+          onClick={(e) => e.stopPropagation()}
           title="Open on GitHub"
           aria-label="Open on GitHub"
-          className="inline-flex h-7 w-7 items-center justify-center rounded-full text-fg-dim transition-colors hover:bg-bg-hover hover:text-fg"
+          className="inline-flex h-9 w-9 items-center justify-center rounded-full text-fg-dim transition-colors hover:bg-bg-hover hover:text-fg sm:h-7 sm:w-7"
         >
           <ExternalLink className="h-3.5 w-3.5" />
         </a>
       ) : (
         <span
-          className="inline-flex h-7 w-7 items-center justify-center text-fg-dim opacity-30"
+          className="inline-flex h-9 w-9 items-center justify-center text-fg-dim opacity-30 sm:h-7 sm:w-7"
           title="No GitHub remote"
         >
           <ExternalLink className="h-3.5 w-3.5" />
         </span>
       )}
+      <span
+        aria-hidden="true"
+        className="inline-flex h-9 w-9 items-center justify-center text-fg-dim sm:h-7 sm:w-7"
+      >
+        <ChevronDown
+          className={cn(
+            "h-3.5 w-3.5 transition-transform",
+            expanded && "rotate-180",
+          )}
+        />
+      </span>
     </div>
   );
 }

--- a/components/RepoCard.tsx
+++ b/components/RepoCard.tsx
@@ -129,7 +129,8 @@ export function RepoCard({ repo, kind, csrfToken }: Props) {
 
         <RowIcons
           ghUrl={ghUrl}
-          onFetch={() => setModalAction("fetch")}
+          repoId={repo.id}
+          csrfToken={csrfToken}
         />
       </div>
 
@@ -252,20 +253,59 @@ function PrCell({ count, url }: { count: number; url: string | null }) {
 
 function RowIcons({
   ghUrl,
-  onFetch,
+  repoId,
+  csrfToken,
 }: {
   ghUrl: string | null;
-  onFetch: () => void;
+  repoId: number;
+  csrfToken: string;
 }) {
+  const [refreshState, setRefreshState] = useState<"idle" | "spinning" | "error">("idle");
+
+  const onRefresh = async () => {
+    if (refreshState === "spinning") return;
+    setRefreshState("spinning");
+    try {
+      const res = await fetch(`/api/repos/${repoId}/refresh`, {
+        method: "POST",
+        headers: { "x-csrf-token": csrfToken },
+      });
+      if (!res.ok) {
+        setRefreshState("error");
+        setTimeout(() => setRefreshState("idle"), 1500);
+      } else {
+        setRefreshState("idle");
+      }
+    } catch {
+      setRefreshState("error");
+      setTimeout(() => setRefreshState("idle"), 1500);
+    }
+  };
+
   return (
     <div className="flex items-center justify-end gap-1">
-      <IconButton
-        title="Refresh sync state with GitHub"
-        ariaLabel="Refresh"
-        onClick={onFetch}
+      <button
+        type="button"
+        onClick={onRefresh}
+        title={
+          refreshState === "error"
+            ? "Refresh failed — see server logs"
+            : "Re-check this repo against GitHub"
+        }
+        aria-label="Refresh"
+        disabled={refreshState === "spinning"}
+        className={cn(
+          "inline-flex h-7 w-7 items-center justify-center rounded-full transition-colors",
+          refreshState === "error"
+            ? "text-accent-attention"
+            : "text-fg-dim hover:bg-bg-hover hover:text-fg",
+          refreshState === "spinning" && "cursor-wait",
+        )}
       >
-        <RefreshCw className="h-3.5 w-3.5" />
-      </IconButton>
+        <RefreshCw
+          className={cn("h-3.5 w-3.5", refreshState === "spinning" && "animate-spin")}
+        />
+      </button>
       {ghUrl ? (
         <a
           href={ghUrl}
@@ -278,34 +318,13 @@ function RowIcons({
           <ExternalLink className="h-3.5 w-3.5" />
         </a>
       ) : (
-        <span className="inline-flex h-7 w-7 items-center justify-center text-fg-dim opacity-30" title="No GitHub remote">
+        <span
+          className="inline-flex h-7 w-7 items-center justify-center text-fg-dim opacity-30"
+          title="No GitHub remote"
+        >
           <ExternalLink className="h-3.5 w-3.5" />
         </span>
       )}
     </div>
-  );
-}
-
-function IconButton({
-  children,
-  onClick,
-  title,
-  ariaLabel,
-}: {
-  children: React.ReactNode;
-  onClick: () => void;
-  title: string;
-  ariaLabel: string;
-}) {
-  return (
-    <button
-      type="button"
-      onClick={onClick}
-      title={title}
-      aria-label={ariaLabel}
-      className="inline-flex h-7 w-7 items-center justify-center rounded-full text-fg-dim transition-colors hover:bg-bg-hover hover:text-fg"
-    >
-      {children}
-    </button>
   );
 }

--- a/components/RepoCard.tsx
+++ b/components/RepoCard.tsx
@@ -3,24 +3,19 @@
 import { cn } from "@/lib/utils";
 import type { RepoView } from "@/lib/state/store";
 import { ActionModal } from "./ActionModal";
-import { useEffect, useRef, useState, type ReactNode } from "react";
+import { useState } from "react";
 import {
   ArrowDown,
   ArrowUp,
-  Check,
-  Copy,
   ExternalLink,
-  FileCode2,
   GitPullRequest,
-  MoreHorizontal,
   RefreshCw,
-  TerminalSquare,
 } from "lucide-react";
 
 export type GroupKind = "push" | "pull" | "diverged" | "attention" | "dirty" | "clean";
 
 export const ROW_GRID =
-  "grid-cols-[minmax(180px,1.4fr)_120px_150px_minmax(200px,1.6fr)_80px_148px_36px]";
+  "grid-cols-[minmax(180px,1.4fr)_120px_150px_minmax(200px,1.6fr)_80px_148px_72px]";
 
 function primaryAction(
   kind: GroupKind,
@@ -30,12 +25,12 @@ function primaryAction(
   if (kind === "push") return { label: "Push", action: "push" };
   if (kind === "pull") return { label: "Pull", action: "pull" };
   if (kind === "diverged") return { label: "Merge", action: "merge" };
-  if (kind === "attention") return { label: "Open", action: "open-editor" };
-  if (kind === "dirty") {
-    if (hasConflicts) return { label: "Resolve", action: "open-editor" };
-    if (hasRemote) return { label: "Commit & push", action: "commit-push" };
-    return { label: "Open", action: "open-editor" };
+  if (kind === "dirty" && !hasConflicts && hasRemote) {
+    return { label: "Commit & push", action: "commit-push" };
   }
+  // No primary button for: attention, dirty+conflicts, dirty+no-remote, clean.
+  // User handles those externally; the icon buttons (Refresh + Open on GitHub)
+  // are still available in the actions column.
   return { label: "", action: null };
 }
 
@@ -84,7 +79,6 @@ export function RepoCard({ repo, kind, csrfToken }: Props) {
           ROW_GRID,
         )}
       >
-        {/* Repo name + branch */}
         <div className="flex min-w-0 flex-col">
           <h3 className="truncate text-[14px] font-medium tracking-tight text-fg">
             {repo.displayName}
@@ -96,10 +90,8 @@ export function RepoCard({ repo, kind, csrfToken }: Props) {
           </span>
         </div>
 
-        {/* Sync ↑n ↓n */}
         <SyncCell ahead={ahead} behind={behind} hasUpstream={!!snap?.upstream} kind={kind} />
 
-        {/* Local changes */}
         <LocalCell
           dirty={dirtyTotal}
           newFiles={newFiles}
@@ -107,16 +99,13 @@ export function RepoCard({ repo, kind, csrfToken }: Props) {
           kind={kind}
         />
 
-        {/* Last commit subject + time */}
         <LastCommitCell
           subject={snap?.lastCommitSubject ?? null}
           ts={snap?.lastCommitTs ?? null}
         />
 
-        {/* PRs */}
         <PrCell count={snap?.openPrCount ?? 0} url={ghPrUrl} />
 
-        {/* Primary action */}
         {button.action ? (
           <button
             onClick={() => setModalAction(button.action)}
@@ -128,8 +117,6 @@ export function RepoCard({ repo, kind, csrfToken }: Props) {
                 "border-accent-pull/35 bg-accent-pull/10 text-accent-pull hover:border-accent-pull/55 hover:bg-accent-pull/20",
               kind === "diverged" &&
                 "border-accent-diverged/35 bg-accent-diverged/10 text-accent-diverged hover:border-accent-diverged/55 hover:bg-accent-diverged/20",
-              kind === "attention" &&
-                "border-accent-attention/35 bg-accent-attention/10 text-accent-attention hover:border-accent-attention/55 hover:bg-accent-attention/20",
               kind === "dirty" &&
                 "border-accent-dirty/35 bg-accent-dirty/10 text-accent-dirty hover:border-accent-dirty/55 hover:bg-accent-dirty/20",
             )}
@@ -140,11 +127,9 @@ export function RepoCard({ repo, kind, csrfToken }: Props) {
           <span />
         )}
 
-        {/* ⋯ menu */}
-        <RowMenu
+        <RowIcons
           ghUrl={ghUrl}
-          remoteUrl={snap?.remoteUrl ?? null}
-          onModalAction={(a) => setModalAction(a)}
+          onFetch={() => setModalAction("fetch")}
         />
       </div>
 
@@ -265,139 +250,62 @@ function PrCell({ count, url }: { count: number; url: string | null }) {
   );
 }
 
-interface RowMenuProps {
+function RowIcons({
+  ghUrl,
+  onFetch,
+}: {
   ghUrl: string | null;
-  remoteUrl: string | null;
-  onModalAction: (action: string) => void;
-}
-
-function RowMenu({ ghUrl, remoteUrl, onModalAction }: RowMenuProps) {
-  const [open, setOpen] = useState(false);
-  const [copied, setCopied] = useState(false);
-  const containerRef = useRef<HTMLDivElement | null>(null);
-
-  useEffect(() => {
-    if (!open) return;
-    const onDoc = (e: MouseEvent) => {
-      if (!containerRef.current?.contains(e.target as Node)) setOpen(false);
-    };
-    const onKey = (e: KeyboardEvent) => {
-      if (e.key === "Escape") setOpen(false);
-    };
-    document.addEventListener("mousedown", onDoc);
-    document.addEventListener("keydown", onKey);
-    return () => {
-      document.removeEventListener("mousedown", onDoc);
-      document.removeEventListener("keydown", onKey);
-    };
-  }, [open]);
-
-  const copyClone = async () => {
-    if (!remoteUrl) return;
-    try {
-      await navigator.clipboard.writeText(remoteUrl);
-      setCopied(true);
-      setTimeout(() => {
-        setCopied(false);
-        setOpen(false);
-      }, 1200);
-    } catch {
-      // ignore — clipboard requires secure context; localhost is fine
-    }
-  };
-
+  onFetch: () => void;
+}) {
   return (
-    <div ref={containerRef} className="relative justify-self-end">
-      <button
-        type="button"
-        onClick={() => setOpen((v) => !v)}
-        className="inline-flex h-7 w-7 items-center justify-center rounded-full text-fg-dim opacity-0 transition-all hover:bg-bg-hover hover:text-fg group-hover:opacity-100 data-[open=true]:opacity-100"
-        data-open={open}
-        aria-label="More actions"
-        aria-haspopup="menu"
-        aria-expanded={open}
+    <div className="flex items-center justify-end gap-1">
+      <IconButton
+        title="Refresh sync state with GitHub"
+        ariaLabel="Refresh"
+        onClick={onFetch}
       >
-        <MoreHorizontal className="h-4 w-4" />
-      </button>
-
-      {open && (
-        <div
-          role="menu"
-          className="absolute right-0 top-full z-20 mt-1 w-56 overflow-hidden rounded-xl border border-border bg-bg-elevated shadow-2xl"
+        <RefreshCw className="h-3.5 w-3.5" />
+      </IconButton>
+      {ghUrl ? (
+        <a
+          href={ghUrl}
+          target="_blank"
+          rel="noopener noreferrer"
+          title="Open on GitHub"
+          aria-label="Open on GitHub"
+          className="inline-flex h-7 w-7 items-center justify-center rounded-full text-fg-dim transition-colors hover:bg-bg-hover hover:text-fg"
         >
-          <MenuItem
-            icon={<RefreshCw className="h-3.5 w-3.5" />}
-            label="Fetch from GitHub"
-            onClick={() => {
-              setOpen(false);
-              onModalAction("fetch");
-            }}
-          />
-          <MenuItem
-            icon={<FileCode2 className="h-3.5 w-3.5" />}
-            label="Open in editor"
-            onClick={() => {
-              setOpen(false);
-              onModalAction("open-editor");
-            }}
-          />
-          <MenuItem
-            icon={<TerminalSquare className="h-3.5 w-3.5" />}
-            label="Open in terminal"
-            onClick={() => {
-              setOpen(false);
-              onModalAction("open-terminal");
-            }}
-          />
-          <div className="my-1 h-px bg-border-subtle" />
-          <MenuItem
-            icon={<ExternalLink className="h-3.5 w-3.5" />}
-            label="Open on GitHub"
-            disabled={!ghUrl}
-            onClick={() => {
-              if (!ghUrl) return;
-              window.open(ghUrl, "_blank", "noopener,noreferrer");
-              setOpen(false);
-            }}
-          />
-          <MenuItem
-            icon={copied ? <Check className="h-3.5 w-3.5 text-accent-clean" /> : <Copy className="h-3.5 w-3.5" />}
-            label={copied ? "Copied!" : "Copy clone URL"}
-            disabled={!remoteUrl}
-            onClick={copyClone}
-          />
-        </div>
+          <ExternalLink className="h-3.5 w-3.5" />
+        </a>
+      ) : (
+        <span className="inline-flex h-7 w-7 items-center justify-center text-fg-dim opacity-30" title="No GitHub remote">
+          <ExternalLink className="h-3.5 w-3.5" />
+        </span>
       )}
     </div>
   );
 }
 
-function MenuItem({
-  icon,
-  label,
+function IconButton({
+  children,
   onClick,
-  disabled,
+  title,
+  ariaLabel,
 }: {
-  icon: ReactNode;
-  label: string;
+  children: React.ReactNode;
   onClick: () => void;
-  disabled?: boolean;
+  title: string;
+  ariaLabel: string;
 }) {
   return (
     <button
-      role="menuitem"
       type="button"
       onClick={onClick}
-      disabled={disabled}
-      className={cn(
-        "flex w-full items-center gap-2.5 px-3 py-2 text-left text-[12.5px] text-fg-muted transition-colors",
-        disabled
-          ? "cursor-not-allowed opacity-40"
-          : "hover:bg-bg-hover hover:text-fg",
-      )}
+      title={title}
+      aria-label={ariaLabel}
+      className="inline-flex h-7 w-7 items-center justify-center rounded-full text-fg-dim transition-colors hover:bg-bg-hover hover:text-fg"
     >
-      <span className="text-fg-dim">{icon}</span>
-      {label}
+      {children}
     </button>
   );
 }

--- a/components/RepoCard.tsx
+++ b/components/RepoCard.tsx
@@ -224,7 +224,7 @@ export function RepoCard({ repo, kind, csrfToken, expanded, onToggle }: Props) {
                 e.stopPropagation();
                 setModalAction(button.action);
               }}
-              className={cn(actionButtonClass(kind), "h-10 self-start px-4 text-[13px]")}
+              className={cn(actionButtonClass(kind), "h-11 self-start px-4 text-[13px] sm:h-10")}
             >
               {button.label}
             </button>
@@ -449,7 +449,7 @@ function RowIcons({
         aria-label="Refresh"
         disabled={refreshState === "spinning"}
         className={cn(
-          "inline-flex h-9 w-9 items-center justify-center rounded-full transition-colors sm:h-7 sm:w-7",
+          "inline-flex h-11 w-11 items-center justify-center rounded-full transition-colors sm:h-7 sm:w-7",
           refreshState === "error"
             ? "text-accent-attention"
             : "text-fg-dim hover:bg-bg-hover hover:text-fg",
@@ -468,13 +468,13 @@ function RowIcons({
           onClick={(e) => e.stopPropagation()}
           title="Open on GitHub"
           aria-label="Open on GitHub"
-          className="inline-flex h-9 w-9 items-center justify-center rounded-full text-fg-dim transition-colors hover:bg-bg-hover hover:text-fg sm:h-7 sm:w-7"
+          className="inline-flex h-11 w-11 items-center justify-center rounded-full text-fg-dim transition-colors hover:bg-bg-hover hover:text-fg sm:h-7 sm:w-7"
         >
           <ExternalLink className="h-3.5 w-3.5" />
         </a>
       ) : (
         <span
-          className="inline-flex h-9 w-9 items-center justify-center text-fg-dim opacity-30 sm:h-7 sm:w-7"
+          className="inline-flex h-11 w-11 items-center justify-center text-fg-dim opacity-30 sm:h-7 sm:w-7"
           title="No GitHub remote"
         >
           <ExternalLink className="h-3.5 w-3.5" />
@@ -482,7 +482,7 @@ function RowIcons({
       )}
       <span
         aria-hidden="true"
-        className="inline-flex h-9 w-9 items-center justify-center text-fg-dim sm:h-7 sm:w-7"
+        className="inline-flex h-11 w-11 items-center justify-center text-fg-dim sm:h-7 sm:w-7"
       >
         <ChevronDown
           className={cn(

--- a/components/RepoGroup.tsx
+++ b/components/RepoGroup.tsx
@@ -13,6 +13,8 @@ interface Props {
   repos: RepoView[];
   csrfToken: string;
   defaultCollapsed?: boolean;
+  expandedRepoId: number | null;
+  onToggleRepo: (id: number) => void;
 }
 
 const TINT: Record<GroupKind, string> = {
@@ -44,6 +46,8 @@ export function RepoGroup({
   repos,
   csrfToken,
   defaultCollapsed = false,
+  expandedRepoId,
+  onToggleRepo,
 }: Props) {
   const [collapsed, setCollapsed] = useState(defaultCollapsed);
   const isEmpty = repos.length === 0;
@@ -61,7 +65,7 @@ export function RepoGroup({
     >
       <header
         className={cn(
-          "flex items-start gap-5 px-6 pb-4 pt-6",
+          "flex items-start gap-3 px-4 pb-3 pt-5 sm:gap-5 sm:px-6 sm:pb-4 sm:pt-6",
           !isEmpty && "cursor-pointer",
         )}
         onClick={isEmpty ? undefined : () => setCollapsed((v) => !v)}
@@ -75,22 +79,22 @@ export function RepoGroup({
       >
         <div
           className={cn(
-            "display shrink-0 text-[64px] leading-none tracking-display-tight",
+            "display shrink-0 text-[44px] leading-none tracking-display-tight sm:text-[64px]",
             ACCENT[kind],
           )}
         >
           {repos.length}
         </div>
 
-        <div className="flex flex-1 flex-col pt-2">
-          <h2 className="display text-[22px] leading-tight text-fg">{headline}</h2>
-          <p className="mt-1 text-[13px] text-fg-muted">{body}</p>
+        <div className="flex min-w-0 flex-1 flex-col pt-1 sm:pt-2">
+          <h2 className="display text-[18px] leading-tight text-fg sm:text-[22px]">{headline}</h2>
+          <p className="mt-1 text-[12px] text-fg-muted sm:text-[13px]">{body}</p>
         </div>
 
         {!isEmpty && (
           <ChevronRight
             className={cn(
-              "mt-3 h-4 w-4 shrink-0 text-fg-dim transition-transform",
+              "mt-2 h-4 w-4 shrink-0 text-fg-dim transition-transform sm:mt-3",
               !collapsed && "rotate-90",
             )}
           />
@@ -107,7 +111,7 @@ export function RepoGroup({
         <div className="border-t border-border-subtle">
           <div
             className={cn(
-              "grid items-center gap-x-4 border-b border-border-subtle bg-bg/30 px-6 py-2 text-[10px] uppercase tracking-[0.12em] text-fg-dim",
+              "hidden items-center gap-x-4 border-b border-border-subtle bg-bg/30 px-6 py-2 text-[10px] uppercase tracking-[0.12em] text-fg-dim sm:grid",
               ROW_GRID,
             )}
           >
@@ -126,6 +130,8 @@ export function RepoGroup({
                 repo={repo}
                 kind={kind}
                 csrfToken={csrfToken}
+                expanded={expandedRepoId === repo.id}
+                onToggle={() => onToggleRepo(repo.id)}
               />
             ))}
           </div>

--- a/components/RowDetail.tsx
+++ b/components/RowDetail.tsx
@@ -197,7 +197,7 @@ function ActionsPanel({ actions }: { actions: Action[] }) {
                 </span>
                 <span className="truncate text-[12px] text-fg">{a.action}</span>
                 <span className="mono shrink-0 text-[11px] text-fg-dim tabular-nums">
-                  {relativeTime(a.startedAt)}
+                  {relativeTime(Math.floor(a.startedAt / 1000))}
                   {failed && ` · exit ${a.exitCode}`}
                 </span>
               </li>

--- a/components/RowDetail.tsx
+++ b/components/RowDetail.tsx
@@ -1,0 +1,258 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { Check, X as XIcon, Loader2, ExternalLink } from "lucide-react";
+
+interface Commit {
+  sha: string;
+  subject: string;
+  author: string;
+  unixTimestamp: number;
+}
+
+interface Action {
+  id: number;
+  action: string;
+  startedAt: number;
+  finishedAt: number | null;
+  exitCode: number | null;
+}
+
+interface Metadata {
+  fullPath: string;
+  defaultBranch: string | null;
+  remoteUrl: string | null;
+  githubOwner: string | null;
+  githubName: string | null;
+  totalCommits: number | null;
+}
+
+interface Details {
+  recentCommits: Commit[];
+  recentActions: Action[];
+  metadata: Metadata;
+}
+
+function relativeTime(unix: number | null | undefined): string {
+  if (!unix) return "—";
+  const deltaSec = Math.floor(Date.now() / 1000 - unix);
+  if (deltaSec < 60) return "just now";
+  if (deltaSec < 3600) return `${Math.floor(deltaSec / 60)}m ago`;
+  if (deltaSec < 86400) return `${Math.floor(deltaSec / 3600)}h ago`;
+  if (deltaSec < 86400 * 30) return `${Math.floor(deltaSec / 86400)}d ago`;
+  if (deltaSec < 86400 * 365) return `${Math.floor(deltaSec / (86400 * 30))}mo ago`;
+  return `${Math.floor(deltaSec / (86400 * 365))}y ago`;
+}
+
+export function RowDetail({ repoId, open }: { repoId: number; open: boolean }) {
+  const [data, setData] = useState<Details | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    let cancelled = false;
+    setLoading(true);
+    setError(null);
+    fetch(`/api/repos/${repoId}/details`)
+      .then((r) => (r.ok ? r.json() : Promise.reject(new Error(r.statusText))))
+      .then((d: Details) => {
+        if (!cancelled) setData(d);
+      })
+      .catch((e) => {
+        if (!cancelled) setError(String(e));
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [open, repoId]);
+
+  if (!open) return null;
+
+  return (
+    <div
+      className="border-t border-border-subtle bg-bg/30 px-4 py-5 sm:px-6"
+      onClick={(e) => e.stopPropagation()}
+    >
+      {loading && !data && (
+        <div className="flex items-center gap-2 text-[12px] text-fg-dim">
+          <Loader2 className="h-3.5 w-3.5 animate-spin" />
+          Loading details…
+        </div>
+      )}
+
+      {error && !data && (
+        <div className="text-[12px] text-accent-attention">
+          Couldn't load details: {error}
+        </div>
+      )}
+
+      {data && (
+        <div className="grid grid-cols-1 gap-6 sm:grid-cols-3">
+          <CommitsPanel commits={data.recentCommits} ghBase={ghBaseUrl(data.metadata)} />
+          <ActionsPanel actions={data.recentActions} />
+          <MetadataPanel meta={data.metadata} />
+        </div>
+      )}
+    </div>
+  );
+}
+
+function ghBaseUrl(m: Metadata): string | null {
+  if (m.githubOwner && m.githubName) {
+    return `https://github.com/${m.githubOwner}/${m.githubName}`;
+  }
+  return null;
+}
+
+function SectionHeading({ children }: { children: React.ReactNode }) {
+  return (
+    <h4 className="mb-3 text-[10px] font-medium uppercase tracking-[0.14em] text-fg-dim">
+      {children}
+    </h4>
+  );
+}
+
+function CommitsPanel({ commits, ghBase }: { commits: Commit[]; ghBase: string | null }) {
+  return (
+    <div>
+      <SectionHeading>Recent commits</SectionHeading>
+      {commits.length === 0 ? (
+        <p className="text-[12px] italic text-fg-dim">No commits yet.</p>
+      ) : (
+        <ul className="flex flex-col gap-1.5">
+          {commits.map((c) => {
+            const short = c.sha.slice(0, 7);
+            const href = ghBase ? `${ghBase}/commit/${c.sha}` : null;
+            const rowInner = (
+              <>
+                <span className="mono shrink-0 text-[11px] text-fg-dim">{short}</span>
+                <span className="truncate text-[12px] text-fg" title={c.subject}>
+                  {c.subject || "(no subject)"}
+                </span>
+                <span className="shrink-0 text-[11px] text-fg-dim" title={c.author}>
+                  {c.author}
+                </span>
+                <span className="mono shrink-0 text-[11px] text-fg-dim tabular-nums">
+                  {relativeTime(c.unixTimestamp)}
+                </span>
+              </>
+            );
+            return (
+              <li key={c.sha}>
+                {href ? (
+                  <a
+                    href={href}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="grid grid-cols-[52px_1fr_auto_auto] items-baseline gap-2 rounded px-1 py-0.5 hover:bg-bg-hover"
+                    onClick={(e) => e.stopPropagation()}
+                  >
+                    {rowInner}
+                  </a>
+                ) : (
+                  <div className="grid grid-cols-[52px_1fr_auto_auto] items-baseline gap-2 px-1 py-0.5">
+                    {rowInner}
+                  </div>
+                )}
+              </li>
+            );
+          })}
+        </ul>
+      )}
+    </div>
+  );
+}
+
+function ActionsPanel({ actions }: { actions: Action[] }) {
+  return (
+    <div>
+      <SectionHeading>Recent gitdash actions</SectionHeading>
+      {actions.length === 0 ? (
+        <p className="text-[12px] italic text-fg-dim">
+          No actions yet. Use Push / Pull / Commit &amp; push and they'll log here.
+        </p>
+      ) : (
+        <ul className="flex flex-col gap-1.5">
+          {actions.map((a) => {
+            const ok = a.exitCode === 0;
+            const failed = a.exitCode !== null && a.exitCode !== 0;
+            const running = a.finishedAt === null;
+            return (
+              <li
+                key={a.id}
+                className="grid grid-cols-[16px_1fr_auto] items-baseline gap-2 px-1 py-0.5"
+              >
+                <span className="flex h-4 items-center">
+                  {running ? (
+                    <Loader2 className="h-3 w-3 animate-spin text-fg-dim" />
+                  ) : ok ? (
+                    <Check className="h-3 w-3 text-accent-clean" />
+                  ) : (
+                    <XIcon className="h-3 w-3 text-accent-attention" />
+                  )}
+                </span>
+                <span className="truncate text-[12px] text-fg">{a.action}</span>
+                <span className="mono shrink-0 text-[11px] text-fg-dim tabular-nums">
+                  {relativeTime(a.startedAt)}
+                  {failed && ` · exit ${a.exitCode}`}
+                </span>
+              </li>
+            );
+          })}
+        </ul>
+      )}
+    </div>
+  );
+}
+
+function MetadataPanel({ meta }: { meta: Metadata }) {
+  return (
+    <div>
+      <SectionHeading>Metadata</SectionHeading>
+      <dl className="flex flex-col gap-2 text-[12px]">
+        <Field label="Path">
+          <span className="mono break-all text-fg-muted" style={{ userSelect: "text" }}>
+            {meta.fullPath}
+          </span>
+        </Field>
+        <Field label="Default branch">
+          <span className="mono text-fg-muted">{meta.defaultBranch ?? "—"}</span>
+        </Field>
+        <Field label="Remote">
+          {meta.githubOwner && meta.githubName ? (
+            <a
+              href={`https://github.com/${meta.githubOwner}/${meta.githubName}`}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="inline-flex items-center gap-1 text-fg-muted underline-offset-2 hover:text-fg hover:underline"
+              onClick={(e) => e.stopPropagation()}
+            >
+              {meta.githubOwner}/{meta.githubName}
+              <ExternalLink className="h-3 w-3" />
+            </a>
+          ) : (
+            <span className="break-all text-fg-muted">{meta.remoteUrl ?? "—"}</span>
+          )}
+        </Field>
+        <Field label="Total commits">
+          <span className="mono tabular-nums text-fg-muted">
+            {meta.totalCommits === null ? "—" : meta.totalCommits.toLocaleString()}
+          </span>
+        </Field>
+      </dl>
+    </div>
+  );
+}
+
+function Field({ label, children }: { label: string; children: React.ReactNode }) {
+  return (
+    <div className="grid grid-cols-[110px_1fr] items-baseline gap-3">
+      <dt className="text-[11px] uppercase tracking-[0.08em] text-fg-dim">{label}</dt>
+      <dd className="min-w-0">{children}</dd>
+    </div>
+  );
+}

--- a/components/ThemeToggle.tsx
+++ b/components/ThemeToggle.tsx
@@ -31,7 +31,7 @@ export function ThemeToggle() {
       onClick={toggle}
       aria-label={mounted ? `Switch to ${theme === "dark" ? "light" : "dark"} mode` : "Toggle theme"}
       title={mounted ? `Switch to ${theme === "dark" ? "light" : "dark"} mode` : "Toggle theme"}
-      className="inline-flex h-8 w-8 items-center justify-center rounded-full border border-border-subtle text-fg-muted transition-colors hover:border-border hover:bg-bg-hover hover:text-fg focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 focus:ring-offset-bg"
+      className="inline-flex h-11 w-11 items-center justify-center rounded-full border border-border-subtle text-fg-muted transition-colors hover:border-border hover:bg-bg-hover hover:text-fg focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 focus:ring-offset-bg sm:h-8 sm:w-8"
     >
       {/* Render both, hide the inactive one — avoids hydration mismatch on initial paint */}
       <Sun className={`h-3.5 w-3.5 ${mounted && theme === "dark" ? "" : "hidden"}`} />

--- a/lib/db/repos.ts
+++ b/lib/db/repos.ts
@@ -228,6 +228,37 @@ export function getAllSnapshots(): Map<number, SnapshotRow> {
   return new Map(rows.map((r) => [r.repo_id, rawToSnapshot(r)]));
 }
 
+export interface ActionLogRow {
+  id: number;
+  action: string;
+  startedAt: number;
+  finishedAt: number | null;
+  exitCode: number | null;
+}
+
+interface ActionLogRaw {
+  id: number;
+  action: string;
+  started_at: number;
+  finished_at: number | null;
+  exit_code: number | null;
+}
+
+export function getRecentActions(repoId: number, limit = 5): ActionLogRow[] {
+  const rows = getDb()
+    .prepare<[number, number], ActionLogRaw>(
+      "SELECT id, action, started_at, finished_at, exit_code FROM actions_log WHERE repo_id = ? ORDER BY started_at DESC LIMIT ?",
+    )
+    .all(repoId, limit);
+  return rows.map((r) => ({
+    id: r.id,
+    action: r.action,
+    startedAt: r.started_at,
+    finishedAt: r.finished_at,
+    exitCode: r.exit_code,
+  }));
+}
+
 function rawToRepoRow(r: RepoRaw): RepoRow {
   return {
     id: r.id,

--- a/lib/git/log.ts
+++ b/lib/git/log.ts
@@ -1,0 +1,83 @@
+import { runGit } from "./exec";
+
+export interface RecentCommit {
+  sha: string;
+  subject: string;
+  author: string;
+  unixTimestamp: number;
+}
+
+export interface RepoLogMetadata {
+  defaultBranch: string | null;
+  totalCommits: number | null;
+}
+
+const FIELD_SEP = "\x09";
+const RECORD_SEP = "\x1e";
+
+export async function getRecentCommits(
+  repoPath: string,
+  limit = 10,
+  timeoutMs = 10_000,
+): Promise<RecentCommit[]> {
+  const result = await runGit(
+    ["log", "-n", String(limit), `--format=%H${FIELD_SEP}%s${FIELD_SEP}%an${FIELD_SEP}%at${RECORD_SEP}`],
+    { cwd: repoPath, mode: "read", timeoutMs },
+  );
+  return result.stdout
+    .split(RECORD_SEP)
+    .map((r) => r.replace(/^\n/, "").trim())
+    .filter(Boolean)
+    .map((record) => {
+      const [sha, subject, author, ts] = record.split(FIELD_SEP);
+      return {
+        sha: sha ?? "",
+        subject: subject ?? "",
+        author: author ?? "",
+        unixTimestamp: Number(ts ?? 0),
+      };
+    })
+    .filter((c) => c.sha.length > 0);
+}
+
+export async function getRepoLogMetadata(
+  repoPath: string,
+  timeoutMs = 10_000,
+): Promise<RepoLogMetadata> {
+  let defaultBranch: string | null = null;
+  try {
+    const head = await runGit(["symbolic-ref", "--short", "refs/remotes/origin/HEAD"], {
+      cwd: repoPath,
+      mode: "read",
+      timeoutMs,
+    });
+    const v = head.stdout.trim();
+    defaultBranch = v.startsWith("origin/") ? v.slice("origin/".length) : v || null;
+  } catch {
+    try {
+      const cur = await runGit(["rev-parse", "--abbrev-ref", "HEAD"], {
+        cwd: repoPath,
+        mode: "read",
+        timeoutMs,
+      });
+      defaultBranch = cur.stdout.trim() || null;
+    } catch {
+      defaultBranch = null;
+    }
+  }
+
+  let totalCommits: number | null = null;
+  try {
+    const count = await runGit(["rev-list", "--count", "HEAD"], {
+      cwd: repoPath,
+      mode: "read",
+      timeoutMs,
+    });
+    const n = Number(count.stdout.trim());
+    totalCommits = Number.isFinite(n) ? n : null;
+  } catch {
+    totalCommits = null;
+  }
+
+  return { defaultBranch, totalCommits };
+}


### PR DESCRIPTION
## Summary

- Closes #8 — click any repo row to reveal recent commits, recent gitdash actions, and metadata (path, default branch, remote link, total commit count). Single-row expansion; Esc closes.
- Closes #25 — Pixel-first mobile layout; cards stack cleanly at 360–480px; desktop (>=640px) layout visually unchanged.

Stacked on top of #22 (feature/20-ux-cleanup). Retarget to `main` once #22 merges.

## What's in here

**New endpoint** `GET /api/repos/[id]/details` — read-only, no CSRF required. 400 on invalid id, 404 on missing repo. Uses `runGit` read-mode allowlist (`log`, `rev-list`, `symbolic-ref`, `rev-parse`).

**New UI**
- `components/RowDetail.tsx` — three-subsection expanded panel (commits, actions, metadata). Three columns on >=sm, stacked on mobile.
- `components/RepoCard.tsx` dual-renders: `hidden sm:grid` preserves the existing desktop row verbatim; `sm:hidden` stacks into a mobile card.
- Rotating chevron in the icon column; `ROW_GRID` last column widens 72px → 104px to fit it alongside refresh + external-link.
- `expandedRepoId` state lives in `Dashboard`, threaded down. Esc closes via `window.addEventListener`. Clicks on action button / icons / PR link stop propagation.

**Mobile details**
- Dashboard header title/body scale; search input becomes full-width 44px (≥Pixel WCAG tap target).
- Group header count scales 64px → 44px on mobile; padding tightens.
- Row cards show name + branch, icons top-right, sync/local/PR chips wrapping inline, last commit line, primary action button as a 40px tap target.

## Test plan

- [ ] Desktop 1280px: row grid renders unchanged (same columns). Click any row → expanded panel slides in below with 3 columns. Click again → collapses. Open a second row → first closes.
- [ ] Desktop expanded panel: commits list shows sha (7-char mono) + subject + author + relative time. Each commit row links to GitHub if remote known. "No actions yet" placeholder displays for repos with zero history. Metadata shows absolute path (selectable), default branch, remote link, total commits.
- [ ] Pixel 7 (412×915): no horizontal scroll. Headline + body legible. Search input full-width. Each card shows repo name, branch, icons (refresh + external + chevron), sync chips, last commit, and Push/Pull/Merge button as tap target. Expanded panel stacks three subsections vertically.
- [ ] 360×780 (smallest Android in common use): no horizontal scroll. All tap targets reach ≥40px.
- [ ] Esc while a row is expanded → closes.
- [ ] `curl /api/repos/999999/details` → 404. `curl /api/repos/abc/details` → 400.

## Pass/fail criteria

Pass: every box above ticks on a live server (`./bin/gitdash start` or `npm run dev`). Fail: any horizontal scroll on Pixel, any keyboard trap, any desktop visual regression.

## Not in scope

- Schema changes (no migrations system; details are computed on read).
- Diff stats per commit (deferred per #8 notes).
- Landscape-specific mobile tweaks.