### PR TITLE
feat(api): manual remote refresh button (#102)

### DIFF
--- a/app/api/repos/[id]/refresh-remote/route.ts
+++ b/app/api/repos/[id]/refresh-remote/route.ts
@@ -1,0 +1,62 @@
+import { NextResponse } from "next/server";
+import { bootstrap } from "@/lib/bootstrap";
+import { validateCsrf } from "@/lib/security/csrf";
+import { getRepoById } from "@/lib/db/repos";
+import { getScheduler, rateLimitCheck, recordRefreshTimestamp } from "@/lib/scan/scheduler";
+
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
+
+/**
+ * POST /api/repos/[id]/refresh-remote
+ *
+ * Force-refreshes the remote state for a single repo by:
+ *   1. Invalidating the gh_etag_cache entries for the repo's slug.
+ *   2. Calling compareWithRemote (fresh GH API call).
+ *   3. Writing the result to the snapshot and emitting a store update.
+ *
+ * Rate-limited to one call per repo per 5 s (in-memory). Returns 429 with
+ * { retryAfterMs } when the limit is hit. CSRF required.
+ */
+export async function POST(
+  req: Request,
+  ctx: { params: Promise<{ id: string }> },
+) {
+  await bootstrap();
+
+  const csrf = req.headers.get("x-csrf-token");
+  if (!validateCsrf(csrf)) {
+    return NextResponse.json({ error: "invalid csrf" }, { status: 403 });
+  }
+
+  const { id } = await ctx.params;
+  const repoId = Number(id);
+  if (!Number.isInteger(repoId) || repoId <= 0) {
+    return NextResponse.json({ error: "invalid repo id" }, { status: 400 });
+  }
+
+  const repo = getRepoById(repoId);
+  if (!repo || repo.deletedAt !== null) {
+    return NextResponse.json({ error: "repo not found" }, { status: 404 });
+  }
+
+  const limit = rateLimitCheck(repoId);
+  if (!limit.allowed) {
+    return NextResponse.json(
+      { error: "rate-limited", retryAfterMs: limit.retryAfterMs },
+      { status: 429 },
+    );
+  }
+
+  const scheduler = getScheduler();
+  if (!scheduler) {
+    return NextResponse.json({ error: "scheduler not running" }, { status: 503 });
+  }
+
+  // Record timestamp before the call so back-to-back clicks are rejected even
+  // if the gh API is slow.
+  recordRefreshTimestamp(repoId);
+
+  const result = await scheduler.refreshRemoteOne(repoId);
+  return NextResponse.json(result);
+}

--- a/components/RepoCard.tsx
+++ b/components/RepoCard.tsx
@@ -128,9 +128,21 @@ export function RepoCard({ repo, kind, csrfToken, expanded, onToggle }: Props) {
           )}
         >
           <div className="flex min-w-0 flex-col">
-            <h3 className="truncate text-[14px] font-medium tracking-tight text-fg">
-              {repo.displayName}
-            </h3>
+            <div className="flex min-w-0 items-center gap-1">
+              <h3 className="truncate text-[14px] font-medium tracking-tight text-fg">
+                {repo.displayName}
+              </h3>
+              {snap?.remoteState === "unknown" &&
+                (snap.remoteCheckedAt === null || Date.now() - snap.remoteCheckedAt > 5 * 60 * 1000) && (
+                  <span
+                    className="shrink-0 text-[11px] text-accent-attention"
+                    title="Remote check is stuck. Possible causes: branch removed on GitHub, auth expired, repo renamed/deleted. Click refresh to retry."
+                    aria-label="Remote check is stuck"
+                  >
+                    ⚠
+                  </span>
+                )}
+            </div>
             <span className="mono truncate text-[11px] text-fg-dim">
               {snap?.detached ? "(detached HEAD)" : snap?.branch ?? "—"}
             </span>
@@ -163,6 +175,7 @@ export function RepoCard({ repo, kind, csrfToken, expanded, onToggle }: Props) {
             repoId={repo.id}
             csrfToken={csrfToken}
             expanded={expanded}
+            snap={snap}
           />
         </div>
 
@@ -182,6 +195,7 @@ export function RepoCard({ repo, kind, csrfToken, expanded, onToggle }: Props) {
               repoId={repo.id}
               csrfToken={csrfToken}
               expanded={expanded}
+              snap={snap}
             />
           </div>
 
@@ -409,59 +423,95 @@ function RowIcons({
   repoId,
   csrfToken,
   expanded,
+  snap,
 }: {
   ghUrl: string | null;
   repoId: number;
   csrfToken: string;
   expanded: boolean;
+  snap: import("@/lib/db/repos").SnapshotRow | null;
 }) {
-  const [refreshState, setRefreshState] = useState<"idle" | "spinning" | "error">("idle");
+  const [refreshState, setRefreshState] = useState<"idle" | "spinning" | "error" | "rate-limited">("idle");
+
+  const remoteCheckedAt = snap?.remoteCheckedAt ?? null;
+  const remoteState = snap?.remoteState ?? null;
+
+  // True when remote check is "unknown" and hasn't succeeded in the last 5 min.
+  const isStuck =
+    remoteState === "unknown" &&
+    (remoteCheckedAt === null || Date.now() - remoteCheckedAt > 5 * 60 * 1000);
+
+  function buildTooltip(): string {
+    if (refreshState === "error") return "Refresh failed — see server logs";
+    if (refreshState === "rate-limited") return "Checked recently — please wait a moment";
+
+    let tip =
+      remoteCheckedAt != null
+        ? `Last remote check: ${relativeTime(remoteCheckedAt / 1000)}`
+        : "Remote not yet checked";
+
+    if (isStuck) {
+      tip +=
+        " · check has been failing\nPossible causes: branch removed on GitHub, auth expired, repo renamed/deleted.";
+    }
+    return tip;
+  }
 
   const onRefresh = async (e: React.MouseEvent) => {
     e.stopPropagation();
-    if (refreshState === "spinning") return;
+    if (refreshState === "spinning" || refreshState === "rate-limited") return;
     setRefreshState("spinning");
     try {
-      const res = await fetch(`/api/repos/${repoId}/refresh`, {
+      const res = await fetch(`/api/repos/${repoId}/refresh-remote`, {
         method: "POST",
         headers: { "x-csrf-token": csrfToken },
       });
-      if (!res.ok) {
+      if (res.status === 429) {
+        setRefreshState("rate-limited");
+        setTimeout(() => setRefreshState("idle"), 5_000);
+      } else if (!res.ok) {
         setRefreshState("error");
-        setTimeout(() => setRefreshState("idle"), 1500);
+        setTimeout(() => setRefreshState("idle"), 2_000);
       } else {
         setRefreshState("idle");
       }
     } catch {
       setRefreshState("error");
-      setTimeout(() => setRefreshState("idle"), 1500);
+      setTimeout(() => setRefreshState("idle"), 2_000);
     }
   };
 
   return (
     <div className="flex items-center justify-end gap-0.5 sm:gap-1">
-      <button
-        type="button"
-        onClick={onRefresh}
-        title={
-          refreshState === "error"
-            ? "Refresh failed — see server logs"
-            : "Re-check this repo against GitHub"
-        }
-        aria-label="Refresh"
-        disabled={refreshState === "spinning"}
-        className={cn(
-          "inline-flex h-11 w-11 items-center justify-center rounded-full transition-colors sm:h-7 sm:w-7",
-          refreshState === "error"
-            ? "text-accent-attention"
-            : "text-fg-dim hover:bg-bg-hover hover:text-fg",
-          refreshState === "spinning" && "cursor-wait",
+      <div className="relative flex items-center">
+        {isStuck && refreshState === "idle" && (
+          <span
+            className="absolute -left-4 text-[11px] text-accent-attention"
+            title="Remote check is stuck. Click refresh to retry."
+            aria-label="Remote check is stuck"
+          >
+            ⚠
+          </span>
         )}
-      >
-        <RefreshCw
-          className={cn("h-3.5 w-3.5", refreshState === "spinning" && "animate-spin")}
-        />
-      </button>
+        <button
+          type="button"
+          onClick={onRefresh}
+          title={buildTooltip()}
+          aria-label="Refresh remote state"
+          disabled={refreshState === "spinning" || refreshState === "rate-limited"}
+          className={cn(
+            "inline-flex h-11 w-11 items-center justify-center rounded-full transition-colors sm:h-7 sm:w-7",
+            refreshState === "error" && "text-accent-attention",
+            refreshState === "rate-limited" && "text-fg-dim opacity-50 cursor-not-allowed",
+            refreshState === "idle" && "text-fg-dim hover:bg-bg-hover hover:text-fg",
+            refreshState === "spinning" && "cursor-wait text-fg-dim",
+          )}
+        >
+          <RefreshCw
+            className={cn("h-3.5 w-3.5", refreshState === "spinning" && "animate-spin")}
+          />
+        </button>
+      </div>
       {ghUrl ? (
         <a
           href={ghUrl}

--- a/lib/scan/scheduler.ts
+++ b/lib/scan/scheduler.ts
@@ -2,7 +2,7 @@ import { existsSync } from "node:fs";
 import pLimit from "p-limit";
 import { discoverRepos, detectWeirdFlags, type DiscoveryConfig, parseGithubSlug } from "./discover";
 import { collectSnapshot } from "@/lib/git/status";
-import { compareWithRemote, fetchOpenPrCount, fetchCanPush } from "@/lib/gh/client";
+import { compareWithRemote, fetchOpenPrCount, fetchCanPush, type RemoteState } from "@/lib/gh/client";
 import {
   upsertDiscoveredRepo,
   upsertSnapshot,
@@ -12,6 +12,35 @@ import {
   getRepoById,
 } from "@/lib/db/repos";
 import { getStore } from "@/lib/state/store";
+import { getDb } from "@/lib/db/schema";
+
+// ---------------------------------------------------------------------------
+// In-memory rate limiter for refreshRemoteOne — module-level Map is adequate
+// for a single-process gitdash and survives Next.js HMR fine.
+// ---------------------------------------------------------------------------
+const refreshTimestamps = new Map<number, number>();
+const MIN_REFRESH_INTERVAL_MS = 5_000;
+
+export function rateLimitCheck(repoId: number): { allowed: boolean; retryAfterMs: number } {
+  const last = refreshTimestamps.get(repoId) ?? 0;
+  const elapsed = Date.now() - last;
+  if (elapsed < MIN_REFRESH_INTERVAL_MS) {
+    return { allowed: false, retryAfterMs: MIN_REFRESH_INTERVAL_MS - elapsed };
+  }
+  return { allowed: true, retryAfterMs: 0 };
+}
+
+export function recordRefreshTimestamp(repoId: number): void {
+  refreshTimestamps.set(repoId, Date.now());
+}
+
+export type RefreshRemoteResult = {
+  state: RemoteState | "no-github" | "no-snapshot";
+  ahead: number;
+  behind: number;
+  remoteSha: string | null;
+  checkedAt: number;
+};
 
 export interface SchedulerOptions {
   config: DiscoveryConfig;
@@ -102,6 +131,64 @@ class Scheduler {
       }
       console.error(`[scheduler] collect failed for ${row.repoPath}`, err);
     }
+  }
+
+  /**
+   * Force-refresh the remote state for a single repo, bypassing the normal
+   * round-robin cadence. Cache entries for this repo's slug are invalidated
+   * first so we get a fresh API call rather than a 304 hit.
+   */
+  async refreshRemoteOne(repoId: number): Promise<RefreshRemoteResult> {
+    const now = Date.now();
+    const row = getRepoById(repoId);
+    if (!row || row.deletedAt !== null) {
+      return { state: "no-github", ahead: 0, behind: 0, remoteSha: null, checkedAt: now };
+    }
+
+    // Collect current local state first.
+    let snap;
+    try {
+      snap = await collectSnapshot({ path: row.repoPath });
+      const weirdFlags = await detectWeirdFlags(row.repoPath);
+      if (snap.remoteUrl && !row.githubOwner) {
+        updateGithubSlug(row.id, snap.remoteUrl);
+      }
+      upsertSnapshot(row.id, snap, null, weirdFlags, now);
+    } catch {
+      return { state: "no-snapshot", ahead: 0, behind: 0, remoteSha: null, checkedAt: now };
+    }
+
+    const slug = parseGithubSlug(snap.remoteUrl);
+    if (!slug) {
+      return { state: "no-github", ahead: 0, behind: 0, remoteSha: null, checkedAt: now };
+    }
+    if (!snap.status.headSha || !snap.status.branch) {
+      return { state: "no-snapshot", ahead: 0, behind: 0, remoteSha: null, checkedAt: now };
+    }
+
+    // Invalidate ETag cache rows for this slug so we bypass 304 caching.
+    const likeCommits = `commits:${slug.owner}/${slug.name}:%`;
+    const likeCompare = `compare:${slug.owner}/${slug.name}:%`;
+    getDb().prepare("DELETE FROM gh_etag_cache WHERE key LIKE ?").run(likeCommits);
+    getDb().prepare("DELETE FROM gh_etag_cache WHERE key LIKE ?").run(likeCompare);
+
+    // Run remote checks in parallel; errors are swallowed by each helper.
+    const [comparison, prCount, canPush] = await Promise.all([
+      compareWithRemote(slug, snap.status.headSha, snap.status.branch),
+      fetchOpenPrCount(slug),
+      fetchCanPush(slug),
+    ]);
+
+    upsertSnapshot(row.id, snap, comparison, [], Date.now(), prCount, canPush);
+    getStore().emitUpdate(repoId);
+
+    return {
+      state: comparison.state,
+      ahead: comparison.ahead,
+      behind: comparison.behind,
+      remoteSha: comparison.remoteSha,
+      checkedAt: comparison.checkedAt,
+    };
   }
 
   async collectAllLocal(): Promise<void> {

--- a/lib/scan/scheduler.ts
+++ b/lib/scan/scheduler.ts
@@ -147,9 +147,10 @@ class Scheduler {
 
     // Collect current local state first.
     let snap;
+    let weirdFlags: string[] = [];
     try {
       snap = await collectSnapshot({ path: row.repoPath });
-      const weirdFlags = await detectWeirdFlags(row.repoPath);
+      weirdFlags = await detectWeirdFlags(row.repoPath);
       if (snap.remoteUrl && !row.githubOwner) {
         updateGithubSlug(row.id, snap.remoteUrl);
       }
@@ -179,7 +180,7 @@ class Scheduler {
       fetchCanPush(slug),
     ]);
 
-    upsertSnapshot(row.id, snap, comparison, [], Date.now(), prCount, canPush);
+    upsertSnapshot(row.id, snap, comparison, weirdFlags, Date.now(), prCount, canPush);
     getStore().emitUpdate(repoId);
 
     return {


### PR DESCRIPTION
## Summary

- Adds `Scheduler.refreshRemoteOne(repoId)` that invalidates `gh_etag_cache` rows for the repo's slug, then runs `compareWithRemote` + `fetchOpenPrCount` + `fetchCanPush` in parallel and writes the result to the snapshot.
- Adds `POST /api/repos/[id]/refresh-remote` — CSRF-validated, in-memory rate-limited (5 s/repo, 429 with `retryAfterMs` on hit).
- Updates `RowIcons` in `RepoCard.tsx` to hit the new endpoint instead of the local-only `/refresh`, showing spinning/rate-limited/error states and a tooltip with "Last remote check: N ago".
- Adds a ⚠ indicator next to the repo name (desktop row) when `remoteState === "unknown"` and the last check was > 5 min ago, with a tooltip explaining possible causes.

Depends on #108 (already merged) which fixed `gh` CLI 304 being treated as failure — without that, this refresh would silently return `unknown` on cached repos.

## Test plan

- [ ] `npm run build` clean ✓
- [ ] `npm run typecheck` clean ✓
- [ ] `/tmp/verify-102.mts` passes: stale cache invalidated, rate limiter blocks immediate re-call ✓
- [ ] Manual: open dashboard, click refresh icon on a repo, observe spinning → row updates via SSE
- [ ] Manual: click refresh twice quickly → second click does nothing (disabled), server returns 429
- [ ] Manual: find a repo with `remoteState=unknown` that hasn't been checked in >5 min → ⚠ appears next to name

## Response shapes

```json
// 200
{ "state": "clean", "ahead": 0, "behind": 0, "remoteSha": "abc123...", "checkedAt": 1750000000000 }

// 429
{ "error": "rate-limited", "retryAfterMs": 3241 }
```

Closes #102