### PR TITLE
Wire open_pr_count in remote tick

### DIFF
--- a/lib/db/repos.ts
+++ b/lib/db/repos.ts
@@ -121,6 +121,7 @@ export function upsertSnapshot(
   remote: RemoteComparison | null,
   weirdFlags: string[],
   now: number,
+  openPrCount: number | null = null,
 ): void {
   getDb().prepare(
     `INSERT INTO snapshots (
@@ -157,7 +158,7 @@ export function upsertSnapshot(
       remote_behind = COALESCE(excluded.remote_behind, remote_behind),
       remote_state = COALESCE(excluded.remote_state, remote_state),
       remote_sha = COALESCE(excluded.remote_sha, remote_sha),
-      open_pr_count = excluded.open_pr_count,
+      open_pr_count = COALESCE(excluded.open_pr_count, open_pr_count),
       weird_flags = excluded.weird_flags,
       collected_at = excluded.collected_at,
       remote_checked_at = COALESCE(excluded.remote_checked_at, remote_checked_at)`,
@@ -183,7 +184,7 @@ export function upsertSnapshot(
     remote_behind: remote?.behind ?? null,
     remote_state: remote?.state ?? null,
     remote_sha: remote?.remoteSha ?? null,
-    open_pr_count: 0,
+    open_pr_count: openPrCount,
     weird_flags: JSON.stringify(weirdFlags),
     collected_at: now,
     remote_checked_at: remote ? now : null,

--- a/lib/gh/client.ts
+++ b/lib/gh/client.ts
@@ -196,7 +196,7 @@ function comparisonFromBody(
   return { state, ahead, behind, remoteSha, localSha, checkedAt: now };
 }
 
-export async function fetchOpenPrCount(slug: GitHubSlug): Promise<number> {
+export async function fetchOpenPrCount(slug: GitHubSlug): Promise<number | null> {
   try {
     const res = await runGh([
       "api",
@@ -207,6 +207,6 @@ export async function fetchOpenPrCount(slug: GitHubSlug): Promise<number> {
     const parsed = JSON.parse(res.stdout) as { total_count?: number };
     return parsed.total_count ?? 0;
   } catch {
-    return 0;
+    return null;
   }
 }

--- a/lib/scan/scheduler.ts
+++ b/lib/scan/scheduler.ts
@@ -1,7 +1,7 @@
 import pLimit from "p-limit";
 import { discoverRepos, detectWeirdFlags, type DiscoveryConfig, parseGithubSlug } from "./discover";
 import { collectSnapshot } from "@/lib/git/status";
-import { compareWithRemote } from "@/lib/gh/client";
+import { compareWithRemote, fetchOpenPrCount } from "@/lib/gh/client";
 import {
   upsertDiscoveredRepo,
   upsertSnapshot,
@@ -127,10 +127,14 @@ class Scheduler {
             const weirdFlags = await detectWeirdFlags(row.repoPath);
             const slug = parseGithubSlug(snap.remoteUrl);
             let comparison = null;
+            let prCount: number | null = null;
             if (slug && snap.status.headSha && snap.status.branch) {
-              comparison = await compareWithRemote(slug, snap.status.headSha, snap.status.branch);
+              [comparison, prCount] = await Promise.all([
+                compareWithRemote(slug, snap.status.headSha, snap.status.branch),
+                fetchOpenPrCount(slug),
+              ]);
             }
-            upsertSnapshot(row.id, snap, comparison, weirdFlags, Date.now());
+            upsertSnapshot(row.id, snap, comparison, weirdFlags, Date.now(), prCount);
             getStore().emitUpdate(row.id);
           } catch (err) {
             console.error(`[scheduler] remote tick failed for ${row.repoPath}`, err);


### PR DESCRIPTION
## Summary
- `fetchOpenPrCount` existed but was never called; `upsertSnapshot` hardcoded `open_pr_count: 0`, so the dashboard PR chip always read 0.
- `tickRemote` now fetches the PR count in parallel with `compareWithRemote`.
- `fetchOpenPrCount` returns `null` on error and the SQL uses `COALESCE(excluded.open_pr_count, open_pr_count)`, so transient API errors or local-only snapshots don't clobber the last known count.

Closes #27

## Test plan
- [ ] `npm run typecheck` passes
- [ ] Start gitdash against a repo with open PRs on GitHub
- [ ] Within one remote tick (~60s), dashboard row shows the correct PR count
- [ ] Local-only action (e.g., edit a file) does not reset the count back to 0