### PR TITLE
fix(bin/gitdash): resolve launcher path before computing DIR (symlink bug)

### DIFF
--- a/bin/gitdash
+++ b/bin/gitdash
@@ -6,7 +6,32 @@ set -euo pipefail
 # Access is protected by Host header validation (RFC1918 + loopback) and
 # a CSRF token required on all mutating requests.
 
-DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+# Resolve the real path of this script so the launcher works when invoked
+# through a PATH symlink (quick-install.sh puts the symlink at ~/.local/bin).
+# Without this, running `gitdash` from PATH would resolve DIR to ~/.local
+# instead of ~/.local/share/gitdash, breaking the build+start paths.
+resolve_self() {
+  local src="${BASH_SOURCE[0]}"
+  if command -v readlink >/dev/null 2>&1 && readlink -f / >/dev/null 2>&1; then
+    readlink -f "$src"
+  elif command -v realpath >/dev/null 2>&1; then
+    realpath "$src"
+  else
+    # Manual symlink walk (macOS without coreutils, minimal BusyBox, etc.)
+    while [[ -L "$src" ]]; do
+      local target
+      target="$(readlink "$src")"
+      if [[ "$target" = /* ]]; then
+        src="$target"
+      else
+        src="$(cd "$(dirname "$src")" && pwd)/$target"
+      fi
+    done
+    cd "$(dirname "$src")" && echo "$(pwd)/$(basename "$src")"
+  fi
+}
+SELF="$(resolve_self)"
+DIR="$(cd "$(dirname "$SELF")/.." && pwd)"
 cd "$DIR"
 
 PORT="${GITDASH_PORT:-7420}"


### PR DESCRIPTION
## Summary
- Launcher now resolves its own symlink before computing the install directory, so `gitdash` works when invoked through the PATH symlink at `~/.local/bin/gitdash`
- Tries `readlink -f` (GNU coreutils), then `realpath`, then a manual symlink-walk fallback — covers every mainstream Linux + macOS configuration

## Why
Real-user failure mode: fresh quick-install completes, user runs `gitdash start`, gets:
```
[gitdash] no build found — running `npm run build` first
npm error Missing script: "build"
```
because `DIR` resolved to `~/.local` (parent of the symlink dir) instead of `~/.local/share/gitdash` (actual install).

Closes #58

## Test plan
Verified locally with a smoke test that creates a fake install + symlink + chained symlink and confirms all three resolve to the correct DIR. Left the rest of the launcher body untouched.

- [ ] On user's box: run `gitdash start` via PATH after pulling this fix — it should find `.next/`, skip the rebuild, bind 0.0.0.0:7420
- [ ] On a fresh box, full clean quick-install flow through to `gitdash start`

🤖 Generated with [Claude Code](https://claude.com/claude-code)