### PR TITLE
feat(install): one-paste PowerShell installer for Windows + macOS path

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,54 +42,56 @@ The installer prints a URL when it's done — open it in your browser.
 
 ## 🪟 Windows — install
 
-**Windows is not natively supported yet.** `install.sh` is a bash script and uses `systemd`, which Windows does not have. Progress tracked in [#21](https://github.com/imwebdev/gitdash/issues/21).
+### One command. Paste into PowerShell.
 
-### ⚠️ Seeing `The token '&&' is not a valid statement separator` in PowerShell?
-
-That's **expected** — PowerShell doesn't understand bash syntax. Do **not** keep trying the Linux command in PowerShell, CMD, or plain Git Bash. You need WSL (below).
-
-### How to install today — use WSL 2 (~5 minutes)
-
-WSL (Windows Subsystem for Linux) gives you a real Ubuntu shell inside Windows.
-
-**Step 1** — Open **PowerShell as Administrator** (right-click the Start button → "Terminal (Admin)" or "Windows PowerShell (Admin)") and run:
+Open **PowerShell** (press `Win + R`, type `powershell`, press Enter) and paste this:
 
 ```powershell
-wsl --install
+iwr -useb https://raw.githubusercontent.com/imwebdev/gitdash/main/scripts/quick-install.ps1 | iex
 ```
 
-**Step 2** — Reboot Windows when it asks.
+That's it. The script handles everything:
 
-**Step 3** — After reboot, Ubuntu launches automatically and asks for a Linux username + password. Set them. (This is the user inside WSL, unrelated to your Windows login.)
+1. If WSL (the Linux layer Windows uses) isn't installed, it installs it for you — it will ask Windows for admin permission (click **Yes** on the UAC prompt), run `wsl --install`, and tell you to reboot.
+2. After you reboot and Ubuntu is set up (it asks for a Linux username + password the first time), **paste the same PowerShell command again**. It will detect WSL is ready and install gitdash.
+3. When it's done, open a new PowerShell window, type `wsl`, then type `gitdash start`, and open http://127.0.0.1:7420 in any Windows browser.
 
-**Step 4** — You're now in a Linux shell (prompt looks like `user@hostname:~$`). Paste this:
+### Common errors you can ignore now
 
-```bash
-bash <(curl -fsSL https://raw.githubusercontent.com/imwebdev/gitdash/main/scripts/quick-install.sh)
-```
+If you previously tried the Linux command in PowerShell and got `The token '&&' is not a valid statement separator` or `The '<' operator is reserved for future use` — that's PowerShell rejecting bash syntax. Use the PowerShell command above instead. It's native PowerShell and paste-safe.
 
-**Step 5** — When the installer finishes, it prints a URL like `http://127.0.0.1:7420`. Open that in any Windows browser (Edge, Chrome, Firefox) — WSL forwards the port automatically.
+### Why does Windows need WSL?
 
-To come back into WSL later: open a new PowerShell window and type `wsl`, or launch "Ubuntu" from the Start menu.
+gitdash uses Linux-only features (`systemd`, bash scripts). It can't run on Windows natively today. Native Windows support is tracked in [#21](https://github.com/imwebdev/gitdash/issues/21). WSL is Microsoft's official "run Linux inside Windows" feature — it's a one-time setup, then gitdash behaves identically to a real Linux install.
 
 ---
 
 ## 🍎 macOS — install
 
-**macOS is not natively supported yet.** Native launchd-based install is being tracked in [#21](https://github.com/imwebdev/gitdash/issues/21).
+Open **Terminal** (⌘+Space → type "Terminal" → Enter) and paste:
 
-### Workaround today — run gitdash on a Linux box, open it from your Mac
+```bash
+bash <(curl -fsSL https://raw.githubusercontent.com/imwebdev/gitdash/main/scripts/quick-install.sh)
+```
 
-gitdash runs as a web server, so it doesn't need to run on the same machine you view it from.
+The installer detects macOS, checks your prereqs (`git`, `node 20+`, `gh` — install with `brew install ...` if missing), walks through `gh auth login`, clones gitdash to `~/.local/share/gitdash`, builds it, and drops a `gitdash` launcher into `~/.local/bin`.
 
-1. On any Linux server you have SSH access to (cloud VM, home server, Raspberry Pi, etc.), run:
-   ```bash
-   bash <(curl -fsSL https://raw.githubusercontent.com/imwebdev/gitdash/main/scripts/quick-install.sh)
-   ```
-2. Note the LAN IP the installer prints (e.g. `http://192.168.1.50:7420`).
-3. On your Mac, open that URL in Safari / Chrome / etc.
+Start it with:
 
-The installer binds to `0.0.0.0` by default, so it's reachable from any device on the same network.
+```bash
+gitdash start
+```
+
+…then open http://127.0.0.1:7420 in Safari / Chrome / Arc / whatever.
+
+### macOS limitations today
+
+- **No auto-start on login** — native `launchd` integration is tracked in [#21](https://github.com/imwebdev/gitdash/issues/21). You run `gitdash start` manually each time.
+- **No `brew install gitdash` formula yet** — use the one-liner above.
+
+### Alternative: run gitdash on a remote Linux box, view from Mac
+
+If you already have a Linux server (cloud VM, home server, Raspberry Pi, etc.), install gitdash there instead — the installer binds `0.0.0.0` by default, so your Mac can open the LAN URL it prints.
 
 ---
 

--- a/scripts/quick-install.ps1
+++ b/scripts/quick-install.ps1
@@ -1,0 +1,164 @@
+# gitdash quick-install for Windows (PowerShell)
+#
+# Usage (paste into any normal PowerShell window):
+#   iwr -useb https://raw.githubusercontent.com/imwebdev/gitdash/main/scripts/quick-install.ps1 | iex
+#
+# What it does (idempotent):
+#   1. Checks whether WSL 2 is installed
+#   2. If not, installs WSL 2 (relaunches as admin if needed) and asks you to reboot
+#   3. If WSL 2 and a distro are ready, runs the Linux quick-install.sh inside WSL
+#   4. Leaves you with a `gitdash` command inside WSL
+
+$ErrorActionPreference = 'Stop'
+
+function Write-Step([string]$msg) { Write-Host "`n-> $msg" -ForegroundColor Cyan }
+function Write-Ok([string]$msg)   { Write-Host "   [ok] $msg" -ForegroundColor Green }
+function Write-Warn([string]$msg) { Write-Host "   [!] $msg" -ForegroundColor Yellow }
+function Write-Fail([string]$msg) { Write-Host "   [x] $msg" -ForegroundColor Red }
+function Die([string]$msg)        { Write-Fail $msg; exit 1 }
+
+function Test-IsAdmin {
+    $id = [Security.Principal.WindowsIdentity]::GetCurrent()
+    $p  = [Security.Principal.WindowsPrincipal]$id
+    return $p.IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)
+}
+
+Write-Host ""
+Write-Host "================================" -ForegroundColor Cyan
+Write-Host "  gitdash installer for Windows " -ForegroundColor Cyan
+Write-Host "================================" -ForegroundColor Cyan
+Write-Host ""
+Write-Host "gitdash runs inside WSL (Windows Subsystem for Linux)."
+Write-Host "This script will set everything up for you."
+
+# -----------------------------------------------------------------------------
+# Step 1: Is WSL even available?
+# -----------------------------------------------------------------------------
+Write-Step "Checking for WSL"
+
+$wslAvailable = $null -ne (Get-Command wsl -ErrorAction SilentlyContinue)
+
+if (-not $wslAvailable) {
+    Write-Warn "WSL is not installed"
+    Write-Host ""
+    Write-Host "I need to install WSL 2 now. This requires:"
+    Write-Host "  - Administrator privileges (I'll ask Windows to elevate)"
+    Write-Host "  - A reboot when it finishes"
+    Write-Host "  - About 3 minutes of your time"
+    Write-Host ""
+    $ans = Read-Host "Install WSL 2 now? [Y/n]"
+    if ($ans -and $ans.Trim().ToLower() -notin @('', 'y', 'yes')) {
+        Write-Host "Aborted. Run this command again whenever you are ready."
+        exit 0
+    }
+
+    if (Test-IsAdmin) {
+        Write-Step "Running: wsl --install"
+        wsl --install
+        Write-Host ""
+        Write-Ok "WSL install started."
+        Write-Host ""
+        Write-Host "IMPORTANT: Reboot Windows now." -ForegroundColor Yellow
+        Write-Host "After reboot, Ubuntu will launch automatically and ask for a Linux"
+        Write-Host "username + password. Set them. Then re-run this same command to finish"
+        Write-Host "installing gitdash."
+        exit 0
+    }
+
+    Write-Host ""
+    Write-Host "Opening a new admin PowerShell window to run 'wsl --install'..."
+    Write-Host "(Windows will show a UAC prompt - click Yes.)"
+    Write-Host ""
+
+    $adminCmd = @'
+Write-Host "Installing WSL 2..." -ForegroundColor Cyan
+wsl --install
+Write-Host ""
+Write-Host "WSL install finished. REBOOT Windows now, then re-run the gitdash" -ForegroundColor Yellow
+Write-Host "install command in your regular PowerShell window to finish." -ForegroundColor Yellow
+Write-Host ""
+Write-Host "Press any key to close this window..."
+[void][System.Console]::ReadKey($true)
+'@
+
+    try {
+        Start-Process -FilePath "powershell.exe" -Verb RunAs -ArgumentList @(
+            '-NoExit', '-NoProfile', '-ExecutionPolicy', 'Bypass',
+            '-Command', $adminCmd
+        ) | Out-Null
+    } catch {
+        Die "Could not launch admin PowerShell. Right-click the Start button, pick 'Terminal (Admin)' or 'Windows PowerShell (Admin)', then run:  wsl --install"
+    }
+
+    Write-Host ""
+    Write-Ok "Admin window opened. Follow its instructions (install + reboot)."
+    Write-Host "Once Windows has rebooted and Ubuntu is set up, run this gitdash"
+    Write-Host "install command again."
+    exit 0
+}
+
+Write-Ok "WSL command is available"
+
+# -----------------------------------------------------------------------------
+# Step 2: Is there a Linux distro installed inside WSL?
+# -----------------------------------------------------------------------------
+Write-Step "Checking for a WSL Linux distro"
+
+# `wsl --list --quiet` can emit UTF-16 output on some systems; decode safely.
+$prevEncoding = [Console]::OutputEncoding
+try {
+    [Console]::OutputEncoding = [System.Text.Encoding]::Unicode
+    $rawList = wsl --list --quiet 2>$null
+} finally {
+    [Console]::OutputEncoding = $prevEncoding
+}
+
+$distros = @()
+if ($rawList) {
+    $distros = $rawList |
+        ForEach-Object { ($_ -replace "`0", '').Trim() } |
+        Where-Object { $_ -ne '' }
+}
+
+if (-not $distros -or $distros.Count -eq 0) {
+    Write-Warn "WSL is installed but no Linux distro is set up yet"
+    Write-Host ""
+    Write-Host "Installing Ubuntu. When the Ubuntu window opens it will ask you for"
+    Write-Host "a Linux username + password - set them, wait for its prompt, close the"
+    Write-Host "Ubuntu window, then run this gitdash install command again."
+    Write-Host ""
+    wsl --install -d Ubuntu
+    exit 0
+}
+
+Write-Ok ("Found: {0}" -f ($distros -join ', '))
+
+# -----------------------------------------------------------------------------
+# Step 3: Run the bash installer inside WSL
+# -----------------------------------------------------------------------------
+Write-Step "Running the gitdash installer inside WSL"
+Write-Host "   (This takes a few minutes - installing Node deps and building.)"
+Write-Host ""
+
+$bashCmd = 'curl -fsSL https://raw.githubusercontent.com/imwebdev/gitdash/main/scripts/quick-install.sh | bash'
+wsl bash -c $bashCmd
+$exitCode = $LASTEXITCODE
+
+if ($exitCode -ne 0) {
+    Die "The Linux installer exited with code $exitCode. See the output above for what went wrong."
+}
+
+# -----------------------------------------------------------------------------
+# Done
+# -----------------------------------------------------------------------------
+Write-Host ""
+Write-Host "================================" -ForegroundColor Green
+Write-Host "  gitdash is installed in WSL   " -ForegroundColor Green
+Write-Host "================================" -ForegroundColor Green
+Write-Host ""
+Write-Host "To start gitdash:"
+Write-Host "  1. Open a new PowerShell window"
+Write-Host "  2. Type:  wsl"
+Write-Host "  3. Inside Linux, type:  gitdash start"
+Write-Host "  4. Open http://127.0.0.1:7420 in any Windows browser"
+Write-Host ""


### PR DESCRIPTION
## Summary

Non-technical Windows users can now paste **one PowerShell command** and get gitdash running — no bash, no cryptic `&&` errors, no "which terminal am I in" confusion.

**The Windows command is now:**
```powershell
iwr -useb https://raw.githubusercontent.com/imwebdev/gitdash/main/scripts/quick-install.ps1 | iex
```

That runs natively in PowerShell. The script handles WSL bootstrap itself: detects whether WSL is installed, auto-elevates to admin to run `wsl --install` if not, asks for a reboot, and on the second run drops you into the existing Linux installer inside WSL.

Also unblocks macOS: `scripts/quick-install.sh` already detects Darwin and supports brew-based prereq hints — the README just wasn't telling Mac users that. Now it does, with a note that launchd autostart is still pending (#21).

## Files

- `scripts/quick-install.ps1` — new. PowerShell bootstrapper. Idempotent.
- `README.md` — Windows section rewritten (one-liner replaces the old 5-step manual WSL walkthrough). macOS section now tells users to run the existing one-liner.

## Closes
Closes #52

## Test plan

### Windows (no WSL installed)
- [ ] Open regular (non-admin) PowerShell
- [ ] Paste the `iwr ... | iex` one-liner
- [ ] Confirm it prompts `[Y/n]` to install WSL
- [ ] Hit Y — confirm a UAC prompt appears and an admin PowerShell opens
- [ ] Admin window runs `wsl --install`, prints reboot instructions, waits for keypress
- [ ] Reboot Windows
- [ ] Re-run the same one-liner after Ubuntu first-boot is done
- [ ] Confirm it detects WSL, runs the Linux installer inside WSL
- [ ] Inside WSL: `gitdash start` works, http://127.0.0.1:7420 loads in Windows browser

### Windows (WSL already installed)
- [ ] Paste the one-liner in regular PowerShell
- [ ] Confirm it skips the WSL install and runs the bash installer directly inside WSL

### macOS
- [ ] On a fresh Mac (or at least one without gitdash), paste the `bash <(curl ...)` one-liner
- [ ] Confirm prereqs check works (git, node 20+, gh)
- [ ] Confirm `gitdash start` produces a working dashboard

### Linux (regression)
- [ ] Existing Linux flow unchanged — confirm `bash <(curl ...)` and `./install.sh` both still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)