### PR TITLE
feat(uninstall): parity across Linux, macOS, Windows (#127)

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,17 +6,17 @@
 
 ---
 
-## ⚡ Install
+## ⚡ Install & uninstall
 
-**Pick your operating system and follow only the steps in that section.**
+**Pick your operating system and follow only the steps in that section.** Each section bundles Install and Uninstall together — no hunting around.
 
-- [🐧 Linux — install](#-linux--install)
-- [🪟 Windows — install](#-windows--install)
-- [🍎 macOS — install](#-macos--install)
+- [🐧 Linux](#-linux)
+- [🪟 Windows](#-windows)
+- [🍎 macOS](#-macos)
 
 ---
 
-## 🐧 Linux — install
+## 🐧 Linux
 
 Works on Ubuntu, Debian, Fedora, Arch, and most other mainstream distros.
 
@@ -43,7 +43,7 @@ Look at your prompt right now:
 - Windows → [🪟 Windows — install](#-windows--install)
 - macOS → [🍎 macOS — install](#-macos--install)
 
-### Paste one of these at your Linux prompt
+### Install
 
 **Quick install (recommended):**
 
@@ -61,11 +61,27 @@ The installer prints a URL when it's done — open it in your browser.
 
 > ❓ Missing `git`, `node 20+`, or `gh`? See [Prereqs](#-prereqs).
 
+### Uninstall
+
+Stops the service, removes the launcher. Source clone is left in place.
+
+```bash
+bash <(curl -fsSL https://raw.githubusercontent.com/imwebdev/gitdash/main/scripts/quick-uninstall.sh)
+bash <(curl -fsSL https://raw.githubusercontent.com/imwebdev/gitdash/main/scripts/quick-uninstall.sh) --purge   # also wipe DB + config
+```
+
+Or if you have the source clone:
+
+```bash
+cd ~/gitdash && ./uninstall.sh           # service only
+cd ~/gitdash && ./uninstall.sh --purge   # also wipe the database
+```
+
 ---
 
-## 🪟 Windows — install
+## 🪟 Windows
 
-### One command. Paste into PowerShell.
+### Install
 
 Open **PowerShell** (press `Win + R`, type `powershell`, press Enter) and paste this:
 
@@ -79,6 +95,23 @@ That's it. The script handles everything:
 2. After you reboot and Ubuntu is set up (it asks for a Linux username + password the first time), **paste the same PowerShell command again**. It will detect WSL is ready and install gitdash.
 3. When it's done, open a new PowerShell window, type `wsl`, then type `gitdash start`, and open http://127.0.0.1:7420 in any Windows browser.
 
+### Uninstall
+
+Removes the `gitdash.cmd` shim from `%LOCALAPPDATA%\gitdash`, strips it from your user PATH, and runs the bash uninstaller inside WSL.
+
+```powershell
+iwr -useb https://raw.githubusercontent.com/imwebdev/gitdash/main/scripts/quick-uninstall.ps1 | iex
+```
+
+To also wipe the WSL-side config + SQLite database:
+
+```powershell
+$env:GITDASH_PURGE='1'
+iwr -useb https://raw.githubusercontent.com/imwebdev/gitdash/main/scripts/quick-uninstall.ps1 | iex
+```
+
+It does **not** `wsl --unregister Ubuntu` — that would nuke anything else you've put in WSL. Run that yourself if you want the distro itself gone.
+
 ### Common errors you can ignore now
 
 If you previously tried the Linux command in PowerShell and got `The token '&&' is not a valid statement separator` or `The '<' operator is reserved for future use` — that's PowerShell rejecting bash syntax. Use the PowerShell command above instead. It's native PowerShell and paste-safe.
@@ -89,7 +122,9 @@ gitdash uses Linux-only features (`systemd`, bash scripts). It can't run on Wind
 
 ---
 
-## 🍎 macOS — install
+## 🍎 macOS
+
+### Install
 
 Open **Terminal** (⌘+Space → type "Terminal" → Enter) and paste:
 
@@ -106,6 +141,15 @@ gitdash start
 ```
 
 …then open http://127.0.0.1:7420 in Safari / Chrome / Arc / whatever.
+
+### Uninstall
+
+Stops any running `gitdash start` process, removes `~/.local/bin/gitdash`, leaves the source clone alone.
+
+```bash
+bash <(curl -fsSL https://raw.githubusercontent.com/imwebdev/gitdash/main/scripts/quick-uninstall.sh)
+bash <(curl -fsSL https://raw.githubusercontent.com/imwebdev/gitdash/main/scripts/quick-uninstall.sh) --purge   # also wipe DB + config
+```
 
 ### macOS limitations today
 
@@ -144,52 +188,6 @@ cd gitdash && git pull && ./install.sh
 Re-running the installer is safe — it stops, rebuilds, and restarts cleanly.
 
 Any browser tab already open on the dashboard will detect the new version within 30 seconds and show a **"new version available — reload"** banner. No manual hard-refresh needed.
-
----
-
-## 🗑️ Remove gitdash
-
-Pick the section for your OS — same idea as install. Each one-liner stops gitdash, removes the launcher, and leaves your source clone in place. Add `--purge` (Linux/macOS) or `$env:GITDASH_PURGE='1'` (Windows) to also wipe the SQLite database + config.
-
-### 🐧 Linux
-
-```bash
-bash <(curl -fsSL https://raw.githubusercontent.com/imwebdev/gitdash/main/scripts/quick-uninstall.sh)
-bash <(curl -fsSL https://raw.githubusercontent.com/imwebdev/gitdash/main/scripts/quick-uninstall.sh) --purge
-```
-
-Or if you have the source clone:
-
-```bash
-cd ~/gitdash && ./uninstall.sh           # service only
-cd ~/gitdash && ./uninstall.sh --purge   # also wipe the database
-```
-
-### 🍎 macOS
-
-```bash
-bash <(curl -fsSL https://raw.githubusercontent.com/imwebdev/gitdash/main/scripts/quick-uninstall.sh)
-bash <(curl -fsSL https://raw.githubusercontent.com/imwebdev/gitdash/main/scripts/quick-uninstall.sh) --purge
-```
-
-Stops any running `gitdash start` process, removes `~/.local/bin/gitdash`, leaves the clone alone.
-
-### 🪟 Windows
-
-```powershell
-iwr -useb https://raw.githubusercontent.com/imwebdev/gitdash/main/scripts/quick-uninstall.ps1 | iex
-```
-
-Removes the `gitdash.cmd` shim from `%LOCALAPPDATA%\gitdash`, strips it from your user PATH, and runs the bash uninstaller inside WSL. To also wipe the WSL-side config + database:
-
-```powershell
-$env:GITDASH_PURGE='1'
-iwr -useb https://raw.githubusercontent.com/imwebdev/gitdash/main/scripts/quick-uninstall.ps1 | iex
-```
-
-It does **not** `wsl --unregister Ubuntu` — that would nuke anything else you've put in WSL. If you want the WSL distro itself gone, run that command yourself.
-
-The repo files stay where they are — delete them yourself if you want gitdash entirely off the disk.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -149,12 +149,47 @@ Any browser tab already open on the dashboard will detect the new version within
 
 ## 🗑️ Remove gitdash
 
+Pick the section for your OS — same idea as install. Each one-liner stops gitdash, removes the launcher, and leaves your source clone in place. Add `--purge` (Linux/macOS) or `$env:GITDASH_PURGE='1'` (Windows) to also wipe the SQLite database + config.
+
+### 🐧 Linux
+
 ```bash
-cd gitdash && ./uninstall.sh           # service only
-cd gitdash && ./uninstall.sh --purge   # also wipe the database
+bash <(curl -fsSL https://raw.githubusercontent.com/imwebdev/gitdash/main/scripts/quick-uninstall.sh)
+bash <(curl -fsSL https://raw.githubusercontent.com/imwebdev/gitdash/main/scripts/quick-uninstall.sh) --purge
 ```
 
-The repo files stay where they are — delete them yourself if you want.
+Or if you have the source clone:
+
+```bash
+cd ~/gitdash && ./uninstall.sh           # service only
+cd ~/gitdash && ./uninstall.sh --purge   # also wipe the database
+```
+
+### 🍎 macOS
+
+```bash
+bash <(curl -fsSL https://raw.githubusercontent.com/imwebdev/gitdash/main/scripts/quick-uninstall.sh)
+bash <(curl -fsSL https://raw.githubusercontent.com/imwebdev/gitdash/main/scripts/quick-uninstall.sh) --purge
+```
+
+Stops any running `gitdash start` process, removes `~/.local/bin/gitdash`, leaves the clone alone.
+
+### 🪟 Windows
+
+```powershell
+iwr -useb https://raw.githubusercontent.com/imwebdev/gitdash/main/scripts/quick-uninstall.ps1 | iex
+```
+
+Removes the `gitdash.cmd` shim from `%LOCALAPPDATA%\gitdash`, strips it from your user PATH, and runs the bash uninstaller inside WSL. To also wipe the WSL-side config + database:
+
+```powershell
+$env:GITDASH_PURGE='1'
+iwr -useb https://raw.githubusercontent.com/imwebdev/gitdash/main/scripts/quick-uninstall.ps1 | iex
+```
+
+It does **not** `wsl --unregister Ubuntu` — that would nuke anything else you've put in WSL. If you want the WSL distro itself gone, run that command yourself.
+
+The repo files stay where they are — delete them yourself if you want gitdash entirely off the disk.
 
 ---
 

--- a/scripts/quick-uninstall.ps1
+++ b/scripts/quick-uninstall.ps1
@@ -1,0 +1,133 @@
+# gitdash quick-uninstall for Windows (PowerShell)
+#
+# Usage (paste into any normal PowerShell window):
+#   iwr -useb https://raw.githubusercontent.com/imwebdev/gitdash/main/scripts/quick-uninstall.ps1 | iex
+#
+# To also wipe the SQLite database + config inside WSL, set $env:GITDASH_PURGE
+# before piping (PowerShell can't pass args through `iwr | iex`):
+#   $env:GITDASH_PURGE='1'
+#   iwr -useb https://raw.githubusercontent.com/imwebdev/gitdash/main/scripts/quick-uninstall.ps1 | iex
+#
+# What it does (idempotent):
+#   1. Removes the gitdash.cmd shim from %LOCALAPPDATA%\gitdash
+#   2. Strips that directory from your user PATH (and current session PATH)
+#   3. Runs the cross-platform bash uninstaller inside WSL to clean up the
+#      gitdash service + launcher inside Ubuntu
+#   4. (Optional) --purge wipes the WSL-side config + SQLite DB
+#
+# What it does NOT do:
+#   - It does not run `wsl --unregister Ubuntu`. That would nuke your entire
+#     WSL Ubuntu and anything else you put there. If you genuinely want that,
+#     run it yourself: `wsl --unregister Ubuntu`
+
+$ErrorActionPreference = 'Stop'
+
+function Write-Step([string]$msg) { Write-Host "`n-> $msg" -ForegroundColor Cyan }
+function Write-Ok([string]$msg)   { Write-Host "   [ok] $msg" -ForegroundColor Green }
+function Write-Warn([string]$msg) { Write-Host "   [!] $msg" -ForegroundColor Yellow }
+function Write-Fail([string]$msg) { Write-Host "   [x] $msg" -ForegroundColor Red }
+function Die([string]$msg)        { Write-Fail $msg; exit 1 }
+
+$Purge = $env:GITDASH_PURGE -eq '1'
+
+Write-Host ""
+Write-Host "==================================" -ForegroundColor Cyan
+Write-Host "  gitdash uninstaller for Windows " -ForegroundColor Cyan
+Write-Host "==================================" -ForegroundColor Cyan
+Write-Host ""
+if ($Purge) {
+    Write-Host "Mode: --purge (will also wipe SQLite database + config)" -ForegroundColor Yellow
+} else {
+    Write-Host "Mode: standard (keeps your config + database; set `$env:GITDASH_PURGE='1' to wipe)"
+}
+
+# -----------------------------------------------------------------------------
+# Step 1: Remove the Windows shim and clean up PATH
+# -----------------------------------------------------------------------------
+Write-Step "Removing Windows launcher shim"
+
+$shimDir  = Join-Path $env:LOCALAPPDATA 'gitdash'
+$shimPath = Join-Path $shimDir 'gitdash.cmd'
+
+if (Test-Path $shimPath) {
+    Remove-Item -Force $shimPath
+    Write-Ok "Removed $shimPath"
+}
+if (Test-Path $shimDir) {
+    # Only remove the dir if empty (paranoia: don't blow away anything the
+    # user might have dropped in there).
+    if (-not (Get-ChildItem -Force $shimDir)) {
+        Remove-Item -Force $shimDir
+        Write-Ok "Removed empty $shimDir"
+    } else {
+        Write-Warn "$shimDir is not empty - left in place"
+    }
+}
+
+# Strip from persistent user PATH
+$userPath = [Environment]::GetEnvironmentVariable('Path', 'User')
+if ($userPath) {
+    $entries = $userPath -split ';' | Where-Object { $_ -and $_ -ne $shimDir }
+    $newUserPath = ($entries -join ';')
+    if ($newUserPath -ne $userPath) {
+        [Environment]::SetEnvironmentVariable('Path', $newUserPath, 'User')
+        Write-Ok "Removed $shimDir from user PATH"
+    }
+}
+
+# Strip from current session PATH too
+$sessionEntries = $env:Path -split ';' | Where-Object { $_ -and $_ -ne $shimDir }
+$env:Path = ($sessionEntries -join ';')
+
+# -----------------------------------------------------------------------------
+# Step 2: Run the bash uninstaller inside WSL
+# -----------------------------------------------------------------------------
+$wslAvailable = $null -ne (Get-Command wsl -ErrorAction SilentlyContinue)
+if (-not $wslAvailable) {
+    Write-Warn "WSL is not installed - nothing to clean up on the Linux side."
+    Write-Host ""
+    Write-Ok "Windows-side cleanup complete."
+    exit 0
+}
+
+Write-Step "Running the gitdash uninstaller inside WSL"
+
+# Build the bash command. quick-uninstall.sh handles install location lookup
+# and forwards --purge to the in-tree uninstall.sh.
+$bashCmd = 'curl -fsSL https://raw.githubusercontent.com/imwebdev/gitdash/main/scripts/quick-uninstall.sh | bash'
+if ($Purge) {
+    $bashCmd = 'curl -fsSL https://raw.githubusercontent.com/imwebdev/gitdash/main/scripts/quick-uninstall.sh | bash -s -- --purge'
+}
+
+wsl bash -c $bashCmd
+$exitCode = $LASTEXITCODE
+
+if ($exitCode -ne 0) {
+    Write-Warn "WSL-side uninstaller exited with code $exitCode (continuing - Windows-side cleanup already done)."
+}
+
+# -----------------------------------------------------------------------------
+# Done
+# -----------------------------------------------------------------------------
+Write-Host ""
+Write-Host "==================================" -ForegroundColor Green
+Write-Host "  gitdash uninstall complete       " -ForegroundColor Green
+Write-Host "==================================" -ForegroundColor Green
+Write-Host ""
+Write-Host "What's gone:"
+Write-Host "  - $shimPath (Windows launcher)"
+Write-Host "  - User PATH entry for $shimDir"
+Write-Host "  - gitdash systemd unit + launcher inside WSL"
+if ($Purge) {
+    Write-Host "  - WSL-side config + SQLite database (--purge)"
+}
+Write-Host ""
+Write-Host "What's still here:"
+Write-Host "  - Your WSL distro (Ubuntu) and everything else inside it"
+Write-Host "  - The gitdash source clone inside WSL (~/gitdash by default)"
+if (-not $Purge) {
+    Write-Host "  - Your gitdash config + SQLite database (re-run with `$env:GITDASH_PURGE='1' to wipe)"
+}
+Write-Host ""
+Write-Host "If you also want WSL gone entirely: wsl --unregister Ubuntu" -ForegroundColor DarkGray
+Write-Host ""

--- a/scripts/quick-uninstall.sh
+++ b/scripts/quick-uninstall.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+# gitdash quick-uninstall for Linux + macOS.
+#
+# Usage (from any shell):
+#   bash <(curl -fsSL https://raw.githubusercontent.com/imwebdev/gitdash/main/scripts/quick-uninstall.sh)
+#   bash <(curl -fsSL https://raw.githubusercontent.com/imwebdev/gitdash/main/scripts/quick-uninstall.sh) --purge
+#
+# What it does:
+#   1. Locates the gitdash install (env GITDASH_HOME, then ~/gitdash, then
+#      legacy ~/.local/share/gitdash)
+#   2. Delegates to that install's ./uninstall.sh (cross-platform)
+#   3. Forwards --purge if you passed it
+#
+# It does NOT delete the source tree itself - the repo is left in place so
+# you can re-install with `cd ~/gitdash && ./install.sh` later. Delete the
+# directory yourself if you want it gone.
+
+set -euo pipefail
+
+C_GREEN=$'\033[0;32m'; C_YELLOW=$'\033[0;33m'; C_RED=$'\033[0;31m'; C_DIM=$'\033[2m'; C_RESET=$'\033[0m'
+ok()   { printf "%s[ok]%s %s\n" "$C_GREEN"  "$C_RESET" "$*"; }
+warn() { printf "%s[!]%s %s\n"  "$C_YELLOW" "$C_RESET" "$*"; }
+die()  { printf "%s[x]%s %s\n"  "$C_RED"    "$C_RESET" "$*" >&2; exit 1; }
+dim()  { printf "%s%s%s\n"      "$C_DIM"    "$*"        "$C_RESET"; }
+
+# Pass through every CLI arg to the underlying uninstall.sh
+ARGS=("$@")
+
+# ---------- locate the install ----------------------------------------------
+DEFAULT_INSTALL_DIR="$HOME/gitdash"
+LEGACY_INSTALL_DIR="${XDG_DATA_HOME:-$HOME/.local/share}/gitdash"
+
+if [[ -n "${GITDASH_HOME:-}" ]]; then
+  INSTALL_DIR="$GITDASH_HOME"
+elif [[ -d "$DEFAULT_INSTALL_DIR/.git" ]]; then
+  INSTALL_DIR="$DEFAULT_INSTALL_DIR"
+elif [[ -d "$LEGACY_INSTALL_DIR/.git" ]]; then
+  INSTALL_DIR="$LEGACY_INSTALL_DIR"
+else
+  die "Could not find a gitdash install. Looked in:
+    \$GITDASH_HOME (unset)
+    $DEFAULT_INSTALL_DIR
+    $LEGACY_INSTALL_DIR
+  If gitdash is installed somewhere else, set GITDASH_HOME=/path/to/gitdash and re-run."
+fi
+
+ok "Found install at $INSTALL_DIR"
+
+UNINSTALLER="$INSTALL_DIR/uninstall.sh"
+if [[ ! -x "$UNINSTALLER" ]]; then
+  die "Found install dir but no executable uninstall.sh at $UNINSTALLER"
+fi
+
+# ---------- delegate to in-tree uninstaller ---------------------------------
+"$UNINSTALLER" "${ARGS[@]}"
+
+echo
+ok "Done. Source tree at $INSTALL_DIR was NOT deleted."
+dim "    rm -rf \"$INSTALL_DIR\"   # if you also want the source gone"

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -1,13 +1,14 @@
 #!/usr/bin/env bash
 # uninstall.sh
 #
-# Cleanly removes the gitdash systemd unit. Optionally also wipes the SQLite
-# database and the persistent CSRF/env config. Does NOT delete the repo itself.
+# Cleanly removes gitdash. Works on Linux (systemd) and macOS (launchd-less
+# foreground process). Optionally also wipes the SQLite database and the
+# persistent CSRF/env config. Does NOT delete the repo itself.
 #
 # Usage:
-#   ./uninstall.sh                # remove unit only, keep config and DB
+#   ./uninstall.sh                # remove service/process + launcher, keep config and DB
 #   ./uninstall.sh --purge        # also delete config + DB (irreversible)
-#   ./uninstall.sh --no-linger    # also disable user lingering (sudo)
+#   ./uninstall.sh --no-linger    # also disable user lingering (Linux, sudo)
 #   ./uninstall.sh --help
 
 set -euo pipefail
@@ -17,6 +18,7 @@ SYSTEMD_DIR="${XDG_CONFIG_HOME:-$HOME/.config}/systemd/user"
 STATE_DIR="${XDG_STATE_HOME:-$HOME/.local/state}/gitdash"
 SERVICE_NAME="gitdash"
 SERVICE_FILE="$SYSTEMD_DIR/$SERVICE_NAME.service"
+LAUNCHER="$HOME/.local/bin/gitdash"
 
 PURGE=0
 DISABLE_LINGER=0
@@ -26,7 +28,9 @@ while [[ $# -gt 0 ]]; do
     --purge)      PURGE=1; shift ;;
     --no-linger)  DISABLE_LINGER=1; shift ;;
     --help|-h)
-      grep -E '^#( |$)' "$0" | sed 's/^# \{0,1\}//'
+      # Only print the leading docstring block (stop at the first non-comment
+      # line). Avoids leaking inline section-divider comments below.
+      awk '/^#!/ {next} /^# / || /^#$/ {sub(/^# ?/, ""); print; next} {exit}' "$0"
       exit 0
       ;;
     *) echo "Unknown flag: $1 (try --help)" >&2; exit 2 ;;
@@ -36,20 +40,54 @@ done
 green() { printf "\033[0;32m%s\033[0m\n" "$*"; }
 dim()   { printf "\033[2m%s\033[0m\n" "$*"; }
 
-if command -v systemctl >/dev/null 2>&1; then
+case "$(uname -s)" in
+  Linux*)  OS="linux"  ;;
+  Darwin*) OS="macos"  ;;
+  *)       OS="other"  ;;
+esac
+
+# ---------- Linux: stop + disable systemd unit -------------------------------
+if [[ "$OS" = "linux" ]] && command -v systemctl >/dev/null 2>&1; then
   if systemctl --user is-enabled "$SERVICE_NAME" >/dev/null 2>&1 || \
      systemctl --user is-active "$SERVICE_NAME" >/dev/null 2>&1; then
     systemctl --user disable --now "$SERVICE_NAME" 2>/dev/null || true
     green "Stopped + disabled $SERVICE_NAME"
   fi
+  if [[ -f "$SERVICE_FILE" ]]; then
+    rm -f "$SERVICE_FILE"
+    systemctl --user daemon-reload 2>/dev/null || true
+    green "Removed $SERVICE_FILE"
+  fi
 fi
 
-if [[ -f "$SERVICE_FILE" ]]; then
-  rm -f "$SERVICE_FILE"
-  command -v systemctl >/dev/null 2>&1 && systemctl --user daemon-reload || true
-  green "Removed $SERVICE_FILE"
+# ---------- macOS: kill any running gitdash foreground process ---------------
+# macOS doesn't (yet — see #21) get a launchd plist; users run `gitdash start`
+# in a shell. The actual long-running process is `next start` bound to 7420.
+if [[ "$OS" = "macos" ]]; then
+  # pgrep -f matches against the full command line. Match the next.js process
+  # bound to gitdash's port to avoid killing unrelated `next` instances.
+  pids=$(pgrep -f "next.*start.*-p[[:space:]]+7420" 2>/dev/null || true)
+  if [[ -n "$pids" ]]; then
+    # shellcheck disable=SC2086
+    kill $pids 2>/dev/null || true
+    sleep 1
+    # Force-kill anything still hanging on
+    # shellcheck disable=SC2086
+    pgrep -f "next.*start.*-p[[:space:]]+7420" >/dev/null 2>&1 && kill -9 $pids 2>/dev/null || true
+    green "Stopped running gitdash process(es)"
+  else
+    dim "No running gitdash process found"
+  fi
 fi
 
+# ---------- Cross-platform: remove the ~/.local/bin/gitdash launcher ---------
+# quick-install.sh symlinks the launcher there on both Linux and macOS.
+if [[ -L "$LAUNCHER" || -f "$LAUNCHER" ]]; then
+  rm -f "$LAUNCHER"
+  green "Removed launcher $LAUNCHER"
+fi
+
+# ---------- --purge: wipe config + state -------------------------------------
 if [[ $PURGE -eq 1 ]]; then
   if [[ -d "$CONFIG_DIR" ]]; then
     rm -rf "$CONFIG_DIR"
@@ -63,7 +101,8 @@ else
   dim "Kept $CONFIG_DIR and $STATE_DIR (use --purge to delete)"
 fi
 
-if [[ $DISABLE_LINGER -eq 1 ]]; then
+# ---------- Linux: optional disable-linger -----------------------------------
+if [[ "$OS" = "linux" && $DISABLE_LINGER -eq 1 ]]; then
   sudo loginctl disable-linger "$USER" 2>/dev/null && green "Disabled user linger" || \
     dim "Could not disable linger (may require sudo or wasn't enabled)"
 fi


### PR DESCRIPTION
Closes #127

## Summary
- `uninstall.sh` now cross-platform (Linux + macOS) — branches on `uname`. Linux path unchanged. macOS kills any `next start -p 7420` process and removes `~/.local/bin/gitdash`.
- `scripts/quick-uninstall.sh` — curl/bash one-liner for Linux + macOS. Locates the install, delegates to its `uninstall.sh`, supports `--purge`.
- `scripts/quick-uninstall.ps1` — iwr/iex one-liner for Windows. Removes the `gitdash.cmd` shim, strips it from user PATH (persistent + session), runs the bash uninstaller inside WSL. Does **not** `wsl --unregister Ubuntu`. `--purge` via `$env:GITDASH_PURGE='1'`.
- README: per-OS uninstall sections mirror the install layout.
- Drive-by: `uninstall.sh --help` now only prints the leading docstring (was leaking inline section comments).

## Why
Install one-liners exist for all three OSes; uninstall was Linux-only. A user who installed via the one-liner shouldn't have to clone the repo and grep through scripts to remove gitdash.

## Test plan
- [ ] Linux: `./uninstall.sh --help` shows just the docstring; `./uninstall.sh` stops the systemd unit; `--purge` wipes config + DB
- [ ] macOS (manual on a Mac): one-liner kills the running gitdash, removes `~/.local/bin/gitdash`, source clone untouched
- [ ] Windows: one-liner removes `%LOCALAPPDATA%\gitdash\gitdash.cmd`, strips it from user PATH (verify in a fresh PowerShell), runs the WSL-side uninstaller
- [ ] Windows `--purge` via `$env:GITDASH_PURGE='1'` wipes the WSL-side SQLite DB

## Note
Ordering: depends on PR #126 being merged first (the Windows uninstaller assumes the `gitdash.cmd` shim from #126 exists). If #126 hasn't merged when this is reviewed, the Windows side still works — it just no-ops the shim removal step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)