### PR TITLE
feat(quick-install): auto-start gitdash after successful install

### DIFF
--- a/scripts/quick-install.sh
+++ b/scripts/quick-install.sh
@@ -332,6 +332,24 @@ print_next_steps() {
   printf '  Re-install: re-run this command; it is idempotent.\n\n'
 }
 
+# Start gitdash in the foreground, replacing this shell with next-server so
+# the user sees the running server's output and URL directly. Ctrl-C stops it.
+# For always-on / systemd-managed installs, ./install.sh is still the path.
+start_gitdash() {
+  local launcher="$INSTALL_DIR/bin/gitdash"
+  if [ ! -x "$launcher" ]; then
+    warn "Launcher not found or not executable at $launcher — skipping auto-start"
+    return 0
+  fi
+
+  step "Starting gitdash"
+  printf '  %s(Ctrl-C to stop. For a persistent systemd install, use ./install.sh instead.)%s\n\n' \
+    "$C_DIM" "$C_RESET"
+
+  # Invoke the launcher at its real path to avoid any PATH / symlink ambiguity.
+  exec "$launcher" start
+}
+
 # ---- main ------------------------------------------------------------------
 main() {
   printf '%sgitdash quick-install%s\n' "$C_BOLD" "$C_RESET"
@@ -350,6 +368,15 @@ main() {
   build_gitdash
   install_launcher
   print_next_steps
+
+  # Auto-start unless explicitly opted out (CI, headless provisioning, etc.)
+  if [ "${GITDASH_NO_START:-0}" = "1" ]; then
+    printf '  %sGITDASH_NO_START=1 set — not auto-starting. Run %sgitdash start%s when ready.%s\n\n' \
+      "$C_DIM" "$C_BOLD" "$C_DIM" "$C_RESET"
+    return 0
+  fi
+
+  start_gitdash
 }
 
 main "$@"


### PR DESCRIPTION
## Summary
- `quick-install.sh` now execs the launcher at the end of `main()`, so paste-one-liner = running server. No more "OK now type one more command" after a long install.
- Opt-out: `GITDASH_NO_START=1 bash <(curl ...)` preserves the old print-and-exit behavior (for CI, headless provisioning).
- Calls the launcher at `$INSTALL_DIR/bin/gitdash` directly (not via PATH) so it works even when `~/.local/bin` isn't on PATH yet in this shell.

## Why
Real user feedback at the end of a 40-minute install odyssey: "cd ~/.local/share/gitdash && ./bin/gitdash start works but i need that run on install". They're right — the one-liner should leave you with a running app, not a to-do item.

## Scope
- Auto-start is foreground only (execs next-server in the same terminal). `install.sh` (systemd user service) remains the path for persistent / autostart-on-boot installs. quick-install.sh does not reach into systemd.

Closes #60

## Test plan
- [ ] Fresh install on Ubuntu: paste one-liner → see `gitdash ready` + URL → Ctrl-C stops cleanly
- [ ] Re-run with `GITDASH_NO_START=1`: install completes, prints next-steps, exits 0
- [ ] Close SSH session mid-run: server dies (expected; use install.sh for persistent)
- [ ] Launcher-not-executable edge case: warn + return 0 (don't hang install)

🤖 Generated with [Claude Code](https://claude.com/claude-code)