### PR TITLE
docs: Linux section must say 'at a Linux prompt' (PuTTY users paste in PowerShell)

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,30 @@
 
 Works on Ubuntu, Debian, Fedora, Arch, and most other mainstream distros.
 
-Open a normal terminal (bash or zsh) and paste **one** of these:
+### 🛑 First — make sure you're actually at a Linux prompt
+
+The install command below only works when you are **inside a Linux shell**, not inside Windows PowerShell or CMD.
+
+Look at your prompt right now:
+
+| Your prompt looks like… | What it is | Paste the command here? |
+|---|---|---|
+| `chirag@ubuntu:~$` or `[root@server ~]#` | ✅ Linux shell | **Yes** |
+| `PS C:\Users\you>` | ❌ Windows PowerShell | **No** — see below |
+| `C:\Users\you>` | ❌ Windows CMD | **No** — see below |
+| `MINGW64 ~` or `MSYS …` | ❌ Git Bash for Windows | **No** — doesn't have `systemd` |
+
+**If you have a remote Linux box** (cloud VM, home server, etc.) and you SSH in from another machine:
+
+- **From Windows via PuTTY:** open PuTTY → enter host → click Open → **paste in the PuTTY window** (right-click pastes).
+- **From Windows via Terminal / PowerShell's built-in ssh:** run `ssh you@your-server-ip` first, confirm the prompt changes to `user@host:~$`, **then** paste.
+- **From macOS:** open Terminal → `ssh you@your-server-ip` → paste after the prompt changes.
+
+**If you don't have a Linux box** and just want to run gitdash on your own machine, go to the section for your OS:
+- Windows → [🪟 Windows — install](#-windows--install)
+- macOS → [🍎 macOS — install](#-macos--install)
+
+### Paste one of these at your Linux prompt
 
 **Quick install (recommended):**
 


### PR DESCRIPTION
## Summary
- Adds a prompt-comparison table at the top of the 🐧 Linux install section so PuTTY / SSH users don't paste bash into PowerShell
- Spells out: "open PuTTY, paste in the PuTTY window (right-click)"
- Links out to the Windows / macOS sections for users who don't have a Linux box

## Why
Real user just spent ~40 minutes fighting the install because they SSH into their Linux box via PuTTY from Windows, but their default terminal is PowerShell — they kept pasting the Linux `bash <(curl ...)` command into PowerShell and getting the exact `The '<' operator is reserved for future use` error we already have a fix for. The old README assumed the reader knew "bash or zsh" meant "not PowerShell." They didn't.

Closes #54

## Test plan
- [ ] Render README.md on GitHub — verify the table aligns correctly across widths
- [ ] Verify the example prompts (`PS C:\...`, `chirag@ubuntu:~$`) are unambiguous enough that a non-technical user can tell which one they're in
- [ ] PuTTY paste instruction (right-click) is correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)