### PR TITLE
feat: read-only GitHub repos get their own dashboard bucket (closes #39)

### DIFF
--- a/components/Dashboard.tsx
+++ b/components/Dashboard.tsx
@@ -21,6 +21,10 @@ interface Group {
 
 function groupFor(repo: RepoView): GroupKind {
   const s = repo.derivedState;
+  // Read-only takes priority — these repos are real, but gitdash actions
+  // (push / merge / commit-push) won't work on them. They go to their own
+  // bucket so we don't tease the user with buttons that will fail.
+  if (s === "read-only") return "read-only";
   if (s === "weird") return "attention";
   if (s === "diverged") return "diverged";
   if (s === "ahead") return "push";
@@ -44,7 +48,7 @@ function buildGroups(repos: RepoView[]): { kind: GroupKind; headline: string; bo
     buckets.set(g, arr);
   }
 
-  const ordered: GroupKind[] = ["attention", "diverged", "push", "pull", "dirty", "clean"];
+  const ordered: GroupKind[] = ["attention", "diverged", "push", "pull", "dirty", "read-only", "clean"];
   // "clean" always renders (with an empty-state placeholder when count = 0)
   return ordered
     .filter((k) => k === "clean" || (buckets.get(k) ?? []).length > 0)
@@ -69,6 +73,7 @@ function headlineFor(kind: GroupKind, n: number): string {
     case "push": return `${plural === "repo" ? "wants" : "want"} to be pushed`;
     case "pull": return `${plural === "repo" ? "has" : "have"} incoming changes`;
     case "dirty": return `${plural === "repo" ? "has" : "have"} unsaved changes`;
+    case "read-only": return `read-only — you can't push here`;
     case "clean": return n === 0
       ? "no updates needed"
       : `${plural === "repo" ? "needs" : "need"} no updates`;
@@ -82,6 +87,7 @@ function bodyFor(kind: GroupKind, _n: number): string {
     case "push": return "You've committed work locally that GitHub doesn't have yet. Hit the button to send it up.";
     case "pull": return "Someone (possibly another machine of yours) pushed commits to GitHub. Download them to catch up.";
     case "dirty": return "Files you've edited but haven't committed. Click Open folder to see what changed and commit from your editor. Gitdash doesn't commit for you.";
+    case "read-only": return "Repos where your GitHub account doesn't have push access. They might have local edits — that's fine — but gitdash won't show push, merge, or commit-push buttons because they would just fail.";
     case "clean": return "These repos are in sync — nothing to push or pull. If a comparison is stale or you suspect the data is wrong, hit Fetch in the row's ⋯ menu to re-check.";
   }
 }

--- a/components/RepoCard.tsx
+++ b/components/RepoCard.tsx
@@ -14,7 +14,7 @@ import {
   RefreshCw,
 } from "lucide-react";
 
-export type GroupKind = "push" | "pull" | "diverged" | "attention" | "dirty" | "clean";
+export type GroupKind = "push" | "pull" | "diverged" | "attention" | "dirty" | "read-only" | "clean";
 
 export const ROW_GRID =
   "grid-cols-[minmax(180px,1.4fr)_120px_150px_minmax(200px,1.6fr)_80px_148px_104px]";
@@ -24,6 +24,8 @@ function primaryAction(
   hasRemote: boolean,
   hasConflicts: boolean,
 ): { label: string; action: string | null } {
+  // read-only repos never show an action button — gitdash can't push there.
+  if (kind === "read-only") return { label: "", action: null };
   if (kind === "push") return { label: "Push", action: "push" };
   if (kind === "pull") return { label: "Pull", action: "pull" };
   if (kind === "diverged") return { label: "Merge", action: "merge" };

--- a/components/RepoGroup.tsx
+++ b/components/RepoGroup.tsx
@@ -23,6 +23,7 @@ const TINT: Record<GroupKind, string> = {
   diverged: "tint-diverged",
   attention: "tint-attention",
   dirty: "tint-dirty",
+  "read-only": "tint-clean",
   clean: "tint-clean",
 };
 
@@ -32,6 +33,7 @@ const ACCENT: Record<GroupKind, string> = {
   diverged: "text-accent-diverged",
   attention: "text-accent-attention",
   dirty: "text-accent-dirty",
+  "read-only": "text-fg-muted",
   clean: "text-accent-clean",
 };
 

--- a/lib/db/repos.ts
+++ b/lib/db/repos.ts
@@ -54,6 +54,11 @@ export interface SnapshotRow {
   weirdFlags: string[];
   collectedAt: number;
   remoteCheckedAt: number | null;
+  /**
+   * GitHub permission on the remote: true = can push, false = read-only,
+   * null = unknown / non-GitHub remote / not yet checked.
+   */
+  canPush: boolean | null;
 }
 
 export function upsertDiscoveredRepo(discovered: DiscoveredRepo, now: number): RepoRow {
@@ -122,6 +127,7 @@ export function upsertSnapshot(
   weirdFlags: string[],
   now: number,
   openPrCount: number | null = null,
+  canPush: boolean | null = null,
 ): void {
   getDb().prepare(
     `INSERT INTO snapshots (
@@ -129,13 +135,15 @@ export function upsertSnapshot(
       ahead, behind, dirty_tracked, staged, staged_deletions,
       untracked, conflicted, detached, last_commit_sha, last_commit_ts,
       last_commit_subject, remote_url, remote_ahead, remote_behind,
-      remote_state, remote_sha, open_pr_count, weird_flags, collected_at, remote_checked_at
+      remote_state, remote_sha, open_pr_count, weird_flags, collected_at, remote_checked_at,
+      can_push
     ) VALUES (
       @repo_id, @branch, @upstream, @head_sha, @upstream_sha,
       @ahead, @behind, @dirty_tracked, @staged, @staged_deletions,
       @untracked, @conflicted, @detached, @last_commit_sha, @last_commit_ts,
       @last_commit_subject, @remote_url, @remote_ahead, @remote_behind,
-      @remote_state, @remote_sha, @open_pr_count, @weird_flags, @collected_at, @remote_checked_at
+      @remote_state, @remote_sha, @open_pr_count, @weird_flags, @collected_at, @remote_checked_at,
+      @can_push
     )
     ON CONFLICT(repo_id) DO UPDATE SET
       branch = excluded.branch,
@@ -161,7 +169,8 @@ export function upsertSnapshot(
       open_pr_count = COALESCE(excluded.open_pr_count, open_pr_count),
       weird_flags = excluded.weird_flags,
       collected_at = excluded.collected_at,
-      remote_checked_at = COALESCE(excluded.remote_checked_at, remote_checked_at)`,
+      remote_checked_at = COALESCE(excluded.remote_checked_at, remote_checked_at),
+      can_push = COALESCE(excluded.can_push, can_push)`,
   ).run({
     repo_id: repoId,
     branch: snap.status.branch,
@@ -188,6 +197,7 @@ export function upsertSnapshot(
     weird_flags: JSON.stringify(weirdFlags),
     collected_at: now,
     remote_checked_at: remote ? now : null,
+    can_push: canPush === null ? null : canPush ? 1 : 0,
   });
 }
 
@@ -217,6 +227,7 @@ interface SnapshotRaw {
   weird_flags: string;
   collected_at: number;
   remote_checked_at: number | null;
+  can_push: number | null;
 }
 
 export function getSnapshot(repoId: number): SnapshotRow | null {
@@ -307,5 +318,9 @@ function rawToSnapshot(r: SnapshotRaw): SnapshotRow {
     weirdFlags,
     collectedAt: r.collected_at,
     remoteCheckedAt: r.remote_checked_at,
+    canPush:
+      r.can_push === null || r.can_push === undefined
+        ? null
+        : r.can_push === 1,
   };
 }

--- a/lib/db/schema.ts
+++ b/lib/db/schema.ts
@@ -61,7 +61,8 @@ function migrate(db: Database.Database): void {
       open_pr_count      INTEGER NOT NULL DEFAULT 0,
       weird_flags        TEXT NOT NULL DEFAULT '[]',
       collected_at       INTEGER NOT NULL,
-      remote_checked_at  INTEGER
+      remote_checked_at  INTEGER,
+      can_push           INTEGER
     );
 
     CREATE TABLE IF NOT EXISTS gh_etag_cache (
@@ -82,6 +83,24 @@ function migrate(db: Database.Database): void {
     );
     CREATE INDEX IF NOT EXISTS idx_actions_repo ON actions_log(repo_id, started_at DESC);
   `);
+
+  // Idempotent column-add migrations. SQLite has no IF NOT EXISTS on ADD
+  // COLUMN, so we probe table_info first. New columns must be NULL-able
+  // (which is fine for our additive use cases — derivation handles nulls).
+  ensureColumn(db, "snapshots", "can_push", "INTEGER");
+}
+
+function ensureColumn(
+  db: Database.Database,
+  table: string,
+  column: string,
+  type: string,
+): void {
+  const cols = db
+    .prepare<[], { name: string }>(`PRAGMA table_info(${table})`)
+    .all();
+  if (cols.some((c) => c.name === column)) return;
+  db.exec(`ALTER TABLE ${table} ADD COLUMN ${column} ${type}`);
 }
 
 export function closeDb(): void {

--- a/lib/gh/client.ts
+++ b/lib/gh/client.ts
@@ -210,3 +210,33 @@ export async function fetchOpenPrCount(slug: GitHubSlug): Promise<number | null>
     return null;
   }
 }
+
+/**
+ * Fetch the user's push permission on a GitHub repo.
+ * Returns:
+ *   - `true` if the user can push
+ *   - `false` if read-only (collaborator without write access, fork upstream, etc.)
+ *   - `null` if the API call fails (auth issue, 404, network), so callers can
+ *     COALESCE with the previously-stored value rather than wiping it.
+ */
+export async function fetchCanPush(slug: GitHubSlug): Promise<boolean | null> {
+  try {
+    const res = await runGh([
+      "api",
+      "--method",
+      "GET",
+      `repos/${slug.owner}/${slug.name}`,
+    ]);
+    const parsed = JSON.parse(res.stdout) as {
+      permissions?: { push?: boolean };
+    };
+    if (typeof parsed.permissions?.push === "boolean") {
+      return parsed.permissions.push;
+    }
+    // Endpoint returned but didn't include `permissions` (e.g. unauthenticated
+    // public-repo response). Treat as unknown rather than guessing read-only.
+    return null;
+  } catch {
+    return null;
+  }
+}

--- a/lib/scan/scheduler.ts
+++ b/lib/scan/scheduler.ts
@@ -1,7 +1,7 @@
 import pLimit from "p-limit";
 import { discoverRepos, detectWeirdFlags, type DiscoveryConfig, parseGithubSlug } from "./discover";
 import { collectSnapshot } from "@/lib/git/status";
-import { compareWithRemote, fetchOpenPrCount } from "@/lib/gh/client";
+import { compareWithRemote, fetchOpenPrCount, fetchCanPush } from "@/lib/gh/client";
 import {
   upsertDiscoveredRepo,
   upsertSnapshot,
@@ -128,13 +128,15 @@ class Scheduler {
             const slug = parseGithubSlug(snap.remoteUrl);
             let comparison = null;
             let prCount: number | null = null;
+            let canPush: boolean | null = null;
             if (slug && snap.status.headSha && snap.status.branch) {
-              [comparison, prCount] = await Promise.all([
+              [comparison, prCount, canPush] = await Promise.all([
                 compareWithRemote(slug, snap.status.headSha, snap.status.branch),
                 fetchOpenPrCount(slug),
+                fetchCanPush(slug),
               ]);
             }
-            upsertSnapshot(row.id, snap, comparison, weirdFlags, Date.now(), prCount);
+            upsertSnapshot(row.id, snap, comparison, weirdFlags, Date.now(), prCount, canPush);
             getStore().emitUpdate(row.id);
           } catch (err) {
             console.error(`[scheduler] remote tick failed for ${row.repoPath}`, err);

--- a/lib/state/store.ts
+++ b/lib/state/store.ts
@@ -18,6 +18,7 @@ export type DerivedState =
   | "behind"
   | "diverged"
   | "dirty"
+  | "read-only"
   | "no-upstream"
   | "weird"
   | "unknown";
@@ -29,6 +30,11 @@ export function deriveState(row: RepoRow, snap: SnapshotRow | null): DerivedStat
   if (snap.stagedDeletions > 500) return "weird";
   const dirty = snap.dirtyTracked + snap.staged + snap.untracked + snap.conflicted;
   if (dirty > 1000) return "weird";
+  // Read-only takes precedence over actionable states (dirty / ahead / etc.)
+  // — gitdash actions can't push to these repos, so showing them in
+  // push/diverged/dirty would be a bait-and-switch. The row stays visible
+  // but gets routed to its own bucket where action buttons are hidden.
+  if (snap.canPush === false) return "read-only";
   if (dirty > 0) return "dirty";
   if (snap.remoteState === "diverged") return "diverged";
   if (snap.remoteState === "ahead" || snap.ahead > 0) return "ahead";


### PR DESCRIPTION
## Summary

Repos where you don't have GitHub push access (read-only collaborator, fork upstream, revoked token scope, org access changes) now show up in their own \"read-only — you can't push here\" group instead of being misclassified into push/dirty/diverged. Action buttons (Push, Pull, Merge, Commit & push) are hidden for those rows since they would fail.

## Why
Direct user feedback: \"one of the repos on that list is archon which I CANNOT push to. I told you if I can't push to it it should not be on the list\". Issue #39 had a design for this — it had been closed but never actually shipped. This re-implements per the original spec and reopens / closes #39 properly.

## Changes
- DB: \`can_push INTEGER\` column on \`snapshots\`, with idempotent \`ALTER TABLE\` for existing installs
- gh: \`fetchCanPush(slug)\` reads \`.permissions.push\` from \`gh api repos/:owner/:name\`
- Scheduler: parallel-fetches \`canPush\` alongside compare + PR count; upsert COALESCEs (transient API failures never silently flip a repo to read-only)
- State: \`canPush === false\` → derived state \`read-only\`, takes priority over dirty/ahead/behind
- UI: new group between dirty and clean; no action buttons render in those rows; row still shows real sync indicators

## Verified locally
- [x] \`npm run typecheck\` clean
- [x] \`npm run build\` clean

## Test plan (real box)
- [ ] On a box with a read-only collaborator repo locally, after one remote-tick cycle, the repo lands in the new section
- [ ] Push button is absent on those rows
- [ ] Repo's own state (ahead/behind/dirty) still visible
- [ ] An owned repo never lands here even if the API call temporarily fails (COALESCE preserves last-known true)

Closes #39

🤖 Generated with [Claude Code](https://claude.com/claude-code)