### PR TITLE
feat(ui): version auto-update banner with /api/version polling (#114)

### DIFF
--- a/app/api/version/route.ts
+++ b/app/api/version/route.ts
@@ -1,0 +1,20 @@
+import { NextResponse } from "next/server";
+
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
+
+const VERSION = process.env.NEXT_PUBLIC_GITDASH_VERSION ?? "";
+const COMMIT = process.env.NEXT_PUBLIC_GITDASH_COMMIT ?? "";
+const BUILT_AT = process.env.NEXT_PUBLIC_GITDASH_BUILT_AT ?? "";
+
+export async function GET() {
+  return NextResponse.json(
+    { version: VERSION, commit: COMMIT, builtAt: BUILT_AT },
+    {
+      headers: {
+        "Cache-Control": "no-store, must-revalidate",
+        Pragma: "no-cache",
+      },
+    },
+  );
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next";
 import { Instrument_Serif, Instrument_Sans, IBM_Plex_Mono } from "next/font/google";
 import "./globals.css";
 import { VersionBadge } from "@/components/VersionBadge";
+import { UpdateBanner } from "@/components/UpdateBanner";
 
 const serif = Instrument_Serif({
   subsets: ["latin"],
@@ -46,6 +47,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
       </head>
       <body suppressHydrationWarning>
         {children}
+        <UpdateBanner />
         <VersionBadge />
       </body>
     </html>

--- a/components/UpdateBanner.tsx
+++ b/components/UpdateBanner.tsx
@@ -1,0 +1,79 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { cn } from "@/lib/utils";
+
+const BUNDLED_COMMIT = process.env.NEXT_PUBLIC_GITDASH_COMMIT ?? "";
+
+export function UpdateBanner() {
+  const [serverCommit, setServerCommit] = useState<string | null>(null);
+
+  useEffect(() => {
+    // Don't poll if we have nothing to compare against (e.g. tarball install)
+    if (!BUNDLED_COMMIT) return;
+
+    let cancelled = false;
+
+    async function check() {
+      try {
+        const res = await fetch("/api/version", { cache: "no-store" });
+        if (!res.ok) return;
+        const data = (await res.json()) as { commit?: string };
+        if (!cancelled && data.commit) setServerCommit(data.commit);
+      } catch {
+        // ignore network blips
+      }
+    }
+
+    check();
+    const interval = setInterval(check, 30_000);
+
+    function onFocus() {
+      check();
+    }
+
+    function onVisibilityChange() {
+      if (!document.hidden) check();
+    }
+
+    window.addEventListener("focus", onFocus);
+    document.addEventListener("visibilitychange", onVisibilityChange);
+
+    return () => {
+      cancelled = true;
+      clearInterval(interval);
+      window.removeEventListener("focus", onFocus);
+      document.removeEventListener("visibilitychange", onVisibilityChange);
+    };
+  }, []);
+
+  // No BUNDLED_COMMIT means we can't compare — render nothing
+  if (!BUNDLED_COMMIT) return null;
+
+  // Still loading or commits match — no banner needed
+  if (!serverCommit || serverCommit === BUNDLED_COMMIT) return null;
+
+  return (
+    <div
+      className={cn(
+        "fixed top-2 left-1/2 z-50 -translate-x-1/2",
+        "rounded-md border border-accent-positive bg-bg-elevated px-4 py-2",
+        "shadow-lg",
+        "flex items-center gap-3 text-sm text-fg",
+      )}
+      role="status"
+    >
+      <span>A new version of gitdash is available.</span>
+      <button
+        type="button"
+        onClick={() => window.location.reload()}
+        className={cn(
+          "rounded-md bg-accent-positive px-3 py-1 text-sm font-medium",
+          "text-bg hover:opacity-90",
+        )}
+      >
+        Reload
+      </button>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

- Adds `GET /api/version` — returns `{ version, commit, builtAt }` baked at build time; `Cache-Control: no-store, must-revalidate` prevents stale responses
- Adds `UpdateBanner` client component that polls `/api/version` every 30s, on window focus, and on tab visibility restore; shows a fixed banner when server commit differs from bundled commit
- Mounts `<UpdateBanner />` in `app/layout.tsx` beside the existing `<VersionBadge />`

Closes #114

## Test plan

- [ ] `npm run build && npm run typecheck` — both clean (verified)
- [ ] Start dev server; open dashboard — no banner visible (commits match)
- [ ] Stop server, rebuild with a different `HEAD` commit (or patch `NEXT_PUBLIC_GITDASH_COMMIT` in `next.config.mjs`), restart
- [ ] Existing browser tab shows banner within 30s — or immediately on refocus / tab switch
- [ ] Click **Reload** — page reloads with new bundle, banner gone
- [ ] `curl -i http://localhost:7420/api/version` — confirm `Cache-Control: no-store, must-revalidate` header present and JSON body contains `version`/`commit`/`builtAt`
- [ ] When `NEXT_PUBLIC_GITDASH_COMMIT` is empty (tarball install), no banner and no polling

🤖 Generated with [Claude Code](https://claude.com/claude-code)