### PR TITLE
fix(install): pin systemd PATH so gh and nvm node are reachable

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -79,8 +79,26 @@ npm run build
 # ─────────────────────────────────────────────────────────
 step "4/6 Configuration"
 mkdir -p "$CONFIG_DIR"
+
+# Pin a PATH for the systemd service so it (a) uses the same Node that just
+# compiled native modules via `npm ci` (better-sqlite3 binds to NODE_MODULE_VERSION)
+# and (b) can find user-installed CLIs like `gh` that live outside system bins.
+# Without this, systemd inherits a clean PATH and may pick up /usr/bin/node
+# (mismatch) or fail to find `gh` (clone feature returns 502). See #82, #66/#67.
+NODE_BIN_DIR="$(dirname "$(command -v node)")"
+SERVICE_PATH="$NODE_BIN_DIR:$HOME/.local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+
 if [[ -f "$ENV_FILE" ]]; then
   dim "  Config exists at $ENV_FILE — keeping existing CSRF token"
+  if ! grep -q '^PATH=' "$ENV_FILE"; then
+    cat >> "$ENV_FILE" <<EOF
+
+# Pinned for the systemd service: same Node native modules were built against,
+# plus ~/.local/bin so user-installed CLIs (gh, etc.) are reachable.
+PATH=$SERVICE_PATH
+EOF
+    green "  Appended PATH= to $ENV_FILE"
+  fi
 else
   CSRF_TOKEN=$(node -e 'console.log(require("crypto").randomBytes(24).toString("base64url"))')
   cat > "$ENV_FILE" <<EOF
@@ -94,6 +112,10 @@ GITDASH_BIND=0.0.0.0
 # GITDASH_EDITOR=code
 # GITDASH_TERMINAL=x-terminal-emulator
 # GITDASH_DB=$HOME/.local/state/gitdash/gitdash.sqlite
+
+# Pinned for the systemd service: same Node native modules were built against,
+# plus ~/.local/bin so user-installed CLIs (gh, etc.) are reachable.
+PATH=$SERVICE_PATH
 EOF
   chmod 600 "$ENV_FILE"
   green "  Wrote $ENV_FILE (mode 600)"


### PR DESCRIPTION
## Summary

- `install.sh` now writes a pinned `PATH=` into `~/.config/gitdash/env` so the systemd service can find both nvm-managed Node (matching the binary `npm ci` compiled native modules against) and user-installed CLIs in `~/.local/bin` (notably `gh`).
- Idempotent: on re-run, only appends `PATH=` if the env file doesn't already have one.

Closes #82.

## Background

This is the in-repo `./install.sh` counterpart to the fix that already shipped for `quick-install.sh` in PR #67 (#66). Two real failures on a box where Node is via nvm and `gh` lives in `~/.local/bin`:

1. systemd inherits a clean PATH → picks up `/usr/bin/node` v22 → `better-sqlite3` native binary `NODE_MODULE_VERSION` mismatch → 500s on every API route.
2. `~/.local/bin` not on PATH → `gh repo list` fails with `ENOENT` → `/api/github/repos` returns 502 → the clone-from-github section (shipped by PR #71) renders empty.

The fix in `install.sh` mirrors PR #67 plus adds `~/.local/bin` to cover (2).

## Test plan

- [x] **Re-run on existing env** (env file already has `PATH=`): no change, service stays up, `/api/github/repos` 200.
- [x] **Fresh install** (env file removed): new env written with correct `PATH=`, service starts, `/api/github/repos` returns 200 with 90 GH repos / 60 cloneable.
- [x] **Service log clean**: no `NODE_MODULE_VERSION` errors, no `spawn gh ENOENT`.
- [ ] CI install-smoke workflow passes (optional — workflow exists from PR #69 but only exercises `quick-install.sh`).

## Notes

- This does not touch `quick-install.sh` — that path was already fixed by PR #67.
- Issue #80 (`open_pr_count` NOT NULL constraint) is a separate, unrelated bug and is still open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)