### PR TITLE
fix(db): coerce openPrCount null→0 so snapshot upserts don't abort

### DIFF
--- a/lib/db/repos.ts
+++ b/lib/db/repos.ts
@@ -193,7 +193,7 @@ export function upsertSnapshot(
     remote_behind: remote?.behind ?? null,
     remote_state: remote?.state ?? null,
     remote_sha: remote?.remoteSha ?? null,
-    open_pr_count: openPrCount,
+    open_pr_count: openPrCount ?? 0,
     weird_flags: JSON.stringify(weirdFlags),
     collected_at: now,
     remote_checked_at: remote ? now : null,


### PR DESCRIPTION
## Summary

- One-line fix in `lib/db/repos.ts:196`: `open_pr_count: openPrCount ?? 0`.
- The schema column is `NOT NULL DEFAULT 0`, but the scheduler's local-only path passes no value, so `upsertSnapshot` was binding `null`, aborting the entire `INSERT…ON CONFLICT` statement.
- Result: any repo whose upsert hit this kept its old snapshot row indefinitely → dashboard showed stale data forever.

Closes #80.

## Why this matters

Not log noise. User-reported on this server:

- `artist-intelligence` was committed + pushed, working tree clean, in sync with origin.
- Dashboard kept showing "1 unsaved, 1 new" with the previous commit subject.
- Scheduler was hitting the constraint **134 times in 10 minutes**, blocking every snapshot refresh.

After fix → zero constraint errors, snapshot row updates within seconds to (clean, head = `Update from gitdash`).

## Test plan

- [x] `npm run build` succeeds.
- [x] After `systemctl --user restart gitdash`, `journalctl --user -u gitdash --since "30 sec ago" | grep -c "NOT NULL constraint"` = 0.
- [x] A clean repo's snapshot row updates: `dirty_tracked=0, staged=0, untracked=0, last_commit_subject` matches `git log -1`.
- [x] A repo with no GitHub remote (no slug) still upserts cleanly with `open_pr_count = 0`.

## Why coerce instead of changing the schema

- SQLite has no migration system in this repo (per CLAUDE.md), so dropping `NOT NULL` would silently fail on existing DBs.
- "Unknown PR count == 0" matches the schema's stated default and is what the column already meant before the regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)