### PR TITLE
feat(security): pre-push secret scan with override flow

### DIFF
--- a/app/api/repos/[id]/actions/[name]/route.ts
+++ b/app/api/repos/[id]/actions/[name]/route.ts
@@ -1,12 +1,44 @@
 import { NextResponse } from "next/server";
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+import path from "node:path";
 import { bootstrap } from "@/lib/bootstrap";
 import { validateCsrf } from "@/lib/security/csrf";
 import { getRepoById, getSnapshot } from "@/lib/db/repos";
 import { isValidAction, startAction } from "@/lib/git/actions";
 import { getScheduler } from "@/lib/scan/scheduler";
+import { scanFiles } from "@/lib/security/secrets";
 
 export const dynamic = "force-dynamic";
 export const runtime = "nodejs";
+
+const execFileAsync = promisify(execFile);
+
+/** Enumerate files that would be staged (modified, added, untracked). */
+async function getStagingCandidates(repoPath: string): Promise<string[]> {
+  let stdout = "";
+  try {
+    const result = await execFileAsync(
+      "git",
+      ["-C", repoPath, "status", "--porcelain=v1", "-z"],
+      { env: { ...process.env, GIT_TERMINAL_PROMPT: "0", GIT_ASKPASS: "/bin/echo" }, timeout: 15_000 },
+    );
+    stdout = result.stdout;
+  } catch {
+    return [];
+  }
+
+  const paths: string[] = [];
+  for (const chunk of stdout.split("\0")) {
+    if (chunk.length < 4) continue;
+    const xy = chunk.slice(0, 2);
+    const filePath = chunk.slice(3);
+    if (!filePath) continue;
+    if (xy === "D " || xy === " D" || xy === "DD") continue;
+    paths.push(filePath);
+  }
+  return paths;
+}
 
 export async function POST(
   req: Request,
@@ -34,14 +66,43 @@ export async function POST(
   }
 
   let commitMessage: string | undefined;
+  let securityOverride = false;
   if (name === "commit-push") {
     try {
-      const body = (await req.json()) as { commitMessage?: unknown };
+      const body = (await req.json()) as { commitMessage?: unknown; securityOverride?: unknown };
       if (typeof body.commitMessage === "string") {
         commitMessage = body.commitMessage;
       }
+      if (body.securityOverride === true) {
+        securityOverride = true;
+      }
     } catch {
       // empty body is fine; sanitizer will use default
+    }
+
+    // Run secret scan before starting the action so we can return a structured
+    // 422 response that the modal can render. This runs synchronously here so
+    // the route can block the action before any git commands run.
+    if (!securityOverride) {
+      try {
+        const candidates = await getStagingCandidates(repo.repoPath);
+        // Guard path traversal
+        const repoRoot = path.resolve(repo.repoPath);
+        const repoRootPrefix = repoRoot.endsWith(path.sep) ? repoRoot : repoRoot + path.sep;
+        const safeCandidates = candidates.filter((rel) => {
+          const abs = path.resolve(repoRoot, rel);
+          return abs === repoRoot || abs.startsWith(repoRootPrefix);
+        });
+        const findings = await scanFiles(repo.repoPath, safeCandidates);
+        if (findings.length > 0) {
+          return NextResponse.json(
+            { error: "secret-scan-blocked", findings },
+            { status: 422 },
+          );
+        }
+      } catch {
+        // If scan itself fails, allow the commit to proceed (fail-open)
+      }
     }
   }
 
@@ -54,6 +115,7 @@ export async function POST(
       action: name,
       branch: snap?.branch ?? null,
       commitMessage,
+      securityOverride,
     });
   } catch (err) {
     return NextResponse.json({ error: String(err) }, { status: 400 });

--- a/app/api/repos/[id]/changes/route.ts
+++ b/app/api/repos/[id]/changes/route.ts
@@ -4,6 +4,7 @@ import path from "node:path";
 import { bootstrap } from "@/lib/bootstrap";
 import { getRepoById } from "@/lib/db/repos";
 import { runGit } from "@/lib/git/exec";
+import { scanFiles, type SecretFinding } from "@/lib/security/secrets";
 
 export const dynamic = "force-dynamic";
 export const runtime = "nodejs";
@@ -101,10 +102,22 @@ export async function GET(
 
   const suspicious = entries.filter((e) => e.reason !== null);
 
+  // Run secret scan on the files that would be staged
+  let secretFindings: SecretFinding[] = [];
+  const relativePaths = entries
+    .filter((e) => e.status !== "D " && e.status !== " D" && e.status !== "DD")
+    .map((e) => e.path);
+  try {
+    secretFindings = await scanFiles(repo.repoPath, relativePaths);
+  } catch {
+    // best-effort — don't block the preview if scan errors
+  }
+
   return NextResponse.json({
     files: entries,
     total: chunks.length,
     suspicious,
     truncated,
+    secretFindings,
   });
 }

--- a/components/ActionModal.tsx
+++ b/components/ActionModal.tsx
@@ -3,7 +3,7 @@
 import { useEffect, useRef, useState } from "react";
 import { createPortal } from "react-dom";
 import type { RepoView } from "@/lib/state/store";
-import { AlertTriangle, X } from "lucide-react";
+import { AlertTriangle, ShieldAlert, X } from "lucide-react";
 import { cn } from "@/lib/utils";
 
 const FOCUSABLE_SELECTOR =
@@ -41,11 +41,20 @@ interface ChangeEntry {
   reason: "secret" | "large" | null;
 }
 
+interface SecretFinding {
+  filePath: string;
+  line: number;
+  ruleId: string;
+  ruleName: string;
+  snippet: string;
+}
+
 interface ChangesResponse {
   files: ChangeEntry[];
   total: number;
   suspicious: ChangeEntry[];
   truncated: boolean;
+  secretFindings: SecretFinding[];
 }
 
 export function ActionModal({ repo, action, csrfToken, onClose }: Props) {
@@ -63,6 +72,8 @@ export function ActionModal({ repo, action, csrfToken, onClose }: Props) {
   const [commitMessage, setCommitMessage] = useState<string>("");
   const [changes, setChanges] = useState<ChangesResponse | null>(null);
   const [changesLoading, setChangesLoading] = useState(isCommitPush);
+  const [overrideConfirm, setOverrideConfirm] = useState<string>("");
+  const [securityOverride, setSecurityOverride] = useState(false);
   const [mounted, setMounted] = useState(false);
   const logRef = useRef<HTMLPreElement | null>(null);
   const esRef = useRef<EventSource | null>(null);
@@ -172,13 +183,28 @@ export function ActionModal({ repo, action, csrfToken, onClose }: Props) {
 
     async function run() {
       try {
-        const body = isCommitPush ? { commitMessage: commitMessage.trim() } : {};
+        const body = isCommitPush
+          ? {
+              commitMessage: commitMessage.trim(),
+              ...(securityOverride ? { securityOverride: true } : {}),
+            }
+          : {};
         const res = await fetch(`/api/repos/${repo.id}/actions/${action}`, {
           method: "POST",
           headers: { "Content-Type": "application/json", "x-csrf-token": csrfToken },
           body: JSON.stringify(body),
         });
         if (!res.ok) {
+          if (res.status === 422) {
+            // Secret scan blocked the commit — should not normally reach here
+            // because the confirm screen gates on the override, but handle defensively.
+            const data = (await res.json()) as { error: string; findings?: unknown };
+            if (!cancelled) {
+              setLog((l) => [...l, `[secret-scan] blocked: ${data.error}`]);
+              setPhase("error");
+            }
+            return;
+          }
           const text = await res.text();
           if (!cancelled) {
             setLog((l) => [...l, `HTTP ${res.status}: ${text}`]);
@@ -217,7 +243,7 @@ export function ActionModal({ repo, action, csrfToken, onClose }: Props) {
       cancelled = true;
       esRef.current?.close();
     };
-  }, [phase, action, repo.id, csrfToken, isCommitPush, commitMessage]);
+  }, [phase, action, repo.id, csrfToken, isCommitPush, commitMessage, securityOverride]);
 
   useEffect(() => {
     if (logRef.current) logRef.current.scrollTop = logRef.current.scrollHeight;
@@ -265,8 +291,16 @@ export function ActionModal({ repo, action, csrfToken, onClose }: Props) {
             loading={changesLoading}
             commitMessage={commitMessage}
             onMessageChange={setCommitMessage}
+            overrideConfirm={overrideConfirm}
+            onOverrideConfirmChange={setOverrideConfirm}
             onCancel={onClose}
-            onConfirm={() => setPhase("running")}
+            onConfirm={() => {
+              const secretFindings = changes?.secretFindings ?? [];
+              if (secretFindings.length > 0 && overrideConfirm === "override") {
+                setSecurityOverride(true);
+              }
+              setPhase("running");
+            }}
           />
         )}
 
@@ -340,6 +374,8 @@ function CommitPushConfirm({
   loading,
   commitMessage,
   onMessageChange,
+  overrideConfirm,
+  onOverrideConfirmChange,
   onCancel,
   onConfirm,
 }: {
@@ -347,11 +383,17 @@ function CommitPushConfirm({
   loading: boolean;
   commitMessage: string;
   onMessageChange: (v: string) => void;
+  overrideConfirm: string;
+  onOverrideConfirmChange: (v: string) => void;
   onCancel: () => void;
   onConfirm: () => void;
 }) {
   const total = changes?.total ?? 0;
   const suspicious = changes?.suspicious ?? [];
+  const secretFindings = changes?.secretFindings ?? [];
+  const hasSecrets = secretFindings.length > 0;
+  // Override is confirmed only when the user types the exact word "override"
+  const overrideReady = !hasSecrets || overrideConfirm === "override";
 
   return (
     <div className="flex flex-col gap-5 overflow-y-auto px-6 py-6">
@@ -404,6 +446,46 @@ function CommitPushConfirm({
               </div>
             </div>
           )}
+
+          {hasSecrets && (
+            <div className="flex gap-3 rounded-lg border border-red-500/50 bg-red-500/10 p-4">
+              <ShieldAlert className="mt-0.5 h-4 w-4 shrink-0 text-red-400" />
+              <div className="w-full text-[12.5px] text-fg-muted">
+                <p className="font-semibold text-red-400">
+                  Secret scan detected {secretFindings.length} potential secret{secretFindings.length === 1 ? "" : "s"}
+                </p>
+                <ul className="mt-2 space-y-1.5 mono text-[11px]">
+                  {secretFindings.slice(0, 8).map((f, i) => (
+                    <li key={i} className="flex flex-col gap-0.5">
+                      <span className="text-red-300">
+                        {f.filePath}:{f.line} — <span className="font-medium">{f.ruleName}</span>
+                      </span>
+                      <span className="text-fg-dim truncate">{f.snippet}</span>
+                    </li>
+                  ))}
+                  {secretFindings.length > 8 && (
+                    <li className="text-fg-dim">…and {secretFindings.length - 8} more</li>
+                  )}
+                </ul>
+                <p className="mt-3 text-[11.5px] text-fg-muted">
+                  Pushing secrets to GitHub can expose credentials publicly and may not be reversible. Remove the secrets, then commit.
+                </p>
+                <label className="mt-3 flex flex-col gap-1.5">
+                  <span className="text-[11px] uppercase tracking-wider text-red-400">
+                    Type <span className="mono font-bold">override</span> to commit anyway (not recommended)
+                  </span>
+                  <input
+                    type="text"
+                    value={overrideConfirm}
+                    onChange={(e) => onOverrideConfirmChange(e.target.value)}
+                    placeholder="override"
+                    autoComplete="off"
+                    className="rounded-lg border border-red-500/40 bg-red-500/5 px-3 py-1.5 text-[13px] text-red-300 placeholder:text-fg-dim focus:border-red-400 focus:outline-none"
+                  />
+                </label>
+              </div>
+            </div>
+          )}
         </>
       )}
 
@@ -431,10 +513,12 @@ function CommitPushConfirm({
         </button>
         <button
           onClick={onConfirm}
-          disabled={!loading && total === 0}
+          disabled={(!loading && total === 0) || !overrideReady}
           className={cn(
             "rounded-full border px-5 py-1.5 text-[13px] font-medium transition-all",
-            "border-accent-push/45 bg-accent-push/15 text-accent-push hover:bg-accent-push/25",
+            hasSecrets && !overrideReady
+              ? "border-red-500/30 bg-red-500/10 text-red-400 cursor-not-allowed opacity-40"
+              : "border-accent-push/45 bg-accent-push/15 text-accent-push hover:bg-accent-push/25",
             "disabled:cursor-not-allowed disabled:opacity-40",
           )}
         >

--- a/lib/git/actions.ts
+++ b/lib/git/actions.ts
@@ -41,7 +41,9 @@ interface StartOptions {
   action: ActionName;
   branch: string | null;
   commitMessage?: string;
+  securityOverride?: boolean;
 }
+
 
 export function startAction(opts: StartOptions): ActionRun {
   const runId = randomUUID();
@@ -62,8 +64,9 @@ export function startAction(opts: StartOptions): ActionRun {
 
   if (opts.action === "commit-push") {
     const message = sanitizeCommitMessage(opts.commitMessage);
+    const securityOverride = opts.securityOverride === true;
     setImmediate(() => {
-      executeCommitPush(run, opts.repoPath, message).catch((err) => {
+      executeCommitPush(run, opts.repoPath, message, securityOverride).catch((err) => {
         run.emitter.emit("done", { exitCode: -1 });
         run.exitCode = -1;
         run.finishedAt = Date.now();
@@ -176,11 +179,19 @@ function recordRunFinish(run: ActionRun): void {
   }
 }
 
-async function executeCommitPush(run: ActionRun, repoPath: string, message: string): Promise<void> {
+async function executeCommitPush(run: ActionRun, repoPath: string, message: string, securityOverride: boolean): Promise<void> {
   const emit = (text: string) => {
     run.lines.push(text);
     run.emitter.emit("line", text);
   };
+
+  // Secret scan already ran in the action route before this point.
+  // If securityOverride is true, the route confirmed the user acknowledged the risk.
+  if (securityOverride) {
+    emit("[secret-scan] ⚠ override — proceeding past secret findings as confirmed by user");
+  } else {
+    emit("[secret-scan] ✓ passed");
+  }
 
   const steps: { label: string; args: string[] }[] = [
     { label: "stage", args: ["add", "-A"] },

--- a/lib/security/secrets.ts
+++ b/lib/security/secrets.ts
@@ -1,0 +1,267 @@
+/**
+ * Pre-push secret scanner.
+ *
+ * Rules: named regex patterns. No external dependencies — pure Node built-ins.
+ * Never log or return full secrets. All matches are truncated to 40 chars + ellipsis.
+ */
+
+import { readFile, stat } from "node:fs/promises";
+import path from "node:path";
+
+export interface SecretFinding {
+  filePath: string;
+  line: number;
+  ruleId: string;
+  ruleName: string;
+  /** First 40 chars of the matched text + ellipsis if truncated. Never the full secret. */
+  snippet: string;
+}
+
+interface Rule {
+  id: string;
+  name: string;
+  /** Tested against each line of the file content. Must have no global flag. */
+  pattern: RegExp;
+}
+
+/** Truncate a matched value to at most 40 printable chars + ellipsis. */
+function safeSnippet(match: string): string {
+  const clean = match.replace(/[\r\n]/g, " ");
+  return clean.length > 40 ? clean.slice(0, 40) + "…" : clean;
+}
+
+/** Shannon entropy in bits per character over `str`. */
+function shannonEntropy(str: string): number {
+  if (str.length === 0) return 0;
+  const freq = new Map<string, number>();
+  for (const ch of str) freq.set(ch, (freq.get(ch) ?? 0) + 1);
+  let h = 0;
+  for (const count of freq.values()) {
+    const p = count / str.length;
+    h -= p * Math.log2(p);
+  }
+  return h;
+}
+
+/**
+ * Lockfiles to skip by exact basename.
+ * Hex blobs in lockfiles are content-addressed hashes, not secrets.
+ */
+const LOCKFILE_NAMES: ReadonlySet<string> = new Set([
+  "package-lock.json",
+  "yarn.lock",
+  "pnpm-lock.yaml",
+  "bun.lock",
+  "Cargo.lock",
+  "Gemfile.lock",
+  "poetry.lock",
+  "composer.lock",
+]);
+
+const MAX_FILE_SIZE = 1 * 1024 * 1024; // 1 MB
+const BINARY_PROBE_BYTES = 8 * 1024; // 8 KB
+
+/**
+ * Ordered rule set. Each rule is applied to every non-skipped line.
+ * Patterns have no global flag so match() returns the first occurrence.
+ */
+const RULES: readonly Rule[] = Object.freeze([
+  {
+    id: "openai-key",
+    name: "OpenAI API key",
+    // sk- followed by 48 alphanumerics
+    pattern: /sk-[A-Za-z0-9]{48}/,
+  },
+  {
+    id: "anthropic-key",
+    name: "Anthropic API key",
+    // sk-ant- prefix used by Anthropic
+    pattern: /sk-ant-[A-Za-z0-9\-_]{20,}/,
+  },
+  {
+    id: "aws-access-key",
+    name: "AWS access key ID",
+    // AKIA or ASIA prefix, 16 uppercase alphanumerics
+    pattern: /(?:AKIA|ASIA)[A-Z0-9]{16}/,
+  },
+  {
+    id: "aws-secret-key",
+    name: "AWS secret access key",
+    // 40-char base64 value preceded by common env var names
+    pattern: /(?:aws_secret|AWS_SECRET)[_A-Za-z]*\s*[=:]\s*["']?[A-Za-z0-9/+]{40}["']?/i,
+  },
+  {
+    id: "github-token",
+    name: "GitHub personal access token",
+    // Classic: ghp_, fine-grained: github_pat_
+    pattern: /(?:ghp_[A-Za-z0-9]{36}|github_pat_[A-Za-z0-9_]{82})/,
+  },
+  {
+    id: "github-oauth",
+    name: "GitHub OAuth token",
+    pattern: /gho_[A-Za-z0-9]{36}/,
+  },
+  {
+    id: "github-app-token",
+    name: "GitHub App token",
+    pattern: /(?:ghs_|ghu_)[A-Za-z0-9]{36}/,
+  },
+  {
+    id: "stripe-secret",
+    name: "Stripe secret key",
+    pattern: /sk_(?:live|test)_[A-Za-z0-9]{24,}/,
+  },
+  {
+    id: "stripe-restricted",
+    name: "Stripe restricted key",
+    pattern: /rk_(?:live|test)_[A-Za-z0-9]{24,}/,
+  },
+  {
+    id: "private-key-block",
+    name: "PEM private key block",
+    pattern: /-----BEGIN (?:RSA |EC |DSA |OPENSSH )?PRIVATE KEY-----/,
+  },
+  {
+    id: "slack-token",
+    name: "Slack API token",
+    // xox[bpars]-... format
+    pattern: /xox[bpars]-[A-Za-z0-9\-]{10,}/,
+  },
+  {
+    id: "slack-webhook",
+    name: "Slack webhook URL",
+    pattern: /https:\/\/hooks\.slack\.com\/services\/[A-Za-z0-9/]+/,
+  },
+  {
+    id: "google-api-key",
+    name: "Google API key",
+    pattern: /AIza[A-Za-z0-9\-_]{35}/,
+  },
+  {
+    id: "gcp-service-account",
+    name: "GCP service account key",
+    pattern: /"type"\s*:\s*"service_account"/,
+  },
+  {
+    id: "jwt-token",
+    name: "JWT token",
+    // eyJ... three base64url segments
+    pattern: /eyJ[A-Za-z0-9_\-]{10,}\.[A-Za-z0-9_\-]{10,}\.[A-Za-z0-9_\-]{10,}/,
+  },
+  {
+    id: "generic-secret-var",
+    name: "Generic secret/password variable",
+    // Catches: SECRET=foo, PASSWORD=bar, TOKEN=baz (value 8+ non-whitespace chars)
+    pattern: /(?:SECRET|PASSWORD|PASSWD|TOKEN|API_KEY|APIKEY)\s*[=:]\s*["']?(?!\s*$)\S{8,}["']?/i,
+  },
+  {
+    id: "high-entropy-env",
+    name: "High-entropy .env value",
+    // Checked separately via entropy logic below — this pattern matches .env-style assignments
+    // and a secondary entropy gate filters out low-entropy values.
+    pattern: /^[A-Z][A-Z0-9_]*\s*=\s*["']?([^\s"'#]{16,})["']?\s*(?:#.*)?$/,
+  },
+] as Rule[]);
+
+/** The rule that gates on entropy — checked separately. */
+const HIGH_ENTROPY_RULE_ID = "high-entropy-env";
+const ENTROPY_THRESHOLD = 4.0;
+
+/**
+ * Scan the text of a single file for secret patterns.
+ * Returns an array of findings. Never includes full secret values.
+ *
+ * @param text     Full text content of the file.
+ * @param filePath Relative or display path (used in findings only).
+ */
+export function scanContent(text: string, filePath: string): SecretFinding[] {
+  const findings: SecretFinding[] = [];
+  const lines = text.split(/\r?\n/);
+
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i]!;
+    const lineNumber = i + 1;
+    const seenRulesThisLine = new Set<string>();
+
+    for (const rule of RULES) {
+      if (seenRulesThisLine.has(rule.id)) continue;
+
+      const m = rule.pattern.exec(line);
+      if (!m) continue;
+
+      // Special entropy gate for the .env-style rule
+      if (rule.id === HIGH_ENTROPY_RULE_ID) {
+        // m[1] is the captured value group
+        const value = m[1];
+        if (!value) continue;
+        if (shannonEntropy(value) <= ENTROPY_THRESHOLD) continue;
+      }
+
+      seenRulesThisLine.add(rule.id);
+      findings.push({
+        filePath,
+        line: lineNumber,
+        ruleId: rule.id,
+        ruleName: rule.name,
+        snippet: safeSnippet(m[0]),
+      });
+    }
+  }
+
+  return findings;
+}
+
+/**
+ * Scan a set of files in a repo for secrets.
+ * Skips lockfiles, binary files (null byte in first 8 KB), and files > 1 MB.
+ *
+ * @param repoPath      Absolute path to the repo root.
+ * @param relativePaths Paths relative to repoPath.
+ */
+export async function scanFiles(
+  repoPath: string,
+  relativePaths: string[],
+): Promise<SecretFinding[]> {
+  const findings: SecretFinding[] = [];
+  const repoRoot = path.resolve(repoPath);
+  const repoRootPrefix = repoRoot.endsWith(path.sep) ? repoRoot : repoRoot + path.sep;
+
+  for (const rel of relativePaths) {
+    const baseName = path.basename(rel);
+
+    // Skip lockfiles
+    if (LOCKFILE_NAMES.has(baseName)) continue;
+
+    const absPath = path.resolve(repoRoot, rel);
+    // Guard against path traversal
+    if (absPath !== repoRoot && !absPath.startsWith(repoRootPrefix)) continue;
+
+    // Skip files > 1 MB (stat before reading)
+    let fileSize = 0;
+    try {
+      const s = await stat(absPath);
+      if (!s.isFile()) continue;
+      fileSize = s.size;
+    } catch {
+      continue; // file may have been deleted between status and scan
+    }
+    if (fileSize > MAX_FILE_SIZE) continue;
+
+    // Read file; skip binary files (null byte in first 8 KB)
+    let content: string;
+    try {
+      const buf = await readFile(absPath);
+      // Check for binary: null byte in first 8 KB
+      const probe = buf.subarray(0, BINARY_PROBE_BYTES);
+      if (probe.includes(0)) continue;
+      content = buf.toString("utf8");
+    } catch {
+      continue;
+    }
+
+    const fileFindings = scanContent(content, rel);
+    findings.push(...fileFindings);
+  }
+
+  return findings;
+}


### PR DESCRIPTION
Closes #92

## Summary

- Adds `lib/security/secrets.ts` with `scanContent` / `scanFiles` — 17 named regex rules (OpenAI, AWS, GitHub, Stripe, Slack, Google, JWT, PEM blocks, generic high-entropy .env values). No external dependencies — pure Node built-ins.
- Wires secret scan into the `commit-push` action route: before starting the git run, enumerate staging candidates via `git status --porcelain=v1 -z`, call `scanFiles`, and return HTTP 422 with structured `{ error, findings }` payload if secrets found and no override.
- Extends `/api/repos/[id]/changes` to run the same scan and return `secretFindings` alongside the existing file list — so the modal shows warnings before the user even clicks.
- Updates `ActionModal` to render a red-bordered findings section (file:line, rule name, snippet) and a typed confirmation input (`override`, case-sensitive) that must be filled before the Commit & push button becomes active when secrets are present.
- Security properties: snippets truncated to 40 chars + ellipsis everywhere; never full secret in logs, API responses, or modal. Lockfiles skipped by exact name; binary files skipped by null-byte probe; files >1MB skipped. Fail-open if scan itself errors (scan error does not block commit).

## Test plan

- [x] Verification script (`/tmp/verify-92.ts`) — 6 cases, all pass: clean string (0 findings), OpenAI key (1 finding, ruleId=openai-key, line=1), PEM block (1 finding), high-entropy .env (1 finding, ruleId=high-entropy-env), low-entropy .env (0 findings), lockfile-style hex blob (0 findings)
- [x] `npm run typecheck` — clean
- [x] `npm run build` — clean
- [ ] Manual smoke: add `sk-<48 chars>` to a tracked file in a test repo, trigger commit-push from the UI, confirm the changes preview shows the finding, confirm the Commit & push button is disabled until typing `override`

## Out of scope

#93 (audit log viewer), #94 (allowlist file), #95 (CI integration), #96 (binary scan) are intentionally out of scope as agreed in the design discussion on #92.

🤖 Generated with [Claude Code](https://claude.com/claude-code)