### PR TITLE
fix(gh): handle 304 in catch — gh CLI exits 1 on Not Modified (#107)

### DIFF
--- a/lib/gh/client.ts
+++ b/lib/gh/client.ts
@@ -65,6 +65,16 @@ async function fetchRemoteSha(slug: GitHubSlug, branch: string): Promise<{ sha: 
   } catch (err) {
     const e = err as { stderr?: string };
     const stderr = e.stderr ?? "";
+    // gh CLI exits 1 on 304 even though it's a successful cache hit.
+    if (/\b304\b/.test(stderr) && cached) {
+      try {
+        const parsed = JSON.parse(cached.body_json) as { sha?: string };
+        if (parsed.sha) return { sha: parsed.sha, fromCache: true };
+      } catch {
+        return null;
+      }
+      return null;
+    }
     if (/404/.test(stderr)) return null;
     if (/403/.test(stderr) && cached) {
       try {
@@ -174,8 +184,21 @@ export async function compareWithRemote(
       if (parsed.etag) writeCache(compareKey, parsed.etag, parsed.body, now);
       return comparisonFromBody(body, remote.sha, localSha, now);
     }
-  } catch {
-    // fallthrough
+  } catch (err) {
+    // gh CLI exits 1 on 304 even though it's a successful cache hit.
+    const stderr = (err as { stderr?: string }).stderr ?? "";
+    if (/\b304\b/.test(stderr) && cachedCmp) {
+      try {
+        const body = JSON.parse(cachedCmp.body_json) as {
+          ahead_by?: number;
+          behind_by?: number;
+          status?: string;
+        };
+        return comparisonFromBody(body, remote.sha, localSha, now);
+      } catch {
+        // fall through
+      }
+    }
   }
   return { state: "unknown", ahead: 0, behind: 0, remoteSha: remote.sha, localSha, checkedAt: now };
 }


### PR DESCRIPTION
## Summary

Critical bug: every tracked repo's remote_state was frozen at first-cache state. Pushes from other machines never propagated. Root cause: gh CLI exits with code 1 on HTTP 304, and the catch handler branched on 404/403 but had no 304 branch — so it fell through to return null.

Closes #107

## Test plan
- [x] ``npm run build`` clean
- [x] ``npm run typecheck`` clean
- [x] Direct ``compareWithRemote`` call against live infosys repo returns ``state=\"clean\"`` instead of ``state=\"unknown\"``
- [ ] **Manual verification**: after deploy, the previously-stuck infosys repo shows ``clean`` in the dashboard within 60s; subsequent pushes from another machine reflect within 60s