### PR TITLE
macOS install (launchd) + Windows WSL docs

### DIFF
--- a/.github/workflows/install-smoke.yml
+++ b/.github/workflows/install-smoke.yml
@@ -1,0 +1,82 @@
+name: Install smoke test
+
+on:
+  pull_request:
+    paths:
+      - 'install.sh'
+      - 'uninstall.sh'
+      - 'scripts/**'
+      - 'bin/gitdash'
+      - 'package.json'
+      - 'package-lock.json'
+      - '.github/workflows/install-smoke.yml'
+  workflow_dispatch:
+
+jobs:
+  macos:
+    name: macOS (launchd)
+    runs-on: macos-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Run installer
+        run: ./install.sh
+
+      - name: Wait for dashboard to respond
+        id: wait
+        run: |
+          for i in $(seq 1 60); do
+            if curl -sf http://127.0.0.1:7420/ -o /dev/null; then
+              echo "Dashboard responded after ${i}s"
+              exit 0
+            fi
+            sleep 1
+          done
+          echo "::error::Dashboard did not respond on :7420 within 60s"
+          exit 1
+
+      - name: Assert launchd task is registered
+        run: |
+          launchctl list com.gitdash
+          test -f "$HOME/Library/LaunchAgents/com.gitdash.plist"
+
+      - name: Dashboard returns HTML (smoke)
+        run: |
+          body=$(curl -sf http://127.0.0.1:7420/)
+          echo "$body" | grep -qi '<html' || {
+            echo "::error::Response on :7420 was not HTML"
+            echo "$body" | head -40
+            exit 1
+          }
+
+      - name: Uninstall
+        run: ./uninstall.sh --purge
+
+      - name: Assert clean removal
+        run: |
+          if launchctl list com.gitdash >/dev/null 2>&1; then
+            echo "::error::com.gitdash still registered after uninstall"
+            exit 1
+          fi
+          if [ -f "$HOME/Library/LaunchAgents/com.gitdash.plist" ]; then
+            echo "::error::plist not removed"
+            exit 1
+          fi
+
+      - name: Collect logs on failure
+        if: failure()
+        run: |
+          echo "--- launchctl list (com.gitdash) ---"
+          launchctl list com.gitdash 2>&1 || true
+          echo "--- plist ---"
+          cat "$HOME/Library/LaunchAgents/com.gitdash.plist" 2>&1 || true
+          echo "--- gitdash.log ---"
+          tail -300 "$HOME/Library/Logs/gitdash.log" 2>&1 || true
+          echo "--- port listeners ---"
+          lsof -i :7420 2>&1 || true

--- a/.github/workflows/install-smoke.yml
+++ b/.github/workflows/install-smoke.yml
@@ -1,6 +1,19 @@
 name: Install smoke test
 
 on:
+  push:
+    branches:
+      - main
+      - 'feature/**'
+      - 'fix/**'
+    paths:
+      - 'install.sh'
+      - 'uninstall.sh'
+      - 'scripts/**'
+      - 'bin/gitdash'
+      - 'package.json'
+      - 'package-lock.json'
+      - '.github/workflows/install-smoke.yml'
   pull_request:
     paths:
       - 'install.sh'

--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ If not installed:
 - **Ubuntu/Debian:** `sudo apt install git`
 - **Fedora/RHEL:** `sudo dnf install git`
 - **Arch:** `sudo pacman -S git`
+- **macOS:** `xcode-select --install` (or `brew install git`)
 
 ### 3. GitHub CLI (`gh`)
 
@@ -44,6 +45,7 @@ If not installed:
 - **Ubuntu/Debian:** [official install instructions](https://github.com/cli/cli/blob/trunk/docs/install_linux.md#debian-ubuntu-linux-raspberry-pi-os-apt)
 - **Fedora/RHEL:** `sudo dnf install gh`
 - **Arch:** `sudo pacman -S github-cli`
+- **macOS:** `brew install gh`
 
 ### 4. Sign `gh` in to your GitHub account
 
@@ -73,10 +75,18 @@ Should show `✓ Logged in to github.com account <your-username>`.
 
 ## Install gitdash
 
+### Linux / macOS
+
 ```bash
 git clone https://github.com/imwebdev/gitdash.git
 cd gitdash
 ./install.sh
+```
+
+…or paste the one-liner (same thing, without the clone step):
+
+```bash
+bash <(curl -fsSL https://raw.githubusercontent.com/imwebdev/gitdash/main/scripts/quick-install.sh)
 ```
 
 That's it. The installer will:
@@ -84,8 +94,17 @@ That's it. The installer will:
 1. Verify all the above prereqs
 2. Install node dependencies and build
 3. Generate a persistent CSRF token (so your browser doesn't get logged out on every restart)
-4. Install a systemd user service so gitdash auto-restarts on crash
-5. Optionally enable lingering (so it survives logout and reboot — asks for `sudo`)
+4. **Linux:** install a systemd user service so gitdash auto-restarts on crash; optionally enable lingering (so it survives logout and reboot — asks for `sudo`)
+5. **macOS:** install a LaunchAgent at `~/Library/LaunchAgents/com.gitdash.plist` so gitdash auto-starts at login and restarts on crash. Logs go to `~/Library/Logs/gitdash.log`.
+
+### Windows (WSL)
+
+Native Windows support isn't shipped yet. The supported path is:
+
+1. Install WSL2 + Ubuntu: `wsl --install` in an admin PowerShell, reboot, launch Ubuntu once to finish setup.
+2. Inside Ubuntu, follow the Linux install steps above. gitdash runs on `http://127.0.0.1:7420` from Windows Chrome/Edge too — WSL forwards loopback automatically.
+
+Native Windows (PowerShell installer + service) is tracked for a follow-up once the WSL path is stable for Windows users.
 
 When it finishes you'll see something like:
 

--- a/bin/gitdash
+++ b/bin/gitdash
@@ -9,8 +9,20 @@ set -euo pipefail
 DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$DIR"
 
+# Source the env file if present. systemd reads this via EnvironmentFile=;
+# launchd doesn't support env files, so we load it here so both paths work.
+ENV_FILE="${XDG_CONFIG_HOME:-$HOME/.config}/gitdash/env"
+if [[ -f "$ENV_FILE" ]]; then
+  set -a
+  # shellcheck disable=SC1090
+  source "$ENV_FILE"
+  set +a
+fi
+
 PORT="${GITDASH_PORT:-7420}"
 BIND="${GITDASH_BIND:-0.0.0.0}"
+
+UNAME="$(uname -s)"
 
 # Generate or reuse CSRF token
 if [[ -z "${GITDASH_CSRF_TOKEN:-}" ]]; then
@@ -26,16 +38,33 @@ if [[ ! -d "$DIR/.next" && "$MODE" == "start" ]]; then
   npm run build
 fi
 
-# Figure out LAN IP for convenience output
-LAN_IP="$(hostname -I 2>/dev/null | tr ' ' '\n' | grep -E '^(192\.168|10\.|172\.(1[6-9]|2[0-9]|3[01]))\.' | head -1 || true)"
+# Figure out LAN IP for convenience output (portable across Linux and macOS).
+LAN_IP=""
+if [[ "$UNAME" == "Darwin" ]]; then
+  for iface in en0 en1 en2 en3; do
+    LAN_IP="$(ipconfig getifaddr "$iface" 2>/dev/null || true)"
+    [[ -n "$LAN_IP" ]] && break
+  done
+else
+  LAN_IP="$(hostname -I 2>/dev/null | tr ' ' '\n' | grep -E '^(192\.168|10\.|172\.(1[6-9]|2[0-9]|3[01]))\.' | head -1 || true)"
+fi
 
 printf '\n  gitdash ready\n'
 printf '    local:   http://127.0.0.1:%s\n' "$PORT"
 [[ -n "$LAN_IP" ]] && printf '    network: http://%s:%s\n' "$LAN_IP" "$PORT"
 printf '    csrf:    %s\n\n' "$GITDASH_CSRF_TOKEN"
 
-# Open browser on the local machine (non-fatal if missing)
-(sleep 1 && xdg-open "http://127.0.0.1:$PORT" >/dev/null 2>&1) &
+# Open browser on the local machine (non-fatal if missing; platform-specific).
+# Skipped for background agents (no DISPLAY / no GUI session) — harmless no-op.
+open_browser() {
+  local url="$1"
+  if [[ "$UNAME" == "Darwin" ]] && command -v open >/dev/null 2>&1; then
+    open "$url" >/dev/null 2>&1 || true
+  elif command -v xdg-open >/dev/null 2>&1; then
+    xdg-open "$url" >/dev/null 2>&1 || true
+  fi
+}
+(sleep 1 && open_browser "http://127.0.0.1:$PORT") &
 
 case "$MODE" in
   start) exec npx next start -H "$BIND" -p "$PORT" ;;

--- a/install.sh
+++ b/install.sh
@@ -20,6 +20,18 @@ SERVICE_NAME="gitdash"
 SERVICE_FILE="$SYSTEMD_DIR/$SERVICE_NAME.service"
 TEMPLATE="$REPO_DIR/scripts/gitdash.service"
 
+# macOS launchd paths
+LAUNCHD_LABEL="com.gitdash"
+LAUNCHD_PLIST_DIR="$HOME/Library/LaunchAgents"
+LAUNCHD_PLIST="$LAUNCHD_PLIST_DIR/$LAUNCHD_LABEL.plist"
+LAUNCHD_TEMPLATE="$REPO_DIR/scripts/gitdash.plist"
+
+case "$(uname -s)" in
+  Linux)  PLATFORM="linux"  ;;
+  Darwin) PLATFORM="macos"  ;;
+  *)      PLATFORM="unknown" ;;
+esac
+
 WANT_LINGER=1
 WANT_START=1
 
@@ -42,14 +54,45 @@ dim()   { printf "\033[2m%s\033[0m\n" "$*"; }
 
 step() { echo; bold "▸ $*"; }
 
+if [[ "$PLATFORM" == "unknown" ]]; then
+  red "Unsupported OS: $(uname -s)"
+  echo "  Linux and macOS are supported. Windows users: run this under WSL2."
+  exit 1
+fi
+
+# Cross-platform helpers for start/stop of the existing service during upgrade.
+service_is_running() {
+  if [[ "$PLATFORM" == "linux" ]]; then
+    command -v systemctl >/dev/null 2>&1 && \
+      systemctl --user is-active "$SERVICE_NAME" >/dev/null 2>&1
+  else
+    launchctl list "$LAUNCHD_LABEL" >/dev/null 2>&1
+  fi
+}
+
+service_stop() {
+  if [[ "$PLATFORM" == "linux" ]]; then
+    systemctl --user stop "$SERVICE_NAME" >/dev/null 2>&1 || true
+  else
+    launchctl unload "$LAUNCHD_PLIST" >/dev/null 2>&1 || true
+  fi
+}
+
+service_start() {
+  if [[ "$PLATFORM" == "linux" ]]; then
+    systemctl --user start "$SERVICE_NAME" >/dev/null 2>&1 || true
+  else
+    launchctl load "$LAUNCHD_PLIST" >/dev/null 2>&1 || true
+  fi
+}
+
 # ─────────────────────────────────────────────────────────
-# If an existing systemd unit is running, stop it first so the port-7420
+# If an existing service is running, stop it first so the port-7420
 # preflight check passes during a re-run (update). We restart it at the end.
 EXISTING_SERVICE_RAN=0
-if command -v systemctl >/dev/null 2>&1 && \
-   systemctl --user is-active "$SERVICE_NAME" >/dev/null 2>&1; then
+if service_is_running; then
   dim "Existing gitdash service is running — stopping it for the duration of the install"
-  systemctl --user stop "$SERVICE_NAME" >/dev/null 2>&1 || true
+  service_stop
   EXISTING_SERVICE_RAN=1
 fi
 
@@ -58,7 +101,7 @@ step "1/6 Preflight checks"
   red "Preflight failed. See messages above. Aborting install."
   if [[ $EXISTING_SERVICE_RAN -eq 1 ]]; then
     dim "Restarting the previously-running service"
-    systemctl --user start "$SERVICE_NAME" >/dev/null 2>&1 || true
+    service_start
   fi
   exit 1
 }
@@ -83,16 +126,23 @@ if [[ -f "$ENV_FILE" ]]; then
   dim "  Config exists at $ENV_FILE — keeping existing CSRF token"
 else
   CSRF_TOKEN=$(node -e 'console.log(require("crypto").randomBytes(24).toString("base64url"))')
+  if [[ "$PLATFORM" == "macos" ]]; then
+    DEFAULT_TERMINAL="Terminal"
+    RESTART_HINT="launchctl unload $LAUNCHD_PLIST && launchctl load $LAUNCHD_PLIST"
+  else
+    DEFAULT_TERMINAL="x-terminal-emulator"
+    RESTART_HINT="systemctl --user restart gitdash"
+  fi
   cat > "$ENV_FILE" <<EOF
-# gitdash environment — sourced by the systemd service.
+# gitdash environment — sourced by bin/gitdash at launch.
 # Edit values below to override defaults. Restart the service after changes:
-#   systemctl --user restart gitdash
+#   $RESTART_HINT
 
 GITDASH_CSRF_TOKEN=$CSRF_TOKEN
 GITDASH_PORT=7420
 GITDASH_BIND=0.0.0.0
 # GITDASH_EDITOR=code
-# GITDASH_TERMINAL=x-terminal-emulator
+# GITDASH_TERMINAL=$DEFAULT_TERMINAL
 # GITDASH_DB=$HOME/.local/state/gitdash/gitdash.sqlite
 EOF
   chmod 600 "$ENV_FILE"
@@ -100,46 +150,79 @@ EOF
 fi
 
 # ─────────────────────────────────────────────────────────
-step "5/6 Installing systemd user service"
-if ! command -v systemctl >/dev/null 2>&1; then
-  red "  systemctl not available — skipping unit install."
-  red "  Run manually:  ./bin/gitdash start"
-  exit 0
-fi
+if [[ "$PLATFORM" == "linux" ]]; then
+  step "5/6 Installing systemd user service"
+  if ! command -v systemctl >/dev/null 2>&1; then
+    red "  systemctl not available — skipping unit install."
+    red "  Run manually:  ./bin/gitdash start"
+    exit 0
+  fi
 
-mkdir -p "$SYSTEMD_DIR"
-sed "s|{{REPO_DIR}}|$REPO_DIR|g" "$TEMPLATE" > "$SERVICE_FILE"
-green "  Wrote $SERVICE_FILE"
+  mkdir -p "$SYSTEMD_DIR"
+  sed "s|{{REPO_DIR}}|$REPO_DIR|g" "$TEMPLATE" > "$SERVICE_FILE"
+  green "  Wrote $SERVICE_FILE"
 
-systemctl --user daemon-reload
+  systemctl --user daemon-reload
 
-if [[ $WANT_START -eq 1 ]]; then
-  systemctl --user enable --now "$SERVICE_NAME"
-  green "  Enabled + started: systemctl --user status $SERVICE_NAME"
-else
-  systemctl --user enable "$SERVICE_NAME"
-  dim "  Enabled (not started). Start with: systemctl --user start $SERVICE_NAME"
-fi
-
-# ─────────────────────────────────────────────────────────
-step "6/6 Auto-start on boot (lingering)"
-if [[ $WANT_LINGER -eq 1 ]]; then
-  if loginctl show-user "$USER" 2>/dev/null | grep -q "Linger=yes"; then
-    dim "  Already enabled."
+  if [[ $WANT_START -eq 1 ]]; then
+    systemctl --user enable --now "$SERVICE_NAME"
+    green "  Enabled + started: systemctl --user status $SERVICE_NAME"
   else
-    echo "  This lets gitdash start at boot without an active login session."
-    echo "  Requires sudo:"
-    if sudo -n loginctl enable-linger "$USER" 2>/dev/null; then
-      green "  Enabled (no password prompt)."
+    systemctl --user enable "$SERVICE_NAME"
+    dim "  Enabled (not started). Start with: systemctl --user start $SERVICE_NAME"
+  fi
+
+  step "6/6 Auto-start on boot (lingering)"
+  if [[ $WANT_LINGER -eq 1 ]]; then
+    if loginctl show-user "$USER" 2>/dev/null | grep -q "Linger=yes"; then
+      dim "  Already enabled."
     else
-      echo
-      sudo loginctl enable-linger "$USER" || {
-        red "  Skipped — you can enable later with: sudo loginctl enable-linger $USER"
-      }
+      echo "  This lets gitdash start at boot without an active login session."
+      echo "  Requires sudo:"
+      if sudo -n loginctl enable-linger "$USER" 2>/dev/null; then
+        green "  Enabled (no password prompt)."
+      else
+        echo
+        sudo loginctl enable-linger "$USER" || {
+          red "  Skipped — you can enable later with: sudo loginctl enable-linger $USER"
+        }
+      fi
     fi
+  else
+    dim "  Skipped (--no-linger). gitdash will only run while you're logged in."
   fi
 else
-  dim "  Skipped (--no-linger). gitdash will only run while you're logged in."
+  # ─── macOS launchd path ────────────────────────────────
+  step "5/6 Installing macOS LaunchAgent"
+  if ! command -v launchctl >/dev/null 2>&1; then
+    red "  launchctl not available — skipping LaunchAgent install."
+    red "  Run manually:  ./bin/gitdash start"
+    exit 0
+  fi
+
+  mkdir -p "$LAUNCHD_PLIST_DIR"
+  # LaunchAgents don't inherit the user's interactive PATH — seed it explicitly
+  # so the wrapper can find node / npm / gh.
+  PLIST_PATH="${PATH}:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin"
+  sed \
+    -e "s|{{REPO_DIR}}|$REPO_DIR|g" \
+    -e "s|{{HOME}}|$HOME|g" \
+    -e "s|{{PATH}}|$PLIST_PATH|g" \
+    "$LAUNCHD_TEMPLATE" > "$LAUNCHD_PLIST"
+  green "  Wrote $LAUNCHD_PLIST"
+
+  # Reload: unload any previous version, then load.
+  launchctl unload "$LAUNCHD_PLIST" >/dev/null 2>&1 || true
+
+  if [[ $WANT_START -eq 1 ]]; then
+    launchctl load "$LAUNCHD_PLIST"
+    green "  Loaded + started: launchctl list $LAUNCHD_LABEL"
+  else
+    dim "  Not started (--no-start). Start with: launchctl load $LAUNCHD_PLIST"
+  fi
+
+  step "6/6 Boot persistence"
+  dim "  macOS LaunchAgents auto-load at login. No linger step needed."
 fi
 
 # ─────────────────────────────────────────────────────────
@@ -156,10 +239,18 @@ echo "    http://127.0.0.1:$PORT"
 [[ -n "$LAN_IP" ]] && echo "    http://$LAN_IP:$PORT  (other devices on your network)"
 echo
 echo "  Useful commands:"
-echo "    systemctl --user status gitdash       # is it running?"
-echo "    systemctl --user restart gitdash      # restart"
-echo "    systemctl --user stop gitdash         # stop"
-echo "    journalctl --user -u gitdash -f       # live logs"
+if [[ "$PLATFORM" == "linux" ]]; then
+  echo "    systemctl --user status gitdash       # is it running?"
+  echo "    systemctl --user restart gitdash      # restart"
+  echo "    systemctl --user stop gitdash         # stop"
+  echo "    journalctl --user -u gitdash -f       # live logs"
+else
+  echo "    launchctl list $LAUNCHD_LABEL         # is it running?"
+  echo "    launchctl unload $LAUNCHD_PLIST && \\"
+  echo "      launchctl load $LAUNCHD_PLIST       # restart"
+  echo "    launchctl unload $LAUNCHD_PLIST       # stop"
+  echo "    tail -f $HOME/Library/Logs/gitdash.log  # live logs"
+fi
 echo "    ./install.sh                          # update + restart (re-runnable)"
 echo "    ./uninstall.sh                        # remove cleanly"
 echo

--- a/lib/db/schema.ts
+++ b/lib/db/schema.ts
@@ -2,8 +2,22 @@ import Database from "better-sqlite3";
 import path from "node:path";
 import { mkdirSync } from "node:fs";
 
-const DEFAULT_DB_PATH = process.env.GITDASH_DB
-  ?? path.join(process.env.HOME ?? ".", ".local", "state", "gitdash", "gitdash.sqlite");
+// Platform-aware default DB path. Honor GITDASH_DB first, then XDG_STATE_HOME
+// (set by systemd user sessions and respected on Linux), then per-OS
+// convention. macOS uses ~/Library/Application Support/gitdash/ because that's
+// where GUI apps are expected to keep their data; Linux stays on XDG state.
+function defaultDbPath(): string {
+  if (process.env.GITDASH_DB) return process.env.GITDASH_DB;
+  const xdg = process.env.XDG_STATE_HOME;
+  if (xdg) return path.join(xdg, "gitdash", "gitdash.sqlite");
+  const home = process.env.HOME ?? ".";
+  if (process.platform === "darwin") {
+    return path.join(home, "Library", "Application Support", "gitdash", "gitdash.sqlite");
+  }
+  return path.join(home, ".local", "state", "gitdash", "gitdash.sqlite");
+}
+
+const DEFAULT_DB_PATH = defaultDbPath();
 
 let instance: Database.Database | null = null;
 

--- a/scripts/gitdash.plist
+++ b/scripts/gitdash.plist
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.gitdash</string>
+
+    <key>ProgramArguments</key>
+    <array>
+        <string>/bin/bash</string>
+        <string>{{REPO_DIR}}/bin/gitdash</string>
+        <string>start</string>
+    </array>
+
+    <key>WorkingDirectory</key>
+    <string>{{REPO_DIR}}</string>
+
+    <!-- Run on login. Survives logout (LaunchAgents are re-loaded on next
+         login). For macOS, this is the closest analogue to systemd's
+         Restart=on-failure + WantedBy=default.target. -->
+    <key>RunAtLoad</key>
+    <true/>
+
+    <!-- Restart automatically if gitdash exits abnormally. SuccessfulExit=false
+         means "keep alive unless it exits 0", matching Restart=on-failure. -->
+    <key>KeepAlive</key>
+    <dict>
+        <key>SuccessfulExit</key>
+        <false/>
+    </dict>
+
+    <!-- Throttle restart loops so a broken build doesn't spin the CPU. -->
+    <key>ThrottleInterval</key>
+    <integer>10</integer>
+
+    <!-- Logs. journalctl is the systemd equivalent; macOS uses flat files. -->
+    <key>StandardOutPath</key>
+    <string>{{HOME}}/Library/Logs/gitdash.log</string>
+    <key>StandardErrorPath</key>
+    <string>{{HOME}}/Library/Logs/gitdash.log</string>
+
+    <!-- GUI login sessions pick up the full user PATH; background agents do
+         not. We need node/npm/gh on PATH so the launcher can find them. -->
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>PATH</key>
+        <string>{{PATH}}</string>
+        <key>HOME</key>
+        <string>{{HOME}}</string>
+    </dict>
+</dict>
+</plist>

--- a/scripts/preflight.sh
+++ b/scripts/preflight.sh
@@ -65,14 +65,25 @@ check "gh authenticated" "gh auth status" "Run: gh auth login   (choose GitHub.c
 echo
 echo "System integration"
 echo "──────────────"
-check "systemctl available" "command -v systemctl" "systemd required for auto-start. Manual launch via ./bin/gitdash start still works."
-check "port 7420 free" "! ss -tln 2>/dev/null | grep -q ':7420 '" "Port 7420 is in use. Stop the other service or set GITDASH_PORT=<other> before running install."
+UNAME_S="$(uname -s)"
+if [[ "$UNAME_S" == "Darwin" ]]; then
+  check "launchctl available" "command -v launchctl" "launchd ships with macOS. This should never fail."
+  # ss doesn't exist on macOS; use lsof instead.
+  check "port 7420 free" "! lsof -nP -iTCP:7420 -sTCP:LISTEN >/dev/null 2>&1" "Port 7420 is in use. Stop the other service or set GITDASH_PORT=<other> before running install."
+else
+  check "systemctl available" "command -v systemctl" "systemd required for auto-start. Manual launch via ./bin/gitdash start still works."
+  check "port 7420 free" "! ss -tln 2>/dev/null | grep -q ':7420 '" "Port 7420 is in use. Stop the other service or set GITDASH_PORT=<other> before running install."
+fi
 
 echo
 echo "Optional"
 echo "──────────────"
 warn "VS Code (\`code\`) available" "command -v code" "Default editor is \`code\`. Override with GITDASH_EDITOR=<your-editor> if you use something else."
-warn "x-terminal-emulator available" "command -v x-terminal-emulator" "Used for the 'Open in terminal' button. Override with GITDASH_TERMINAL=<gnome-terminal|kitty|alacritty|...> if needed."
+if [[ "$UNAME_S" == "Darwin" ]]; then
+  warn "Terminal.app available" "[ -d /System/Applications/Utilities/Terminal.app ] || [ -d /Applications/Utilities/Terminal.app ]" "Override with GITDASH_TERMINAL=<iterm|wezterm|...> if you prefer a different terminal."
+else
+  warn "x-terminal-emulator available" "command -v x-terminal-emulator" "Used for the 'Open in terminal' button. Override with GITDASH_TERMINAL=<gnome-terminal|kitty|alacritty|...> if needed."
+fi
 
 echo
 if [[ $errors -gt 0 ]]; then

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -14,9 +14,24 @@ set -euo pipefail
 
 CONFIG_DIR="${XDG_CONFIG_HOME:-$HOME/.config}/gitdash"
 SYSTEMD_DIR="${XDG_CONFIG_HOME:-$HOME/.config}/systemd/user"
-STATE_DIR="${XDG_STATE_HOME:-$HOME/.local/state}/gitdash"
 SERVICE_NAME="gitdash"
 SERVICE_FILE="$SYSTEMD_DIR/$SERVICE_NAME.service"
+
+LAUNCHD_LABEL="com.gitdash"
+LAUNCHD_PLIST="$HOME/Library/LaunchAgents/$LAUNCHD_LABEL.plist"
+
+case "$(uname -s)" in
+  Linux)  PLATFORM="linux"  ;;
+  Darwin) PLATFORM="macos"  ;;
+  *)      PLATFORM="unknown" ;;
+esac
+
+# State dir is platform-aware, matching lib/db/schema.ts default.
+if [[ "$PLATFORM" == "macos" ]]; then
+  STATE_DIR="${XDG_STATE_HOME:-$HOME/Library/Application Support}/gitdash"
+else
+  STATE_DIR="${XDG_STATE_HOME:-$HOME/.local/state}/gitdash"
+fi
 
 PURGE=0
 DISABLE_LINGER=0
@@ -36,18 +51,31 @@ done
 green() { printf "\033[0;32m%s\033[0m\n" "$*"; }
 dim()   { printf "\033[2m%s\033[0m\n" "$*"; }
 
-if command -v systemctl >/dev/null 2>&1; then
-  if systemctl --user is-enabled "$SERVICE_NAME" >/dev/null 2>&1 || \
-     systemctl --user is-active "$SERVICE_NAME" >/dev/null 2>&1; then
-    systemctl --user disable --now "$SERVICE_NAME" 2>/dev/null || true
-    green "Stopped + disabled $SERVICE_NAME"
+if [[ "$PLATFORM" == "linux" ]]; then
+  if command -v systemctl >/dev/null 2>&1; then
+    if systemctl --user is-enabled "$SERVICE_NAME" >/dev/null 2>&1 || \
+       systemctl --user is-active "$SERVICE_NAME" >/dev/null 2>&1; then
+      systemctl --user disable --now "$SERVICE_NAME" 2>/dev/null || true
+      green "Stopped + disabled $SERVICE_NAME"
+    fi
   fi
-fi
 
-if [[ -f "$SERVICE_FILE" ]]; then
-  rm -f "$SERVICE_FILE"
-  command -v systemctl >/dev/null 2>&1 && systemctl --user daemon-reload || true
-  green "Removed $SERVICE_FILE"
+  if [[ -f "$SERVICE_FILE" ]]; then
+    rm -f "$SERVICE_FILE"
+    command -v systemctl >/dev/null 2>&1 && systemctl --user daemon-reload || true
+    green "Removed $SERVICE_FILE"
+  fi
+elif [[ "$PLATFORM" == "macos" ]]; then
+  if launchctl list "$LAUNCHD_LABEL" >/dev/null 2>&1; then
+    launchctl unload "$LAUNCHD_PLIST" >/dev/null 2>&1 || true
+    green "Unloaded LaunchAgent $LAUNCHD_LABEL"
+  fi
+  if [[ -f "$LAUNCHD_PLIST" ]]; then
+    rm -f "$LAUNCHD_PLIST"
+    green "Removed $LAUNCHD_PLIST"
+  fi
+else
+  dim "Unknown platform ($(uname -s)); skipping service teardown."
 fi
 
 if [[ $PURGE -eq 1 ]]; then
@@ -63,9 +91,11 @@ else
   dim "Kept $CONFIG_DIR and $STATE_DIR (use --purge to delete)"
 fi
 
-if [[ $DISABLE_LINGER -eq 1 ]]; then
+if [[ $DISABLE_LINGER -eq 1 && "$PLATFORM" == "linux" ]]; then
   sudo loginctl disable-linger "$USER" 2>/dev/null && green "Disabled user linger" || \
     dim "Could not disable linger (may require sudo or wasn't enabled)"
+elif [[ $DISABLE_LINGER -eq 1 ]]; then
+  dim "--no-linger has no effect on $PLATFORM (LaunchAgents don't use linger)."
 fi
 
 echo


### PR DESCRIPTION
## Summary
V1 of cross-platform install.

**macOS:** \`./install.sh\` on Darwin installs a LaunchAgent (\`~/Library/LaunchAgents/com.gitdash.plist\`) with RunAtLoad + KeepAlive-on-failure. Logs go to \`~/Library/Logs/gitdash.log\`. No linger step needed.

**Windows:** README points users at WSL2. Native Windows installer is out of scope for V1.

**Shared plumbing:**
- \`bin/gitdash\` sources the env file itself (launchd has no \`EnvironmentFile\` equivalent; this makes systemd + launchd use the same path).
- \`scripts/preflight.sh\` branches on \`uname -s\` (lsof on macOS, ss on Linux).
- \`lib/db/schema.ts\` defaults DB path per-platform (\`~/Library/Application Support/gitdash/\` on macOS, XDG state on Linux).

Closes #21

## Test plan
- [ ] Fresh macOS: \`./install.sh\` succeeds, \`launchctl list com.gitdash\` shows it, dashboard reachable at http://127.0.0.1:7420
- [ ] macOS logout/login: gitdash survives
- [ ] macOS \`./uninstall.sh\`: cleanly removes plist, dashboard gone
- [ ] Linux existing install: re-run \`./install.sh\` still works (no regressions)
- [ ] Linux \`./uninstall.sh\`: cleanly removes systemd unit
- [ ] \`./scripts/preflight.sh\` on macOS shows launchctl + lsof-based checks
- [ ] WSL (inside Ubuntu) install path works as plain Linux