### PR TITLE
fix(error-hints): translate 'Author identity unknown' commit failure

### DIFF
--- a/lib/git/error-hints.ts
+++ b/lib/git/error-hints.ts
@@ -93,6 +93,15 @@ const PATTERNS: readonly Pattern[] = [
       "Your branch and the remote have both moved.\n" +
       "Fix: pull with rebase to replay your commits on top  ( git pull --rebase ), then push.",
   },
+  {
+    test: /Author identity unknown|unable to auto-detect email address|Please tell me who you are/i,
+    hint:
+      "Git doesn't know who you are yet — first commit on this machine.\n" +
+      "Fix: open a terminal and run\n" +
+      '  git config --global user.email "you@example.com"\n' +
+      '  git config --global user.name "Your Name"\n' +
+      "then click Commit & push again.",
+  },
 ];
 
 export function translateGitError(lines: readonly string[]): ErrorHint | null {


### PR DESCRIPTION
## Summary
- Adds a pattern to ``lib/git/error-hints.ts`` for the \"Author identity unknown\" / \"unable to auto-detect email address\" failure that ``git commit`` produces on fresh machines without ``user.email`` / ``user.name`` configured.
- Maps the multi-line cryptic block to a one-line hint with the exact two commands to run.
- Follow-up to #76 (which built the translation framework but didn't include this pattern).

Closes #88

## Test plan
- [x] ``npm run build`` passes
- [x] ``npm run typecheck`` passes
- [x] Pattern unit-tested against the real cryptic output: matches the ``unable to auto-detect email`` line and prints the friendly hint
- [x] Regression check: existing patterns (e.g. no-upstream branch) still match correctly
- [ ] **Manual verification**: trigger Commit & push on a machine with unset git identity, confirm the friendly hint appears in the modal