### PR TITLE
Graceful shutdown: stop scheduler/watcher, close DB on SIGTERM

### DIFF
--- a/lib/bootstrap.ts
+++ b/lib/bootstrap.ts
@@ -1,6 +1,7 @@
-import { ensureSchedulerStarted } from "@/lib/scan/scheduler";
-import { ensureWatcherStarted } from "@/lib/scan/watcher";
+import { ensureSchedulerStarted, getScheduler } from "@/lib/scan/scheduler";
+import { ensureWatcherStarted, getWatcher } from "@/lib/scan/watcher";
 import { DEFAULT_CONFIG, type DiscoveryConfig } from "@/lib/scan/discover";
+import { closeDb } from "@/lib/db/schema";
 import { readFile } from "node:fs/promises";
 import path from "node:path";
 
@@ -18,10 +19,52 @@ async function loadConfig(): Promise<DiscoveryConfig> {
   }
 }
 
+const shutdownKey = Symbol.for("gitdash.shutdown.registered");
+type GlobalWithShutdown = typeof globalThis & { [shutdownKey]?: boolean };
+
+function registerShutdownHandlers(): void {
+  const g = globalThis as GlobalWithShutdown;
+  if (g[shutdownKey]) return;
+  g[shutdownKey] = true;
+
+  let shuttingDown = false;
+  const shutdown = (signal: NodeJS.Signals) => {
+    if (shuttingDown) return;
+    shuttingDown = true;
+    console.log(`[gitdash] ${signal} received, shutting down`);
+    // Stop producers first so in-flight writes drain against a live DB.
+    try {
+      getScheduler()?.stop();
+    } catch (err) {
+      console.error("[gitdash] scheduler stop failed", err);
+    }
+    try {
+      getWatcher()?.stop();
+    } catch (err) {
+      console.error("[gitdash] watcher stop failed", err);
+    }
+    // Give chokidar a tick to release fd handles before closing the DB.
+    setTimeout(() => {
+      try {
+        closeDb();
+      } catch (err) {
+        console.error("[gitdash] db close failed", err);
+      }
+      process.exit(0);
+    }, 150);
+    // Hard safety net if something hangs.
+    setTimeout(() => process.exit(1), 5_000).unref();
+  };
+
+  process.once("SIGTERM", () => shutdown("SIGTERM"));
+  process.once("SIGINT", () => shutdown("SIGINT"));
+}
+
 export async function bootstrap(): Promise<void> {
   if (bootstrapped) return;
   bootstrapped = true;
   const config = await loadConfig();
   await ensureSchedulerStarted({ config });
   await ensureWatcherStarted();
+  registerShutdownHandlers();
 }

--- a/lib/scan/watcher.ts
+++ b/lib/scan/watcher.ts
@@ -80,3 +80,7 @@ export async function ensureWatcherStarted(): Promise<WatcherPool> {
   }
   return g[globalKey]!;
 }
+
+export function getWatcher(): WatcherPool | null {
+  return g[globalKey] ?? null;
+}


### PR DESCRIPTION
## Summary
- \`bootstrap()\` registers \`SIGTERM\`/\`SIGINT\` handlers once per process (HMR-safe via \`globalThis\` Symbol).
- Shutdown order: stop scheduler → stop watcher → 150ms grace for chokidar handles → \`closeDb()\` → \`process.exit(0)\`.
- 5s safety timeout (\`unref\`'d) forces exit if anything hangs.
- Adds \`getWatcher()\` so bootstrap reaches the singleton without re-instantiating.

Closes #31

## Test plan
- [ ] \`./bin/gitdash start\` → note PID
- [ ] \`kill -TERM <pid>\`: process exits within ~200ms
- [ ] \`pgrep -P <pid>\` → empty (no orphaned git/gh/chokidar children)
- [ ] \`systemctl restart gitdash\` → no zombie state; new instance starts clean
- [ ] \`npm run typecheck\` passes