### PR TITLE
fix(ui): collapse 'on GitHub, not on this machine' by default + move to bottom

### DIFF
--- a/components/Dashboard.tsx
+++ b/components/Dashboard.tsx
@@ -231,10 +231,6 @@ export function Dashboard({ initialRepos, csrfToken }: Props) {
         </div>
       </header>
 
-      <div className="mb-5">
-        <RemoteReposSection csrfToken={csrfToken} refreshKey={repos.length} />
-      </div>
-
       {groups.length === 0 ? (
         <EmptyState hasRepos={repos.length > 0} />
       ) : (
@@ -256,6 +252,10 @@ export function Dashboard({ initialRepos, csrfToken }: Props) {
           ))}
         </div>
       )}
+
+      <div className="mt-5">
+        <RemoteReposSection csrfToken={csrfToken} refreshKey={repos.length} />
+      </div>
 
       <footer className="mt-16 flex items-center justify-between border-t border-border-subtle pt-6 text-[12px] text-fg-dim">
         <span>{repos.length} tracked</span>

--- a/components/RemoteReposSection.tsx
+++ b/components/RemoteReposSection.tsx
@@ -30,7 +30,10 @@ export function RemoteReposSection({ csrfToken, refreshKey = 0 }: Props) {
     "idle" | "loading" | "loaded" | "error"
   >("idle");
   const [errorBlock, setErrorBlock] = useState<string | null>(null);
-  const [collapsed, setCollapsed] = useState(false);
+  // Collapsed by default — this is a secondary, exploratory section that
+  // sits below the actionable groups. Users who want to clone something
+  // will click in.
+  const [collapsed, setCollapsed] = useState(true);
 
   const load = useCallback(async () => {
     setLoadState("loading");


### PR DESCRIPTION
Per user feedback after #71 shipped. The remote-repos section was rendering open at the top, displacing the actionable push/pull/diverged groups. Now collapsed by default and below the local groups.

🤖 Generated with [Claude Code](https://claude.com/claude-code)