### PR TITLE
feat(ui): version badge in dashboard footer (#110)

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import { Instrument_Serif, Instrument_Sans, IBM_Plex_Mono } from "next/font/google";
 import "./globals.css";
+import { VersionBadge } from "@/components/VersionBadge";
 
 const serif = Instrument_Serif({
   subsets: ["latin"],
@@ -43,7 +44,10 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
       <head>
         <script dangerouslySetInnerHTML={{ __html: themeBootScript }} />
       </head>
-      <body suppressHydrationWarning>{children}</body>
+      <body suppressHydrationWarning>
+        {children}
+        <VersionBadge />
+      </body>
     </html>
   );
 }

--- a/components/VersionBadge.tsx
+++ b/components/VersionBadge.tsx
@@ -1,0 +1,45 @@
+"use client";
+
+import { useState } from "react";
+import { cn } from "@/lib/utils";
+
+const VERSION = process.env.NEXT_PUBLIC_GITDASH_VERSION ?? "";
+const COMMIT = process.env.NEXT_PUBLIC_GITDASH_COMMIT ?? "";
+const BUILT_AT = process.env.NEXT_PUBLIC_GITDASH_BUILT_AT ?? "";
+
+export function VersionBadge() {
+  const [copied, setCopied] = useState(false);
+  if (!VERSION && !COMMIT) return null;
+
+  const display = [VERSION && `v${VERSION}`, COMMIT].filter(Boolean).join(" · ");
+  const copyText = `gitdash ${display.replaceAll(" · ", " (")}${COMMIT ? ")" : ""}`;
+  const builtAtTooltip = BUILT_AT
+    ? `Built ${new Date(Number(BUILT_AT)).toLocaleString()}`
+    : "";
+
+  async function handleClick() {
+    try {
+      await navigator.clipboard.writeText(copyText);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 1500);
+    } catch {
+      // clipboard may be unavailable on http (non-localhost) — just no-op
+    }
+  }
+
+  return (
+    <button
+      type="button"
+      onClick={handleClick}
+      title={builtAtTooltip || "Click to copy version"}
+      className={cn(
+        "fixed bottom-2 right-2 z-50 select-none rounded-md px-2 py-0.5 text-xs",
+        "text-fg-dim opacity-40 transition-opacity hover:opacity-100",
+        "font-mono tracking-tight",
+      )}
+      aria-label="gitdash version"
+    >
+      {copied ? "copied!" : display}
+    </button>
+  );
+}

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,7 +1,20 @@
 import path from "node:path";
 import { fileURLToPath } from "node:url";
+import { execSync } from "node:child_process";
+import { readFileSync } from "node:fs";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+let commit = "";
+let builtAt = String(Date.now());
+try {
+  commit = execSync("git rev-parse --short HEAD", { encoding: "utf8" }).trim();
+} catch {}
+let version = "";
+try {
+  const pkg = JSON.parse(readFileSync("./package.json", "utf8"));
+  version = pkg.version ?? "";
+} catch {}
 
 /** @type {import('next').NextConfig} */
 const nextConfig = {
@@ -11,6 +24,11 @@ const nextConfig = {
   serverExternalPackages: ["better-sqlite3", "chokidar"],
   typescript: { ignoreBuildErrors: false },
   eslint: { ignoreDuringBuilds: false },
+  env: {
+    NEXT_PUBLIC_GITDASH_VERSION: version,
+    NEXT_PUBLIC_GITDASH_COMMIT: commit,
+    NEXT_PUBLIC_GITDASH_BUILT_AT: builtAt,
+  },
 };
 
 export default nextConfig;


### PR DESCRIPTION
Closes #110

## What changed

- `next.config.mjs`: reads `package.json` version + git short SHA + build timestamp at build time, injects as `NEXT_PUBLIC_*` env vars
- `components/VersionBadge.tsx`: new client component — fixed bottom-right badge showing `v0.1.0 · <sha>`, subtle (opacity 40%) until hover, click-to-copy via Clipboard API with 1.5 s "copied!" confirmation
- `app/layout.tsx`: mounts `<VersionBadge />` just before `</body>`

## Test plan

- [ ] `npm run build` — passes clean, no TS/lint errors
- [ ] `npm run typecheck` — passes clean
- [ ] Visit dashboard → see `v0.1.0 · <7-char-sha>` badge bottom-right at low opacity
- [ ] Hover → opacity 100%, tooltip shows build date/time
- [ ] Click → "copied!" feedback for 1.5 s; paste confirms `gitdash v0.1.0 (<sha>)`
- [ ] On HTTP LAN (e.g. phone at `http://192.168.x.x:7420`) → badge visible, click silently no-ops if clipboard API unavailable

## Tradeoffs

- Build-time bake: SHA reflects the commit at build time, not runtime. Correct for production installs.
- Clipboard on non-secure origins (HTTP over LAN) fails silently — acceptable per spec; badge still displays version info.

🤖 Generated with [Claude Code](https://claude.com/claude-code)