### PR TITLE
CI: install smoke test workflow on macOS

### DIFF
--- a/.github/workflows/install-smoke.yml
+++ b/.github/workflows/install-smoke.yml
@@ -1,0 +1,95 @@
+name: Install smoke test
+
+on:
+  push:
+    branches:
+      - main
+      - 'feature/**'
+      - 'fix/**'
+    paths:
+      - 'install.sh'
+      - 'uninstall.sh'
+      - 'scripts/**'
+      - 'bin/gitdash'
+      - 'package.json'
+      - 'package-lock.json'
+      - '.github/workflows/install-smoke.yml'
+  pull_request:
+    paths:
+      - 'install.sh'
+      - 'uninstall.sh'
+      - 'scripts/**'
+      - 'bin/gitdash'
+      - 'package.json'
+      - 'package-lock.json'
+      - '.github/workflows/install-smoke.yml'
+  workflow_dispatch:
+
+jobs:
+  macos:
+    name: macOS (launchd)
+    runs-on: macos-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Run installer
+        run: ./install.sh
+
+      - name: Wait for dashboard to respond
+        id: wait
+        run: |
+          for i in $(seq 1 60); do
+            if curl -sf http://127.0.0.1:7420/ -o /dev/null; then
+              echo "Dashboard responded after ${i}s"
+              exit 0
+            fi
+            sleep 1
+          done
+          echo "::error::Dashboard did not respond on :7420 within 60s"
+          exit 1
+
+      - name: Assert launchd task is registered
+        run: |
+          launchctl list com.gitdash
+          test -f "$HOME/Library/LaunchAgents/com.gitdash.plist"
+
+      - name: Dashboard returns HTML (smoke)
+        run: |
+          body=$(curl -sf http://127.0.0.1:7420/)
+          echo "$body" | grep -qi '<html' || {
+            echo "::error::Response on :7420 was not HTML"
+            echo "$body" | head -40
+            exit 1
+          }
+
+      - name: Uninstall
+        run: ./uninstall.sh --purge
+
+      - name: Assert clean removal
+        run: |
+          if launchctl list com.gitdash >/dev/null 2>&1; then
+            echo "::error::com.gitdash still registered after uninstall"
+            exit 1
+          fi
+          if [ -f "$HOME/Library/LaunchAgents/com.gitdash.plist" ]; then
+            echo "::error::plist not removed"
+            exit 1
+          fi
+
+      - name: Collect logs on failure
+        if: failure()
+        run: |
+          echo "--- launchctl list (com.gitdash) ---"
+          launchctl list com.gitdash 2>&1 || true
+          echo "--- plist ---"
+          cat "$HOME/Library/LaunchAgents/com.gitdash.plist" 2>&1 || true
+          echo "--- gitdash.log ---"
+          tail -300 "$HOME/Library/Logs/gitdash.log" 2>&1 || true
+          echo "--- port listeners ---"
+          lsof -i :7420 2>&1 || true


### PR DESCRIPTION
## Summary

- New `.github/workflows/install-smoke.yml` that runs `./install.sh` on `macos-latest`, validates launchd registration + dashboard reachability, then cleanly uninstalls.
- Must land on `main` first — GitHub Actions only registers workflows from the default branch, which is why PR #44 couldn't trigger it from its own branch.

## Why now

PR #44 (macOS launchd install) and issue #21 are blocked on Mac verification. We don't own Apple hardware, so GHA `macos-latest` is the signal. This PR unblocks PR #44's gate.

Closes #46.

## Test plan

- [ ] Merge this PR to main
- [ ] Re-push feature/21-macos-install (trivial commit) to trigger the workflow
- [ ] Confirm the run passes (install → launchctl registered → :7420 returns HTML → uninstall → clean)
- [ ] Break install.sh intentionally in a scratch branch, confirm the failure path dumps `gitdash.log`, plist, and `lsof :7420`

## Scope notes

- macOS job only for now. Linux + Windows jobs land alongside #45 (native Windows + unified installer).
- No product code touched. This is infra-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)