### PR TITLE
fix(systemd): pin PATH to install-time node (better-sqlite3 ABI mismatch) + StartLimit placement

### DIFF
--- a/scripts/gitdash.service
+++ b/scripts/gitdash.service
@@ -3,17 +3,19 @@ Description=gitdash — local git status dashboard
 Documentation=https://github.com/imwebdev/gitdash
 After=network.target
 
+# Rate-limit restart loops — these directives belong in [Unit], not [Service]
+StartLimitIntervalSec=60
+StartLimitBurst=3
+
 [Service]
 Type=simple
 WorkingDirectory={{REPO_DIR}}
 ExecStart=/bin/bash {{REPO_DIR}}/bin/gitdash start
 EnvironmentFile=%h/.config/gitdash/env
 
-# Restart on crash; throttle to avoid tight loops
+# Restart on crash with a short backoff
 Restart=on-failure
 RestartSec=5
-StartLimitIntervalSec=60
-StartLimitBurst=3
 
 # Logging via journald — view with: journalctl --user -u gitdash -f
 StandardOutput=journal

--- a/scripts/quick-install.sh
+++ b/scripts/quick-install.sh
@@ -367,24 +367,44 @@ setup_systemd_service() {
 
   mkdir -p "$config_dir" "$systemd_dir"
 
-  # Env file: keep existing (to preserve CSRF token) or create fresh
+  # Capture the node that built the native modules (e.g. better-sqlite3).
+  # systemd --user starts with a minimal PATH (/usr/bin:/bin) and would
+  # otherwise pick up an unrelated system node — mismatched NODE_MODULE_VERSION
+  # then breaks the native .node binaries at runtime (ERR_DLOPEN_FAILED).
+  local node_dir
+  node_dir="$(dirname "$(command -v node 2>/dev/null || echo /usr/bin/node)")"
+  local service_path="$node_dir:/usr/local/bin:/usr/bin:/bin"
+
+  # Env file: keep existing (to preserve CSRF token) but always refresh PATH
+  # because the user's node location may have changed since last install.
+  local csrf_line
   if [ -f "$env_file" ]; then
-    ok "existing env at $env_file — keeping"
+    ok "existing env at $env_file — keeping CSRF token, refreshing PATH"
+    # Extract the existing CSRF token so we can rewrite the file cleanly
+    csrf_line="$(grep -E '^GITDASH_CSRF_TOKEN=' "$env_file" || echo "")"
+    if [ -z "$csrf_line" ]; then
+      csrf_line="GITDASH_CSRF_TOKEN=$(node -e 'console.log(require("crypto").randomBytes(24).toString("base64url"))')"
+    fi
   else
-    local csrf_token
-    csrf_token="$(node -e 'console.log(require("crypto").randomBytes(24).toString("base64url"))')"
-    cat > "$env_file" <<EOF
+    csrf_line="GITDASH_CSRF_TOKEN=$(node -e 'console.log(require("crypto").randomBytes(24).toString("base64url"))')"
+  fi
+
+  cat > "$env_file" <<EOF
 # gitdash environment — sourced by the systemd service.
 # Edit values below to override defaults. Restart after changes:
 #   systemctl --user restart gitdash
 
-GITDASH_CSRF_TOKEN=$csrf_token
+$csrf_line
 GITDASH_PORT=${GITDASH_PORT:-7420}
 GITDASH_BIND=${GITDASH_BIND:-0.0.0.0}
+
+# Pin the node used at install time — prevents better-sqlite3 /
+# NODE_MODULE_VERSION mismatch when systemd's minimal PATH would
+# otherwise pick up an older apt-installed node.
+PATH=$service_path
 EOF
-    chmod 600 "$env_file"
-    ok "wrote $env_file (mode 600)"
-  fi
+  chmod 600 "$env_file"
+  ok "wrote $env_file (mode 600; PATH pinned to $node_dir)"
 
   # Render service file with absolute install path
   sed "s|{{REPO_DIR}}|$INSTALL_DIR|g" "$template" > "$service_file"


### PR DESCRIPTION
## Summary
- Detects \`dirname \$(command -v node)\` at install and writes it into the env file's PATH — systemd loads it, launcher uses the same node that built the \`.node\` binaries. Kills the \`NODE_MODULE_VERSION\` mismatch crash.
- Re-renders the env file on re-install (preserving CSRF token) so PATH gets refreshed if the user's node location changed.
- Moves \`StartLimitIntervalSec\` / \`StartLimitBurst\` to [Unit] where systemd expects them. Warning gone.

## Why
Real production failure, confirmed in user's journalctl:
\`\`\`
Error: The module '.../better-sqlite3/build/Release/better_sqlite3.node'
was compiled against a different Node.js version using NODE_MODULE_VERSION 137.
This version of Node.js requires NODE_MODULE_VERSION 127.
\`\`\`
User had nvm-installed Node 24 (NMV 137) in their shell PATH. quick-install.sh picked it up to build better-sqlite3. Then systemd started the service with its stripped PATH, found \`/usr/bin/node\` (apt's Node 22, NMV 127), crashed on every page render.

Closes #66

## Test plan
- [ ] Ubuntu with nvm Node 24 + apt Node 22: install → service starts → page renders
- [ ] Ubuntu with only apt Node 20/22: no change, still works
- [ ] Re-run installer: CSRF token preserved, PATH refreshed
- [ ] \`systemctl --user status gitdash\` no longer prints the \`Unknown key name 'StartLimitIntervalSec'\` warning

🤖 Generated with [Claude Code](https://claude.com/claude-code)