### PR TITLE
fix(install): set git user.email/user.name during install (#121)

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -63,6 +63,30 @@ step "1/6 Preflight checks"
   exit 1
 }
 
+# Without a git identity, the very first Commit & push from the dashboard
+# fails with the cryptic "Author identity unknown" block. Set defaults from
+# the gh-authenticated account using the GitHub noreply email so the user's
+# real address never lands in commit metadata.
+if ! git config --global --get user.email >/dev/null 2>&1 || \
+   ! git config --global --get user.name >/dev/null 2>&1; then
+  if command -v gh >/dev/null 2>&1 && gh auth status >/dev/null 2>&1; then
+    GH_LOGIN="$(gh api user --jq '.login' 2>/dev/null || echo "")"
+    GH_ID="$(gh api user --jq '.id' 2>/dev/null || echo "")"
+    GH_NAME="$(gh api user --jq '.name // .login' 2>/dev/null || echo "")"
+    if [[ -n "$GH_LOGIN" && -n "$GH_ID" ]]; then
+      git config --global user.email "${GH_ID}+${GH_LOGIN}@users.noreply.github.com"
+      git config --global user.name "${GH_NAME:-$GH_LOGIN}"
+      green "  set git user.email = ${GH_ID}+${GH_LOGIN}@users.noreply.github.com (GitHub noreply)"
+      green "  set git user.name  = ${GH_NAME:-$GH_LOGIN}"
+    fi
+  else
+    dim "  gh not authenticated — git user.email/user.name not set."
+    dim "  Run manually before first commit:"
+    dim "    git config --global user.email \"you@example.com\""
+    dim "    git config --global user.name  \"Your Name\""
+  fi
+fi
+
 # ─────────────────────────────────────────────────────────
 step "2/6 Installing dependencies"
 cd "$REPO_DIR"

--- a/scripts/quick-install.sh
+++ b/scripts/quick-install.sh
@@ -288,6 +288,33 @@ ensure_gh_auth() {
   else
     warn "gh auth setup-git failed — you may still hit auth errors on push"
   fi
+
+  # Ensure git identity is configured. Without this, every first commit fails
+  # with the cryptic "Author identity unknown" block and gitdash's Commit
+  # & push button leads beginners to a wall of git output. Derive defaults
+  # from the gh-authenticated account; use the GitHub noreply email so the
+  # user's real address never lands in commit metadata.
+  if git config --global --get user.email >/dev/null 2>&1 && \
+     git config --global --get user.name >/dev/null 2>&1; then
+    ok "git identity already set ($(git config --global --get user.email))"
+  else
+    local gh_login gh_id gh_name email name
+    gh_login="$(gh api user --jq '.login' 2>/dev/null || echo "")"
+    gh_id="$(gh api user --jq '.id' 2>/dev/null || echo "")"
+    gh_name="$(gh api user --jq '.name // .login' 2>/dev/null || echo "")"
+    if [ -n "$gh_login" ] && [ -n "$gh_id" ]; then
+      email="${gh_id}+${gh_login}@users.noreply.github.com"
+      name="${gh_name:-$gh_login}"
+      git config --global user.email "$email"
+      git config --global user.name "$name"
+      ok "set git user.email = $email"
+      ok "set git user.name  = $name"
+    else
+      warn "could not derive identity from gh — set manually:"
+      printf '    git config --global user.email "you@example.com"\n'
+      printf '    git config --global user.name  "Your Name"\n'
+    fi
+  fi
 }
 
 # ---- clone / update --------------------------------------------------------


### PR DESCRIPTION
Closes #121. Tested syntax of both shell scripts. Existing identity preserved (idempotent). gh-not-authed path warns gracefully.