### PR TITLE
feat(status): suggest /security-review when unreviewed commits accumulate (#98)

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,6 +245,66 @@ Sample output lines:
 
 If gitdash hasn't scanned the directory yet, or the path isn't a git repo, the command prints nothing and exits 0 — it never pollutes your session with errors.
 
+### Security review nudge
+
+When `gitdash status` fires at session start it also checks whether a security review is overdue. If you have accumulated 5 or more commits since your last review, or 7 or more days have passed, a second line appears:
+
+```
+✓ gitdash: in sync · main
+   → 6 commit(s) since last review · run /security-review to scan
+```
+
+The thresholds are configurable in `~/.config/gitdash/config.json`:
+
+```json
+{
+  "reviewSuggest": {
+    "enabled": true,
+    "commitThreshold": 5,
+    "daysCadence": 7
+  }
+}
+```
+
+Set `"enabled": false` to silence the nudge entirely.
+
+### Optional Stop hook — mark-reviewed automatically (opt-in)
+
+After each Claude Code session you can automatically record the current HEAD as reviewed by adding a `Stop` hook. **This is opt-in — gitdash does not install it automatically.**
+
+Add this block to `~/.claude/settings.json` alongside the `SessionStart` entry:
+
+```json
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "matcher": "*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "gitdash status --cwd $CLAUDE_PROJECT_DIR"
+          }
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "matcher": "*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "gitdash mark-reviewed --cwd $CLAUDE_PROJECT_DIR"
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+You can also run `gitdash mark-reviewed` manually at any time to reset the review counter for the repo in your current directory.
+
 ---
 
 ## 📜 License

--- a/bin/gitdash
+++ b/bin/gitdash
@@ -57,6 +57,17 @@ if [[ "$MODE" == "status" ]]; then
   exec "$TSX" "$DIR/scripts/status.ts" "$@"
 fi
 
+# mark-reviewed subcommand: records current HEAD as the last-reviewed point.
+if [[ "$MODE" == "mark-reviewed" ]]; then
+  shift
+  TSX="$DIR/node_modules/.bin/tsx"
+  if [[ ! -x "$TSX" ]]; then
+    # Silent failure — runs in hook context
+    exit 0
+  fi
+  exec "$TSX" "$DIR/scripts/mark-reviewed.ts" "$@"
+fi
+
 if [[ ! -d "$DIR/.next" && "$MODE" == "start" ]]; then
   echo "[gitdash] no build found — running \`npm run build\` first"
   npm run build
@@ -86,5 +97,5 @@ fi
 case "$MODE" in
   start) exec "$NEXT" start -H "$BIND" -p "$PORT" ;;
   dev)   exec "$NEXT" dev   -H "$BIND" -p "$PORT" ;;
-  *)     echo "usage: gitdash [start|dev|status [--cwd <path>]]" >&2; exit 1 ;;
+  *)     echo "usage: gitdash [start|dev|status|mark-reviewed [--cwd <path>]]" >&2; exit 1 ;;
 esac

--- a/lib/db/repos.ts
+++ b/lib/db/repos.ts
@@ -14,6 +14,8 @@ export interface RepoRow {
   discoveredAt: number;
   lastSeenAt: number;
   deletedAt: number | null;
+  lastReviewAt: number | null;
+  reviewedHeadSha: string | null;
 }
 
 interface RepoRaw {
@@ -26,6 +28,8 @@ interface RepoRaw {
   discovered_at: number;
   last_seen_at: number;
   deleted_at: number | null;
+  last_review_at: number | null;
+  reviewed_head_sha: string | null;
 }
 
 export interface SnapshotRow {
@@ -93,6 +97,8 @@ export function upsertDiscoveredRepo(discovered: DiscoveredRepo, now: number): R
     discoveredAt: now,
     lastSeenAt: now,
     deletedAt: null,
+    lastReviewAt: null,
+    reviewedHeadSha: null,
   };
 }
 
@@ -282,7 +288,22 @@ function rawToRepoRow(r: RepoRaw): RepoRow {
     discoveredAt: r.discovered_at,
     lastSeenAt: r.last_seen_at,
     deletedAt: r.deleted_at,
+    lastReviewAt: r.last_review_at ?? null,
+    reviewedHeadSha: r.reviewed_head_sha ?? null,
   };
+}
+
+export function getRepoByPath(repoPath: string): RepoRow | null {
+  const row = getDb()
+    .prepare<[string], RepoRaw>("SELECT * FROM repos WHERE repo_path = ? AND deleted_at IS NULL")
+    .get(repoPath);
+  return row ? rawToRepoRow(row) : null;
+}
+
+export function markRepoReviewed(repoId: number, headSha: string, now: number): void {
+  getDb()
+    .prepare("UPDATE repos SET last_review_at = ?, reviewed_head_sha = ? WHERE id = ?")
+    .run(now, headSha, repoId);
 }
 
 function rawToSnapshot(r: SnapshotRaw): SnapshotRow {

--- a/lib/db/schema.ts
+++ b/lib/db/schema.ts
@@ -88,6 +88,8 @@ function migrate(db: Database.Database): void {
   // COLUMN, so we probe table_info first. New columns must be NULL-able
   // (which is fine for our additive use cases — derivation handles nulls).
   ensureColumn(db, "snapshots", "can_push", "INTEGER");
+  ensureColumn(db, "repos", "last_review_at", "INTEGER");
+  ensureColumn(db, "repos", "reviewed_head_sha", "TEXT");
 }
 
 function ensureColumn(

--- a/scripts/mark-reviewed.ts
+++ b/scripts/mark-reviewed.ts
@@ -1,0 +1,96 @@
+/**
+ * scripts/mark-reviewed.ts
+ *
+ * Records the current HEAD SHA as the last-reviewed point for a repo.
+ * Usage:  tsx scripts/mark-reviewed.ts [--cwd <path>]
+ * Called by:  bin/gitdash mark-reviewed [--cwd <path>]
+ *
+ * Exits 0 always — never pollutes hook output with errors.
+ */
+
+import { existsSync } from "node:fs";
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+import path from "node:path";
+
+const execFileAsync = promisify(execFile);
+
+// ── CLI arg parsing ───────────────────────────────────────────────────────────
+
+const args = process.argv.slice(2);
+let inputDir = process.env.PWD ?? process.cwd();
+
+for (let i = 0; i < args.length; i++) {
+  if (args[i] === "--cwd" && args[i + 1]) {
+    inputDir = args[i + 1]!;
+    break;
+  }
+}
+
+// ── Resolve git root ──────────────────────────────────────────────────────────
+
+function findGitRoot(startDir: string): string | null {
+  let dir = path.resolve(startDir);
+  for (let i = 0; i < 50; i++) {
+    if (existsSync(path.join(dir, ".git"))) return dir;
+    const parent = path.dirname(dir);
+    if (parent === dir) return null;
+    dir = parent;
+  }
+  return null;
+}
+
+async function main(): Promise<void> {
+  const gitRoot = findGitRoot(inputDir);
+  if (!gitRoot) return;
+
+  // Get current HEAD SHA
+  let headSha: string;
+  try {
+    const { stdout } = await execFileAsync("git", ["-C", gitRoot, "rev-parse", "HEAD"]);
+    headSha = stdout.trim();
+    if (!headSha) return;
+  } catch {
+    return;
+  }
+
+  // Use getDb (write connection) since this is an explicit write operation
+  // Inline the DB path logic to avoid pulling in the full bootstrap chain
+  const DB_PATH =
+    process.env.GITDASH_DB ??
+    path.join(
+      process.env.HOME ?? ".",
+      ".local",
+      "state",
+      "gitdash",
+      "gitdash.sqlite",
+    );
+
+  if (!existsSync(DB_PATH)) return;
+
+  // Dynamically import getDb — this triggers migrations which is fine
+  // (idempotent) and ensures the new columns exist before we write.
+  const { getDb } = await import("../lib/db/schema.js");
+  const db = getDb();
+
+  const repo = db
+    .prepare<[string], { id: number }>(
+      "SELECT id FROM repos WHERE repo_path = ? AND deleted_at IS NULL",
+    )
+    .get(gitRoot);
+
+  if (!repo) return;
+
+  const now = Date.now();
+  db.prepare(
+    "UPDATE repos SET last_review_at = ?, reviewed_head_sha = ? WHERE id = ?",
+  ).run(now, headSha, repo.id);
+}
+
+main().catch(() => {
+  // Silent on all errors — runs in hook context
+});
+
+process.on("unhandledRejection", () => {
+  // Stay silent
+});

--- a/scripts/status.ts
+++ b/scripts/status.ts
@@ -2,6 +2,8 @@
  * scripts/status.ts
  *
  * Prints a one-line git status summary for the repo at --cwd (default $PWD).
+ * Optionally prints a second line nudging for a security review when
+ * unreviewed commits accumulate past configured thresholds.
  * Reads SQLite directly — no server needed.
  *
  * Usage:  tsx scripts/status.ts [--cwd <path>]
@@ -11,7 +13,8 @@
  */
 
 import Database from "better-sqlite3";
-import { existsSync } from "node:fs";
+import { existsSync, readFileSync } from "node:fs";
+import { execFile } from "node:child_process";
 import path from "node:path";
 
 // ── CLI arg parsing ──────────────────────────────────────────────────────────
@@ -56,6 +59,74 @@ const DB_PATH =
 
 if (!existsSync(DB_PATH)) process.exit(0);
 
+// ── Load reviewSuggest config ────────────────────────────────────────────────
+
+interface ReviewSuggestConfig {
+  enabled: boolean;
+  commitThreshold: number;
+  daysCadence: number;
+}
+
+function loadReviewConfig(): ReviewSuggestConfig {
+  const defaults: ReviewSuggestConfig = {
+    enabled: true,
+    commitThreshold: 5,
+    daysCadence: 7,
+  };
+  try {
+    const configPath = path.join(
+      process.env.XDG_CONFIG_HOME ?? path.join(process.env.HOME ?? ".", ".config"),
+      "gitdash",
+      "config.json",
+    );
+    if (!existsSync(configPath)) return defaults;
+    const raw = JSON.parse(readFileSync(configPath, "utf8")) as Record<string, unknown>;
+    const rs = raw["reviewSuggest"] as Record<string, unknown> | undefined;
+    if (!rs) return defaults;
+    return {
+      enabled: typeof rs["enabled"] === "boolean" ? rs["enabled"] : defaults.enabled,
+      commitThreshold:
+        typeof rs["commitThreshold"] === "number" ? rs["commitThreshold"] : defaults.commitThreshold,
+      daysCadence:
+        typeof rs["daysCadence"] === "number" ? rs["daysCadence"] : defaults.daysCadence,
+    };
+  } catch {
+    return defaults;
+  }
+}
+
+// ── execFile helper (no shell, matches security model) ───────────────────────
+
+function gitRevListCount(repoPath: string, range: string): Promise<number> {
+  return new Promise((resolve) => {
+    execFile(
+      "git",
+      ["-C", repoPath, "rev-list", "--count", range],
+      { timeout: 5000 },
+      (err, stdout) => {
+        if (err) { resolve(0); return; }
+        const n = parseInt(stdout.trim(), 10);
+        resolve(isNaN(n) ? 0 : n);
+      },
+    );
+  });
+}
+
+function gitRevParse(repoPath: string, ref: string): Promise<string | null> {
+  return new Promise((resolve) => {
+    execFile(
+      "git",
+      ["-C", repoPath, "rev-parse", "--verify", ref],
+      { timeout: 5000 },
+      (err, stdout) => {
+        if (err) { resolve(null); return; }
+        const sha = stdout.trim();
+        resolve(sha || null);
+      },
+    );
+  });
+}
+
 try {
   const db = new Database(DB_PATH, { readonly: true });
 
@@ -66,10 +137,12 @@ try {
     is_system_repo: number;
     github_owner: string | null;
     github_name: string | null;
+    last_review_at: number | null;
+    reviewed_head_sha: string | null;
   }
   const repo = db
     .prepare<[string], RepoRaw>(
-      "SELECT id, is_system_repo, github_owner, github_name FROM repos WHERE repo_path = ? AND deleted_at IS NULL",
+      "SELECT id, is_system_repo, github_owner, github_name, last_review_at, reviewed_head_sha FROM repos WHERE repo_path = ? AND deleted_at IS NULL",
     )
     .get(gitRoot);
 
@@ -157,9 +230,67 @@ try {
   };
 
   process.stdout.write(lines[state] + "\n");
+
+  // ── Review nudge ───────────────────────────────────────────────────────────
+
+  const reviewConfig = loadReviewConfig();
+  const lastReviewAt: number | null = repo.last_review_at ?? null;
+  const reviewedHeadSha: string | null = repo.reviewed_head_sha ?? null;
+
   db.close();
+
+  if (reviewConfig.enabled) {
+    // Async git calls — run and always exit 0 when done
+    (async () => {
+      try {
+        // Compute commitsSinceReview
+        let commitsSinceReview: number;
+
+        if (reviewedHeadSha) {
+          // Check if the reviewed SHA is still reachable
+          const resolved = await gitRevParse(gitRoot, reviewedHeadSha);
+          if (resolved) {
+            // Count commits from reviewed sha to HEAD
+            commitsSinceReview = await gitRevListCount(gitRoot, `${reviewedHeadSha}..HEAD`);
+          } else {
+            // SHA no longer reachable (force-push / rebase) — count from total
+            commitsSinceReview = await gitRevListCount(gitRoot, "HEAD");
+          }
+        } else {
+          // Never reviewed — count all commits
+          commitsSinceReview = await gitRevListCount(gitRoot, "HEAD");
+        }
+
+        // Compute daysSinceReview.
+        // Only apply the time cadence when a baseline review exists.
+        // When lastReviewAt is null the repo has never been reviewed — the
+        // time trigger does not apply (only the commit threshold does).
+        const daysSinceReview =
+          lastReviewAt === null
+            ? null
+            : (Date.now() - lastReviewAt) / 86_400_000;
+
+        // Edge case: brand-new repo with 0–2 commits, never reviewed → skip nudge
+        const commitThresholdMet = commitsSinceReview >= reviewConfig.commitThreshold;
+        const timeThresholdMet =
+          daysSinceReview !== null && daysSinceReview >= reviewConfig.daysCadence;
+
+        const isNewAndUnreviewed = reviewedHeadSha === null && commitsSinceReview <= 2;
+        const shouldNudge = !isNewAndUnreviewed && (commitThresholdMet || timeThresholdMet);
+
+        if (shouldNudge) {
+          process.stdout.write(
+            `   → ${commitsSinceReview} commit(s) since last review · run /security-review to scan\n`,
+          );
+        }
+      } catch {
+        // Stay silent on any error
+      }
+    })().finally(() => process.exit(0));
+  } else {
+    process.exit(0);
+  }
 } catch {
   // DB locked, corrupt, or missing table — stay silent
+  process.exit(0);
 }
-
-process.exit(0);


### PR DESCRIPTION
## Summary

- Adds `last_review_at` and `reviewed_head_sha` columns to the `repos` table (idempotent via `ensureColumn`)
- Extends `gitdash status` to print a second nudge line when ≥5 commits or ≥7 days have accumulated since the last review
- Adds `gitdash mark-reviewed` subcommand (`scripts/mark-reviewed.ts`) that records current HEAD as the reviewed baseline
- Config via `~/.config/gitdash/config.json` `reviewSuggest` block (`enabled`, `commitThreshold`, `daysCadence`)
- README: documents the nudge feature and opt-in Stop hook for automatic mark-reviewed

## Stacking note

This PR stacks on **#86** (`feature/85-claude-code-status-hook`). It should be merged **after** #86. The base branch is set accordingly.

Closes #98

## Hook output examples

**No nudge (in sync, few commits):**
```
✓ gitdash: in sync · main
```

**Nudge fires (≥5 commits since review):**
```
✓ gitdash: in sync · main
   → 6 commit(s) since last review · run /security-review to scan
```

**Nudge fires (time cadence, 8 days elapsed):**
```
✓ gitdash: in sync · main
   → 0 commit(s) since last review · run /security-review to scan
```

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm run build` clean
- [x] `/tmp/verify-98.ts` — all 5 assertions pass:
  1. 3 commits, never reviewed → no nudge (< threshold)
  2. 6 commits, never reviewed → nudge fires
  3. `mark-reviewed` → no nudge (0 commits since review)
  4. 5 more commits → nudge fires again
  5. Rewind `last_review_at` to 8 days ago → nudge fires from time cadence

🤖 Generated with [Claude Code](https://claude.com/claude-code)