### PR TITLE
fix(scheduler): mark repo deleted immediately when path goes missing

### DIFF
--- a/lib/scan/scheduler.ts
+++ b/lib/scan/scheduler.ts
@@ -1,3 +1,4 @@
+import { existsSync } from "node:fs";
 import pLimit from "p-limit";
 import { discoverRepos, detectWeirdFlags, type DiscoveryConfig, parseGithubSlug } from "./discover";
 import { collectSnapshot } from "@/lib/git/status";
@@ -94,6 +95,11 @@ class Scheduler {
       upsertSnapshot(row.id, snap, null, weirdFlags, now);
       getStore().emitUpdate(row.id);
     } catch (err) {
+      if (!existsSync(row.repoPath) || !existsSync(row.gitDirPath)) {
+        markRepoDeleted(row.id, now);
+        getStore().emitBulk();
+        return;
+      }
       console.error(`[scheduler] collect failed for ${row.repoPath}`, err);
     }
   }


### PR DESCRIPTION
## Summary
- ``collectOne`` previously caught snapshot errors with a bare ``console.error`` and bailed, leaving deleted repos visible in the UI until the 10-minute discovery sweep ran.
- Now the catch checks whether the repo path or ``.git`` path still exists; if either is gone, calls ``markRepoDeleted`` and emits so the UI drops the row immediately (within the existing 300ms watcher debounce).
- Transient errors (lock contention, NOT NULL DB constraints, network blips during remote checks) still fall through to ``console.error`` — only true filesystem absence triggers deletion.

Closes #90

## Test plan
- [x] ``npm run build`` passes
- [x] ``npm run typecheck`` passes
- [x] **End-to-end verified** with synthetic test:
  - Real git repo created in /tmp, registered, collected → ``deletedAt=null`` ✓
  - First collect with an unrelated DB error → still ``deletedAt=null`` (transient errors don't nuke repos) ✓
  - ``rm -rf`` the repo, collect again → ``deletedAt`` gets set ✓
- [ ] **Manual verification**: ``rm -rf`` a tracked repo with gitdash running, confirm it disappears from the dashboard within a second or two