### PR TITLE
feat(github): list cloneable repos + one-click clone

### DIFF
--- a/app/api/github/clone/route.ts
+++ b/app/api/github/clone/route.ts
@@ -1,0 +1,89 @@
+import { NextResponse, type NextRequest } from "next/server";
+import { bootstrap } from "@/lib/bootstrap";
+import { validateCsrf } from "@/lib/security/csrf";
+import { cloneGithubRepo, CloneError, resolveCloneDir } from "@/lib/gh/clone";
+import { getScheduler } from "@/lib/scan/scheduler";
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+
+interface CloneRequestBody {
+  owner?: unknown;
+  name?: unknown;
+}
+
+interface CloneConfig {
+  cloneDir?: string;
+}
+
+async function readCloneConfig(): Promise<CloneConfig> {
+  const xdg =
+    process.env.XDG_CONFIG_HOME ??
+    path.join(process.env.HOME ?? ".", ".config");
+  const configPath = path.join(xdg, "gitdash", "config.json");
+  try {
+    const raw = await readFile(configPath, "utf8");
+    return JSON.parse(raw) as CloneConfig;
+  } catch {
+    return {};
+  }
+}
+
+export async function POST(req: NextRequest) {
+  if (!validateCsrf(req.headers.get("x-csrf-token"))) {
+    return NextResponse.json({ error: "invalid csrf" }, { status: 403 });
+  }
+
+  await bootstrap();
+
+  let body: CloneRequestBody;
+  try {
+    body = (await req.json()) as CloneRequestBody;
+  } catch {
+    return NextResponse.json({ error: "invalid JSON body" }, { status: 400 });
+  }
+
+  const owner = typeof body.owner === "string" ? body.owner : "";
+  const name = typeof body.name === "string" ? body.name : "";
+  if (!owner || !name) {
+    return NextResponse.json(
+      { error: "owner and name are required strings" },
+      { status: 400 },
+    );
+  }
+
+  const config = await readCloneConfig();
+  const cloneDir = resolveCloneDir(config.cloneDir);
+
+  try {
+    const result = await cloneGithubRepo({ owner, name, cloneDir });
+
+    // Ask the scheduler to discover the new repo + take a fresh snapshot.
+    // Best-effort — if the scheduler isn't ready yet, the next periodic
+    // discovery cycle will pick up the freshly-cloned repo on its own.
+    try {
+      const scheduler = getScheduler();
+      if (scheduler) {
+        await scheduler.runDiscovery();
+      }
+    } catch {
+      // ignore — scheduler nudge is non-critical
+    }
+
+    return NextResponse.json(result);
+  } catch (err) {
+    if (err instanceof CloneError) {
+      return NextResponse.json(
+        {
+          error: err.message,
+          destination: err.destination,
+          output: err.output,
+        },
+        { status: 500 },
+      );
+    }
+    return NextResponse.json(
+      { error: (err as Error).message ?? String(err) },
+      { status: 500 },
+    );
+  }
+}

--- a/app/api/github/repos/route.ts
+++ b/app/api/github/repos/route.ts
@@ -1,0 +1,67 @@
+import { NextResponse } from "next/server";
+import { bootstrap } from "@/lib/bootstrap";
+import {
+  fetchUserGithubRepos,
+  filterCloneable,
+  getKnownGithubSlugs,
+} from "@/lib/gh/list";
+import { resolveCloneDir } from "@/lib/gh/clone";
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+
+interface CloneConfig {
+  cloneDir?: string;
+}
+
+/**
+ * Read cloneDir override from ~/.config/gitdash/config.json. Same file
+ * DiscoveryConfig comes from. If missing or unparseable, return undefined
+ * and let resolveCloneDir fall back to its default.
+ */
+async function readCloneConfig(): Promise<CloneConfig> {
+  const xdg =
+    process.env.XDG_CONFIG_HOME ??
+    path.join(process.env.HOME ?? ".", ".config");
+  const configPath = path.join(xdg, "gitdash", "config.json");
+  try {
+    const raw = await readFile(configPath, "utf8");
+    return JSON.parse(raw) as CloneConfig;
+  } catch {
+    return {};
+  }
+}
+
+export async function GET() {
+  await bootstrap();
+
+  let remote;
+  try {
+    remote = await fetchUserGithubRepos();
+  } catch (err) {
+    const e = err as Error & { stderr?: string };
+    return NextResponse.json(
+      {
+        error: "gh repo list failed",
+        detail: (e.stderr ?? e.message ?? String(err)).slice(0, 1000),
+        hint: "Run `gh auth status` on the box. If unauthenticated, run `gh auth login`.",
+      },
+      { status: 502 },
+    );
+  }
+
+  const known = getKnownGithubSlugs();
+  const cloneable = filterCloneable(remote, known);
+
+  const config = await readCloneConfig();
+  const cloneDir = resolveCloneDir(config.cloneDir);
+
+  return NextResponse.json({
+    repos: cloneable,
+    cloneDir,
+    counts: {
+      total: remote.length,
+      cloneable: cloneable.length,
+      alreadyLocal: remote.length - cloneable.length,
+    },
+  });
+}

--- a/components/Dashboard.tsx
+++ b/components/Dashboard.tsx
@@ -5,6 +5,7 @@ import type { RepoView } from "@/lib/state/store";
 import { RepoGroup } from "./RepoGroup";
 import type { GroupKind } from "./RepoCard";
 import { ThemeToggle } from "./ThemeToggle";
+import { RemoteReposSection } from "./RemoteReposSection";
 
 interface Props {
   initialRepos: RepoView[];
@@ -229,6 +230,10 @@ export function Dashboard({ initialRepos, csrfToken }: Props) {
           <ThemeToggle />
         </div>
       </header>
+
+      <div className="mb-5">
+        <RemoteReposSection csrfToken={csrfToken} refreshKey={repos.length} />
+      </div>
 
       {groups.length === 0 ? (
         <EmptyState hasRepos={repos.length > 0} />

--- a/components/RemoteRepoCard.tsx
+++ b/components/RemoteRepoCard.tsx
@@ -1,0 +1,174 @@
+"use client";
+
+import { useState } from "react";
+import { Download, ExternalLink, Lock, GitFork, Archive } from "lucide-react";
+import { cn } from "@/lib/utils";
+
+export interface RemoteRepoView {
+  slug: string;
+  owner: string;
+  name: string;
+  description: string | null;
+  pushedAt: string | null;
+  isFork: boolean;
+  isArchived: boolean;
+  isPrivate: boolean;
+  url: string;
+}
+
+interface Props {
+  repo: RemoteRepoView;
+  cloneDir: string;
+  csrfToken: string;
+  onCloned?: (slug: string) => void;
+}
+
+function relativeTimeIso(iso: string | null): string {
+  if (!iso) return "—";
+  const ts = new Date(iso).getTime();
+  if (Number.isNaN(ts)) return "—";
+  const deltaSec = Math.floor((Date.now() - ts) / 1000);
+  if (deltaSec < 60) return "just now";
+  if (deltaSec < 3600) return `${Math.floor(deltaSec / 60)}m ago`;
+  if (deltaSec < 86400) return `${Math.floor(deltaSec / 3600)}h ago`;
+  if (deltaSec < 86400 * 30) return `${Math.floor(deltaSec / 86400)}d ago`;
+  if (deltaSec < 86400 * 365)
+    return `${Math.floor(deltaSec / (86400 * 30))}mo ago`;
+  return `${Math.floor(deltaSec / (86400 * 365))}y ago`;
+}
+
+export function RemoteRepoCard({
+  repo,
+  cloneDir,
+  csrfToken,
+  onCloned,
+}: Props) {
+  const [status, setStatus] = useState<
+    "idle" | "cloning" | "done" | "error"
+  >("idle");
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+
+  const onClone = async () => {
+    if (status === "cloning") return;
+    setStatus("cloning");
+    setErrorMessage(null);
+    try {
+      const res = await fetch("/api/github/clone", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "x-csrf-token": csrfToken,
+        },
+        body: JSON.stringify({ owner: repo.owner, name: repo.name }),
+      });
+      if (!res.ok) {
+        const payload = (await res.json().catch(() => ({}))) as {
+          error?: string;
+          output?: string;
+          hint?: string;
+        };
+        const msg =
+          payload.error ?? `clone failed (HTTP ${res.status})`;
+        const hint = payload.hint ? ` — ${payload.hint}` : "";
+        const tail = payload.output
+          ? `\n${payload.output.split("\n").slice(-4).join("\n")}`
+          : "";
+        setErrorMessage(`${msg}${hint}${tail}`);
+        setStatus("error");
+        return;
+      }
+      setStatus("done");
+      onCloned?.(repo.slug);
+    } catch (err) {
+      setErrorMessage((err as Error).message ?? String(err));
+      setStatus("error");
+    }
+  };
+
+  return (
+    <article className="flex flex-col gap-2 rounded-xl border border-border bg-bg-elevated/40 p-4 sm:flex-row sm:items-center sm:gap-4">
+      <div className="min-w-0 flex-1">
+        <div className="flex items-center gap-2">
+          <a
+            href={repo.url}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="truncate font-medium text-fg hover:underline"
+            title={repo.slug}
+          >
+            {repo.slug}
+          </a>
+          {repo.isPrivate && (
+            <Lock
+              className="h-3.5 w-3.5 text-fg-dim"
+              aria-label="private"
+            />
+          )}
+          {repo.isFork && (
+            <GitFork
+              className="h-3.5 w-3.5 text-fg-dim"
+              aria-label="fork"
+            />
+          )}
+          {repo.isArchived && (
+            <Archive
+              className="h-3.5 w-3.5 text-fg-dim"
+              aria-label="archived"
+            />
+          )}
+        </div>
+        {repo.description && (
+          <p className="mt-1 line-clamp-1 text-[13px] text-fg-muted">
+            {repo.description}
+          </p>
+        )}
+        <p className="mt-1 text-[11px] text-fg-dim">
+          last push {relativeTimeIso(repo.pushedAt)} · clones into{" "}
+          <span className="mono">
+            {cloneDir}/{repo.name}
+          </span>
+        </p>
+        {errorMessage && (
+          <pre className="mono mt-2 max-h-32 overflow-auto whitespace-pre-wrap rounded bg-bg-elevated/80 p-2 text-[11px] text-accent-attention">
+            {errorMessage}
+          </pre>
+        )}
+      </div>
+
+      <div className="flex shrink-0 items-center gap-2">
+        <a
+          href={repo.url}
+          target="_blank"
+          rel="noopener noreferrer"
+          aria-label="Open on GitHub"
+          className="rounded-full border border-border p-1.5 text-fg-muted transition-colors hover:text-fg"
+        >
+          <ExternalLink className="h-3.5 w-3.5" />
+        </a>
+        <button
+          type="button"
+          onClick={onClone}
+          disabled={status === "cloning" || status === "done"}
+          className={cn(
+            "shrink-0 whitespace-nowrap rounded-full border px-3.5 py-1 text-[12px] font-medium tracking-tight transition-all",
+            status === "done"
+              ? "border-accent-clean/40 bg-accent-clean/10 text-accent-clean"
+              : status === "error"
+                ? "border-accent-attention/40 bg-accent-attention/10 text-accent-attention hover:bg-accent-attention/20"
+                : "border-accent-pull/40 bg-accent-pull/10 text-accent-pull hover:bg-accent-pull/20 disabled:opacity-50",
+          )}
+        >
+          {status === "cloning" && "Cloning…"}
+          {status === "idle" && (
+            <span className="flex items-center gap-1.5">
+              <Download className="h-3.5 w-3.5" />
+              Clone here
+            </span>
+          )}
+          {status === "done" && "Cloned ✓"}
+          {status === "error" && "Retry"}
+        </button>
+      </div>
+    </article>
+  );
+}

--- a/components/RemoteReposSection.tsx
+++ b/components/RemoteReposSection.tsx
@@ -1,0 +1,143 @@
+"use client";
+
+import { useEffect, useState, useCallback } from "react";
+import { RemoteRepoCard, type RemoteRepoView } from "./RemoteRepoCard";
+import { ChevronDown } from "lucide-react";
+
+interface ApiPayload {
+  repos: RemoteRepoView[];
+  cloneDir: string;
+  counts: { total: number; cloneable: number; alreadyLocal: number };
+  error?: string;
+  detail?: string;
+  hint?: string;
+}
+
+interface Props {
+  csrfToken: string;
+  /**
+   * Bumped by the parent whenever local repos change (via SSE). Triggers a
+   * refresh of the remote-repos list so the card we just cloned disappears
+   * once the scheduler has discovered it locally.
+   */
+  refreshKey?: number;
+}
+
+export function RemoteReposSection({ csrfToken, refreshKey = 0 }: Props) {
+  const [repos, setRepos] = useState<RemoteRepoView[]>([]);
+  const [cloneDir, setCloneDir] = useState<string>("~/repos");
+  const [loadState, setLoadState] = useState<
+    "idle" | "loading" | "loaded" | "error"
+  >("idle");
+  const [errorBlock, setErrorBlock] = useState<string | null>(null);
+  const [collapsed, setCollapsed] = useState(false);
+
+  const load = useCallback(async () => {
+    setLoadState("loading");
+    setErrorBlock(null);
+    try {
+      const res = await fetch("/api/github/repos");
+      const payload = (await res.json()) as ApiPayload;
+      if (!res.ok) {
+        setErrorBlock(
+          [payload.error ?? "GitHub API failed", payload.hint, payload.detail]
+            .filter(Boolean)
+            .join("\n"),
+        );
+        setLoadState("error");
+        return;
+      }
+      setRepos(payload.repos ?? []);
+      setCloneDir(payload.cloneDir ?? "~/repos");
+      setLoadState("loaded");
+    } catch (err) {
+      setErrorBlock((err as Error).message ?? String(err));
+      setLoadState("error");
+    }
+  }, []);
+
+  useEffect(() => {
+    void load();
+  }, [load, refreshKey]);
+
+  const onCloned = (slug: string) => {
+    // Optimistic removal — gives instant feedback while the scheduler picks
+    // up the new repo locally.
+    setRepos((cur) => cur.filter((r) => r.slug !== slug));
+    // Background re-fetch so other clients / state stay consistent.
+    void load();
+  };
+
+  // Don't show anything if everything's already cloned and load succeeded.
+  // Beginners shouldn't see an empty section noisily for no reason.
+  if (loadState === "loaded" && repos.length === 0) return null;
+
+  return (
+    <section className="rounded-2xl border border-border bg-bg-elevated/30 p-5">
+      <header className="flex items-baseline justify-between gap-3">
+        <button
+          type="button"
+          onClick={() => setCollapsed((c) => !c)}
+          className="flex items-baseline gap-2 text-left"
+          aria-expanded={!collapsed}
+        >
+          <ChevronDown
+            className={`h-4 w-4 self-center text-fg-muted transition-transform ${collapsed ? "-rotate-90" : ""}`}
+          />
+          <h2 className="display text-[20px] tracking-display-tight text-fg">
+            on GitHub, not on this machine
+          </h2>
+          {loadState === "loaded" && (
+            <span className="text-[12px] text-fg-dim">{repos.length}</span>
+          )}
+        </button>
+        {loadState !== "idle" && (
+          <button
+            type="button"
+            onClick={load}
+            className="text-[11px] uppercase tracking-wider text-fg-dim hover:text-fg"
+          >
+            {loadState === "loading" ? "loading…" : "refresh"}
+          </button>
+        )}
+      </header>
+
+      {!collapsed && (
+        <>
+          {loadState === "loading" && repos.length === 0 && (
+            <p className="mt-3 text-[13px] text-fg-muted">
+              fetching your repos from GitHub…
+            </p>
+          )}
+
+          {loadState === "error" && (
+            <pre className="mono mt-3 whitespace-pre-wrap rounded bg-bg-elevated/80 p-3 text-[12px] text-accent-attention">
+              {errorBlock}
+            </pre>
+          )}
+
+          {loadState === "loaded" && repos.length > 0 && (
+            <p className="mt-2 text-[13px] text-fg-muted">
+              one click clones into{" "}
+              <span className="mono">{cloneDir}</span>. configure with{" "}
+              <span className="mono">cloneDir</span> in{" "}
+              <span className="mono">~/.config/gitdash/config.json</span>.
+            </p>
+          )}
+
+          <div className="mt-3 flex flex-col gap-2">
+            {repos.map((r) => (
+              <RemoteRepoCard
+                key={r.slug}
+                repo={r}
+                cloneDir={cloneDir}
+                csrfToken={csrfToken}
+                onCloned={onCloned}
+              />
+            ))}
+          </div>
+        </>
+      )}
+    </section>
+  );
+}

--- a/lib/gh/clone.ts
+++ b/lib/gh/clone.ts
@@ -1,0 +1,120 @@
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+import { mkdir, stat } from "node:fs/promises";
+import path from "node:path";
+import os from "node:os";
+
+const execFileAsync = promisify(execFile);
+
+/** Owner/name segments that aren't filesystem booby-traps. */
+const SAFE_SEGMENT_RE = /^[A-Za-z0-9][A-Za-z0-9._-]{0,99}$/;
+
+export interface CloneResult {
+  ok: boolean;
+  destination: string;
+  /** Truncated combined stdout/stderr — surfaced to the client on failure. */
+  output: string;
+}
+
+export class CloneError extends Error {
+  readonly destination: string;
+  readonly output: string;
+  constructor(message: string, destination: string, output: string) {
+    super(message);
+    this.name = "CloneError";
+    this.destination = destination;
+    this.output = output;
+  }
+}
+
+/**
+ * Resolve the directory new repos clone into. Order:
+ *   1. explicit `cloneDir` argument (passed by caller after reading config)
+ *   2. $HOME/repos (sensible default for non-technical users — visible)
+ */
+export function resolveCloneDir(configValue: string | undefined): string {
+  if (configValue && configValue.trim().length > 0) {
+    // Resolve ~ if user wrote it as a literal in config.json
+    if (configValue.startsWith("~/")) {
+      return path.join(os.homedir(), configValue.slice(2));
+    }
+    return path.resolve(configValue);
+  }
+  return path.join(os.homedir(), "repos");
+}
+
+/**
+ * Clone owner/name into <cloneDir>/<name>. Synchronous-ish — awaits the gh
+ * subprocess to finish (5-min timeout). For monorepos > a few hundred MB the
+ * user is better off shelling out to `gh repo clone` themselves.
+ */
+export async function cloneGithubRepo(opts: {
+  owner: string;
+  name: string;
+  cloneDir: string;
+}): Promise<CloneResult> {
+  const { owner, name, cloneDir } = opts;
+
+  if (!SAFE_SEGMENT_RE.test(owner)) {
+    throw new CloneError(`invalid owner '${owner}'`, "", "");
+  }
+  if (!SAFE_SEGMENT_RE.test(name)) {
+    throw new CloneError(`invalid repo name '${name}'`, "", "");
+  }
+
+  // Refuse anything that resolves outside the user's home tree. Defence in
+  // depth in case config.json contains a hostile cloneDir.
+  const homeDir = os.homedir();
+  const targetDir = path.resolve(cloneDir);
+  if (!targetDir.startsWith(homeDir + path.sep) && targetDir !== homeDir) {
+    throw new CloneError(
+      `cloneDir must be inside your home directory; got ${targetDir}`,
+      targetDir,
+      "",
+    );
+  }
+
+  await mkdir(targetDir, { recursive: true });
+  const destination = path.join(targetDir, name);
+
+  // If something already exists at that path (.git or otherwise), bail —
+  // never overwrite. The user can move/delete and try again.
+  try {
+    await stat(destination);
+    throw new CloneError(
+      `${destination} already exists`,
+      destination,
+      "",
+    );
+  } catch (err) {
+    const e = err as NodeJS.ErrnoException;
+    if (e.code !== "ENOENT") {
+      // any error that isn't "not found" — including our CloneError above —
+      // propagates
+      throw err;
+    }
+  }
+
+  const slug = `${owner}/${name}`;
+  try {
+    const { stdout, stderr } = await execFileAsync(
+      "gh",
+      ["repo", "clone", slug, destination],
+      { timeout: 5 * 60_000, maxBuffer: 4 * 1024 * 1024 },
+    );
+    return {
+      ok: true,
+      destination,
+      output: ((stdout ?? "") + (stderr ?? "")).slice(0, 4000),
+    };
+  } catch (err) {
+    const e = err as { stdout?: string; stderr?: string; code?: number; message?: string };
+    const output = ((e.stdout ?? "") + (e.stderr ?? "") + (e.message ?? ""))
+      .slice(0, 4000);
+    throw new CloneError(
+      `gh repo clone ${slug} failed (exit ${e.code ?? "?"})`,
+      destination,
+      output,
+    );
+  }
+}

--- a/lib/gh/list.ts
+++ b/lib/gh/list.ts
@@ -1,0 +1,102 @@
+import { runGh } from "@/lib/git/exec";
+import { getDb } from "@/lib/db/schema";
+
+export interface RemoteRepoInfo {
+  /** owner/name slug — primary key for cross-referencing local clones */
+  slug: string;
+  owner: string;
+  name: string;
+  description: string | null;
+  /** ISO 8601 from GitHub, surfaced as-is so the client can format. */
+  pushedAt: string | null;
+  /** True if this is a fork. Surfaced so UI can dim or label them. */
+  isFork: boolean;
+  /** True if archived. Same. */
+  isArchived: boolean;
+  /** True if private — only relevant for badges in the UI. */
+  isPrivate: boolean;
+  /** GitHub web URL — for "open on GitHub" affordance later. */
+  url: string;
+}
+
+/**
+ * Shape of a single row from `gh repo list --json ...`. Subset of GitHub's
+ * Repository object; only the fields we ask for via --json show up.
+ */
+interface GhRepoListRow {
+  name: string;
+  description: string | null;
+  pushedAt: string | null;
+  isFork: boolean;
+  isArchived: boolean;
+  isPrivate: boolean;
+  url: string;
+  owner: { login: string };
+}
+
+const GH_LIST_FIELDS = [
+  "name",
+  "description",
+  "pushedAt",
+  "isFork",
+  "isArchived",
+  "isPrivate",
+  "url",
+  "owner",
+].join(",");
+
+/**
+ * Fetch the authenticated user's repos. Limits at 200 — enough for >95% of
+ * users; if anyone has more they can paginate via `gh repo list` directly
+ * for now (a follow-up issue can add server-side pagination if needed).
+ */
+export async function fetchUserGithubRepos(): Promise<RemoteRepoInfo[]> {
+  const { stdout } = await runGh(
+    ["repo", "list", "--limit", "200", "--json", GH_LIST_FIELDS],
+    { timeoutMs: 20_000 },
+  );
+
+  const rows = JSON.parse(stdout) as GhRepoListRow[];
+  return rows.map((row) => ({
+    slug: `${row.owner.login}/${row.name}`,
+    owner: row.owner.login,
+    name: row.name,
+    description: row.description,
+    pushedAt: row.pushedAt,
+    isFork: row.isFork,
+    isArchived: row.isArchived,
+    isPrivate: row.isPrivate,
+    url: row.url,
+  }));
+}
+
+/**
+ * Slugs (owner/name lowercase) of repos we already know about locally.
+ * Used to filter `fetchUserGithubRepos` so we don't show "clone me" cards
+ * for repos already cloned on this machine.
+ */
+export function getKnownGithubSlugs(): Set<string> {
+  const rows = getDb()
+    .prepare<[], { owner: string | null; name: string | null }>(
+      `SELECT github_owner AS owner, github_name AS name
+         FROM repos
+        WHERE deleted_at IS NULL
+          AND github_owner IS NOT NULL
+          AND github_name IS NOT NULL`,
+    )
+    .all();
+  const out = new Set<string>();
+  for (const row of rows) {
+    if (!row.owner || !row.name) continue;
+    out.add(`${row.owner.toLowerCase()}/${row.name.toLowerCase()}`);
+  }
+  return out;
+}
+
+/** Filter remote repos to only those NOT already cloned locally. */
+export function filterCloneable(
+  remote: RemoteRepoInfo[],
+  knownSlugs: Set<string>,
+): RemoteRepoInfo[] {
+  return remote.filter((r) => !knownSlugs.has(r.slug.toLowerCase()));
+}


### PR DESCRIPTION
## Summary

Closes the product gap surfaced by real user feedback today: \"I need a list of repos on github that i could pull down to this server. you have not shown me that. i basically want to be able to go from computer to computer and install all the git repos i need.\"

New section in the dashboard, **\"on GitHub, not on this machine\"**, listing the user's repos via `gh repo list --json` minus anything already cloned. Each row has a \"Clone here\" button that runs `gh repo clone owner/name <cloneDir>/name`, then nudges the scheduler so the new repo moves into its proper local section within seconds.

## How

- `lib/gh/list.ts` — fetch + filter against the local DB
- `lib/gh/clone.ts` — sync clone with strict input validation, $HOME-confined destination, 5-min timeout
- `app/api/github/repos/route.ts` — GET, returns `{repos, cloneDir, counts}`
- `app/api/github/clone/route.ts` — POST `{owner, name}`, CSRF-required
- `components/RemoteRepoCard.tsx` + `components/RemoteReposSection.tsx` — UI
- `components/Dashboard.tsx` — renders the new section above existing groups

`cloneDir` is configurable in `~/.config/gitdash/config.json`. Default is `~/repos`.

## Verified locally
- [x] `npm run typecheck` clean
- [x] `npm run build` clean — both new routes registered

## Test plan (real box)
- [ ] On a Linux box with `gh auth login` done, dashboard renders the new section with repos that aren't local
- [ ] Click \"Clone here\" → button shows \"Cloning…\" → on success becomes \"Cloned ✓\" → card disappears within ~30s as scheduler discovers it locally
- [ ] Force a failure (e.g. delete `gh` auth) → error block appears with the gh stderr inline
- [ ] Set `\"cloneDir\": \"~/work\"` in config.json and re-load → button copy reflects new dir; clone lands at `~/work/<repo>`

Closes #70

🤖 Generated with [Claude Code](https://claude.com/claude-code)