### PR TITLE
docs: drop /path/to placeholder in README update + uninstall blocks

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ Every repo on your machine, sorted by what it needs:
 ## 🔄 Update gitdash
 
 ```bash
-cd /path/to/gitdash && git pull && ./install.sh
+cd gitdash && git pull && ./install.sh
 ```
 
 Re-running the installer is safe — it stops, rebuilds, and restarts cleanly.
@@ -148,8 +148,8 @@ Re-running the installer is safe — it stops, rebuilds, and restarts cleanly.
 ## 🗑️ Remove gitdash
 
 ```bash
-cd /path/to/gitdash && ./uninstall.sh           # service only
-cd /path/to/gitdash && ./uninstall.sh --purge   # also wipe the database
+cd gitdash && ./uninstall.sh           # service only
+cd gitdash && ./uninstall.sh --purge   # also wipe the database
 ```
 
 The repo files stay where they are — delete them yourself if you want.


### PR DESCRIPTION
## Summary
- The install one-liner uses bare `cd gitdash` but the update and uninstall blocks use a `/path/to/gitdash` placeholder, which beginners trip on.
- Fix: match the install — bare `cd gitdash` everywhere.

Closes #74.

## Test plan
- [ ] Read the rendered README on the PR page
- [ ] Confirm the install, update, and remove blocks all use `cd gitdash` consistently

🤖 Generated with [Claude Code](https://claude.com/claude-code)