### PR TITLE
feat(notify): desktop alert on transition into behind/diverged

### DIFF
--- a/lib/notify/desktop.ts
+++ b/lib/notify/desktop.ts
@@ -1,0 +1,51 @@
+import { execFile } from "node:child_process";
+import { platform } from "node:os";
+
+const NOTIFY_TIMEOUT_MS = 3000;
+
+function notifyEnabled(): boolean {
+  const v = (process.env.GITDASH_NOTIFY ?? "").toLowerCase();
+  return v !== "off" && v !== "0" && v !== "false";
+}
+
+function send(cmd: string, args: string[]): void {
+  execFile(cmd, args, { timeout: NOTIFY_TIMEOUT_MS }, (err) => {
+    if (err) {
+      // notify-send / osascript missing or failed — log once at debug level, never throw
+      if (process.env.GITDASH_NOTIFY_DEBUG) {
+        console.error(`[notify] ${cmd} failed:`, err.message);
+      }
+    }
+  });
+}
+
+export function notifyTransition(opts: {
+  repoName: string;
+  branch: string | null;
+  upstream: string | null;
+  behind: number;
+  ahead: number;
+  state: "behind" | "diverged";
+}): void {
+  if (!notifyEnabled()) return;
+
+  const upstream = opts.upstream ?? "remote";
+  const branch = opts.branch ?? "?";
+  const title = "gitdash";
+  let body: string;
+  if (opts.state === "diverged") {
+    body = `${opts.repoName}: diverged from ${upstream} (${opts.ahead} ahead, ${opts.behind} behind)`;
+  } else {
+    body = `${opts.repoName}: ${opts.behind} behind ${upstream} on ${branch}`;
+  }
+
+  const plat = platform();
+  if (plat === "linux") {
+    send("notify-send", ["--app-name=gitdash", "--icon=git", title, body]);
+  } else if (plat === "darwin") {
+    const escaped = body.replace(/"/g, '\\"');
+    const escapedTitle = title.replace(/"/g, '\\"');
+    send("osascript", ["-e", `display notification "${escaped}" with title "${escapedTitle}"`]);
+  }
+  // Other platforms: silent no-op.
+}

--- a/lib/scan/scheduler.ts
+++ b/lib/scan/scheduler.ts
@@ -9,8 +9,10 @@ import {
   listActiveRepos,
   markRepoDeleted,
   getRepoById,
+  getSnapshot,
 } from "@/lib/db/repos";
-import { getStore } from "@/lib/state/store";
+import { deriveState, displayName, getStore } from "@/lib/state/store";
+import { notifyTransition } from "@/lib/notify/desktop";
 
 export interface SchedulerOptions {
   config: DiscoveryConfig;
@@ -123,6 +125,9 @@ class Scheduler {
       slice.map((row) =>
         this.remoteLimit(async () => {
           try {
+            const oldSnap = getSnapshot(row.id);
+            const oldState = deriveState(row, oldSnap);
+
             const snap = await collectSnapshot({ path: row.repoPath });
             const weirdFlags = await detectWeirdFlags(row.repoPath);
             const slug = parseGithubSlug(snap.remoteUrl);
@@ -137,6 +142,28 @@ class Scheduler {
               ]);
             }
             upsertSnapshot(row.id, snap, comparison, weirdFlags, Date.now(), prCount, canPush);
+
+            const newSnap = getSnapshot(row.id);
+            const newState = deriveState(row, newSnap);
+            const transitionedToBehind =
+              (newState === "behind" || newState === "diverged") &&
+              oldState !== "behind" &&
+              oldState !== "diverged";
+            if (transitionedToBehind && newSnap) {
+              try {
+                notifyTransition({
+                  repoName: displayName(row.repoPath),
+                  branch: newSnap.branch,
+                  upstream: newSnap.upstream,
+                  behind: newSnap.remoteBehind ?? newSnap.behind,
+                  ahead: newSnap.remoteAhead ?? newSnap.ahead,
+                  state: newState as "behind" | "diverged",
+                });
+              } catch (notifyErr) {
+                console.error(`[scheduler] notify failed for ${row.repoPath}`, notifyErr);
+              }
+            }
+
             getStore().emitUpdate(row.id);
           } catch (err) {
             console.error(`[scheduler] remote tick failed for ${row.repoPath}`, err);


### PR DESCRIPTION
## Summary

Closes #78.

- New `lib/notify/desktop.ts`: platform-detected `notify-send` (Linux) / `osascript` (macOS) wrapper; silent no-op on other platforms; failures never propagate
- Wired into `lib/scan/scheduler.ts::tickRemote`: derive state from old snapshot, write new snapshot, derive new state, fire only on transition into `behind` or `diverged`
- Off-switch: `GITDASH_NOTIFY=off` (default on). Debug missing-binary errors with `GITDASH_NOTIFY_DEBUG=1`

## Test plan

- [ ] Build: `npm run build` (verified locally — clean)
- [ ] Typecheck: `npm run typecheck` (verified locally — clean)
- [ ] Functional: clone same repo on two machines. Push from machine B. On machine A within ~one remote-tick, expect exactly one desktop notification: `"<repo>: 1 behind origin/main"`. Subsequent polls of the same repo should not re-notify.
- [ ] Headless: on a host without `notify-send`, scheduler should keep ticking with no errors (errors only surface with `GITDASH_NOTIFY_DEBUG=1`)
- [ ] Off-switch: `GITDASH_NOTIFY=off bin/gitdash start` → no notifications fire

🤖 Generated with [Claude Code](https://claude.com/claude-code)