### PR TITLE
feat(cli): gitdash status subcommand for Claude Code hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,6 +208,45 @@ For folder-scan rules and editor/terminal overrides see [`CLAUDE.md`](./CLAUDE.m
 
 ---
 
+## 🤖 Claude Code SessionStart hook
+
+`gitdash status` prints a one-line repo summary to stdout, making it useful as a Claude Code `SessionStart` hook. When Claude Code opens a project that gitdash tracks, you see the current sync state immediately in the session banner.
+
+Add this to `~/.claude/settings.json`:
+
+```json
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "matcher": "*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "gitdash status --cwd $CLAUDE_PROJECT_DIR"
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+Sample output lines:
+
+```
+✓ gitdash: in sync · main
+↑ gitdash: 3 ahead · main
+↓ gitdash: 2 behind · main
+⇅ gitdash: 3 ahead, 2 behind · main
+✗ gitdash: 4 uncommitted change(s) · feature/my-branch
+⚠ gitdash: no upstream · main
+```
+
+If gitdash hasn't scanned the directory yet, or the path isn't a git repo, the command prints nothing and exits 0 — it never pollutes your session with errors.
+
+---
+
 ## 📜 License
 
 MIT (see `LICENSE` if/when added).

--- a/bin/gitdash
+++ b/bin/gitdash
@@ -46,6 +46,17 @@ export GITDASH_PORT="$PORT"
 
 MODE="${1:-start}"
 
+# status subcommand: reads SQLite directly, no server/port/CSRF needed.
+if [[ "$MODE" == "status" ]]; then
+  shift
+  TSX="$DIR/node_modules/.bin/tsx"
+  if [[ ! -x "$TSX" ]]; then
+    echo "[gitdash] tsx not found — run \`npm install\` in $DIR" >&2
+    exit 1
+  fi
+  exec "$TSX" "$DIR/scripts/status.ts" "$@"
+fi
+
 if [[ ! -d "$DIR/.next" && "$MODE" == "start" ]]; then
   echo "[gitdash] no build found — running \`npm run build\` first"
   npm run build
@@ -75,5 +86,5 @@ fi
 case "$MODE" in
   start) exec "$NEXT" start -H "$BIND" -p "$PORT" ;;
   dev)   exec "$NEXT" dev   -H "$BIND" -p "$PORT" ;;
-  *)     echo "usage: gitdash [start|dev]" >&2; exit 1 ;;
+  *)     echo "usage: gitdash [start|dev|status [--cwd <path>]]" >&2; exit 1 ;;
 esac

--- a/scripts/status.ts
+++ b/scripts/status.ts
@@ -151,9 +151,9 @@ try {
     diverged:     `⇅ gitdash: ${ahead} ahead, ${behind} behind · ${branch}`,
     dirty:        `✗ gitdash: ${dirty} uncommitted change(s) · ${branch}`,
     "read-only":  `✓ gitdash: read-only · ${branch}`,
-    "no-upstream":`⚠ gitdash: no upstream · ${branch}`,
+    "no-upstream":`ⓘ gitdash: local-only · ${branch}`,
     weird:        `⚠ gitdash: needs attention · ${branch}`,
-    unknown:      `⚠ gitdash: needs attention · ${branch}`,
+    unknown:      `ⓘ gitdash: remote check pending · ${branch}`,
   };
 
   process.stdout.write(lines[state] + "\n");

--- a/scripts/status.ts
+++ b/scripts/status.ts
@@ -1,0 +1,165 @@
+/**
+ * scripts/status.ts
+ *
+ * Prints a one-line git status summary for the repo at --cwd (default $PWD).
+ * Reads SQLite directly — no server needed.
+ *
+ * Usage:  tsx scripts/status.ts [--cwd <path>]
+ * Called by:  bin/gitdash status [--cwd <path>]
+ *
+ * Exits 0 always. Prints nothing for untracked dirs or DB errors.
+ */
+
+import Database from "better-sqlite3";
+import { existsSync } from "node:fs";
+import path from "node:path";
+
+// ── CLI arg parsing ──────────────────────────────────────────────────────────
+
+const args = process.argv.slice(2);
+let inputDir = process.env.PWD ?? process.cwd();
+
+for (let i = 0; i < args.length; i++) {
+  if (args[i] === "--cwd" && args[i + 1]) {
+    inputDir = args[i + 1]!;
+    break;
+  }
+}
+
+// ── Resolve git root ─────────────────────────────────────────────────────────
+
+function findGitRoot(startDir: string): string | null {
+  let dir = path.resolve(startDir);
+  for (let i = 0; i < 50; i++) {
+    if (existsSync(path.join(dir, ".git"))) return dir;
+    const parent = path.dirname(dir);
+    if (parent === dir) return null; // filesystem root
+    dir = parent;
+  }
+  return null;
+}
+
+const gitRoot = findGitRoot(inputDir);
+if (!gitRoot) process.exit(0);
+
+// ── Open DB read-only ────────────────────────────────────────────────────────
+
+const DB_PATH =
+  process.env.GITDASH_DB ??
+  path.join(
+    process.env.HOME ?? ".",
+    ".local",
+    "state",
+    "gitdash",
+    "gitdash.sqlite",
+  );
+
+if (!existsSync(DB_PATH)) process.exit(0);
+
+try {
+  const db = new Database(DB_PATH, { readonly: true });
+
+  // ── Lookup repo ────────────────────────────────────────────────────────────
+
+  interface RepoRaw {
+    id: number;
+    is_system_repo: number;
+    github_owner: string | null;
+    github_name: string | null;
+  }
+  const repo = db
+    .prepare<[string], RepoRaw>(
+      "SELECT id, is_system_repo, github_owner, github_name FROM repos WHERE repo_path = ? AND deleted_at IS NULL",
+    )
+    .get(gitRoot);
+
+  if (!repo) process.exit(0);
+
+  // ── Load snapshot ──────────────────────────────────────────────────────────
+
+  interface SnapRaw {
+    branch: string | null;
+    upstream: string | null;
+    ahead: number;
+    behind: number;
+    dirty_tracked: number;
+    staged: number;
+    staged_deletions: number;
+    untracked: number;
+    conflicted: number;
+    detached: number;
+    remote_state: string | null;
+    remote_ahead: number | null;
+    remote_behind: number | null;
+    weird_flags: string;
+    can_push: number | null;
+  }
+  const snap = db
+    .prepare<[number], SnapRaw>(
+      `SELECT branch, upstream, ahead, behind, dirty_tracked, staged,
+              staged_deletions, untracked, conflicted, detached,
+              remote_state, remote_ahead, remote_behind,
+              weird_flags, can_push
+       FROM snapshots WHERE repo_id = ?`,
+    )
+    .get(repo.id);
+
+  if (!snap) process.exit(0);
+
+  // ── Derive state (mirrors lib/state/store.ts::deriveState) ────────────────
+
+  let weirdFlags: string[] = [];
+  try { weirdFlags = JSON.parse(snap.weird_flags); } catch { weirdFlags = []; }
+
+  const detached = snap.detached === 1;
+  const dirty = snap.dirty_tracked + snap.staged + snap.untracked + snap.conflicted;
+  const canPush = snap.can_push === null ? null : snap.can_push === 1;
+
+  type State = "clean" | "ahead" | "behind" | "diverged" | "dirty" | "read-only" | "no-upstream" | "weird" | "unknown";
+  let state: State;
+
+  if (weirdFlags.length > 0 || detached || snap.staged_deletions > 500 || dirty > 1000) {
+    state = "weird";
+  } else if (canPush === false) {
+    state = "read-only";
+  } else if (dirty > 0) {
+    state = "dirty";
+  } else if (snap.remote_state === "diverged") {
+    state = "diverged";
+  } else if (snap.remote_state === "ahead" || snap.ahead > 0) {
+    state = "ahead";
+  } else if (snap.remote_state === "behind" || snap.behind > 0) {
+    state = "behind";
+  } else if (!snap.upstream && !snap.remote_state) {
+    state = "no-upstream";
+  } else if (snap.remote_state === "unknown") {
+    state = "unknown";
+  } else {
+    state = "clean";
+  }
+
+  // ── Format output ──────────────────────────────────────────────────────────
+
+  const branch = snap.branch ?? "HEAD";
+  const ahead = snap.remote_ahead ?? snap.ahead;
+  const behind = snap.remote_behind ?? snap.behind;
+
+  const lines: Record<State, string> = {
+    clean:        `✓ gitdash: in sync · ${branch}`,
+    ahead:        `↑ gitdash: ${ahead} ahead · ${branch}`,
+    behind:       `↓ gitdash: ${behind} behind · ${branch}`,
+    diverged:     `⇅ gitdash: ${ahead} ahead, ${behind} behind · ${branch}`,
+    dirty:        `✗ gitdash: ${dirty} uncommitted change(s) · ${branch}`,
+    "read-only":  `✓ gitdash: read-only · ${branch}`,
+    "no-upstream":`⚠ gitdash: no upstream · ${branch}`,
+    weird:        `⚠ gitdash: needs attention · ${branch}`,
+    unknown:      `⚠ gitdash: needs attention · ${branch}`,
+  };
+
+  process.stdout.write(lines[state] + "\n");
+  db.close();
+} catch {
+  // DB locked, corrupt, or missing table — stay silent
+}
+
+process.exit(0);


### PR DESCRIPTION
## Summary

- Adds `gitdash status [--cwd <path>]` CLI subcommand that reads SQLite directly (no server needed)
- Walks up from `--cwd` (default `$PWD`) to find git root, looks up repo in DB, calls `deriveState` logic, prints one-line summary
- Exits 0 always; prints nothing for untracked dirs, missing DB, locked DB, or repos not yet scanned
- Documents Claude Code `SessionStart` hook usage in README with example `~/.claude/settings.json` snippet

Closes #85

## Test plan

- [ ] `./bin/gitdash status --cwd /home/cchhita/gitdash` — prints a status line (e.g. `↑ gitdash: N ahead · branch`)
- [ ] `./bin/gitdash status --cwd /tmp` — prints nothing, exits 0
- [ ] `./bin/gitdash status --cwd $(mktemp -d)` — prints nothing, exits 0 (no git root)
- [ ] `npm run build` passes
- [ ] `npm run typecheck` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)