### PR TITLE
docs(readme): note auto-update banner in update workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,8 @@ cd gitdash && git pull && ./install.sh
 
 Re-running the installer is safe — it stops, rebuilds, and restarts cleanly.
 
+Any browser tab already open on the dashboard will detect the new version within 30 seconds and show a **"new version available — reload"** banner. No manual hard-refresh needed.
+
 ---
 
 ## 🗑️ Remove gitdash


### PR DESCRIPTION
Adds a one-line note under the Update section pointing out that open tabs will see a reload prompt after deploys. No code changes.