### PR TITLE
fix: in-UI Sign-in-to-GitHub button + NORTH STAR rule (#129)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,6 +2,27 @@
 
 This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 
+## NORTH STAR — gitdash is for beginners
+
+**The user of gitdash is a beginner.** Every interaction must be doable by clicking buttons in a browser. **No solution is acceptable that requires the end user to:**
+
+- Open a terminal (PowerShell, WSL, Terminal, bash, anything)
+- Type a shell command
+- Edit a config file by hand
+- Read a stack trace, error code, or technical jargon
+- Know what `gh`, `git`, `systemd`, `wsl`, `npm`, or any CLI tool is
+
+If a feature can fail in a way that requires the user to drop to a terminal to fix it, **that failure mode is a P0 bug** and must be fixed by adding a button in the UI that does the recovery automatically — not by writing a help-desk doc that says "run `gh auth login`".
+
+This rule applies to:
+- Install / uninstall (one-liner only; no manual cleanup)
+- Auth (gh, git credentials) — must be a button + browser flow, not a terminal command
+- Sync errors (push fails, pull fails, merge conflicts) — must surface in UI with a click-to-fix path
+- Service management (start/stop/status) — must be a button, not `systemctl`
+- Configuration changes — must be a settings page, not editing JSON
+
+**When triaging any bug or implementing any feature, ask: "can a beginner who has never used a terminal recover from this on their own?" If the answer is no, add a button before shipping.**
+
 ## Workflow — GitHub-first (mandatory)
 
 Inherited from `~/.claude/CLAUDE.md` and `~/CLAUDE.md`. **Every bug, feature, and task needs a GitHub issue before any code is written.** No exceptions, including when the user types a request directly into chat — first action is to create or find the issue.

--- a/app/api/github/auth/login/route.ts
+++ b/app/api/github/auth/login/route.ts
@@ -1,0 +1,31 @@
+import { NextResponse, type NextRequest } from "next/server";
+import { bootstrap } from "@/lib/bootstrap";
+import { validateCsrf } from "@/lib/security/csrf";
+import { startGhAuthLogin, isGhAuthenticated } from "@/lib/gh/auth";
+
+export async function POST(req: NextRequest) {
+  await bootstrap();
+
+  if (!validateCsrf(req.headers.get("x-csrf-token"))) {
+    return NextResponse.json({ error: "csrf" }, { status: 403 });
+  }
+
+  const existing = await isGhAuthenticated();
+  if (existing) {
+    return NextResponse.json({ alreadyAuthenticated: true, login: existing });
+  }
+
+  try {
+    const result = await startGhAuthLogin();
+    return NextResponse.json(result);
+  } catch (err) {
+    const message = (err as Error).message ?? String(err);
+    return NextResponse.json(
+      {
+        error: "could not start GitHub sign-in",
+        detail: message.slice(0, 500),
+      },
+      { status: 502 },
+    );
+  }
+}

--- a/app/api/github/auth/poll/route.ts
+++ b/app/api/github/auth/poll/route.ts
@@ -1,0 +1,25 @@
+import { NextResponse, type NextRequest } from "next/server";
+import { bootstrap } from "@/lib/bootstrap";
+import { getAuthState, isGhAuthenticated } from "@/lib/gh/auth";
+
+export async function GET(req: NextRequest) {
+  await bootstrap();
+
+  const runId = req.nextUrl.searchParams.get("runId");
+  if (!runId) {
+    return NextResponse.json({ error: "runId required" }, { status: 400 });
+  }
+
+  const state = getAuthState(runId);
+  if (!state) {
+    return NextResponse.json({ error: "unknown runId" }, { status: 404 });
+  }
+
+  if (state.state === "success") {
+    // Try to enrich with the actual login if gh auth completed.
+    const login = state.login || (await isGhAuthenticated()) || "";
+    return NextResponse.json({ state: "success", login });
+  }
+
+  return NextResponse.json(state);
+}

--- a/components/GhSignInModal.tsx
+++ b/components/GhSignInModal.tsx
@@ -1,0 +1,252 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import { Copy, Check, ExternalLink, Github, Loader2 } from "lucide-react";
+
+interface Props {
+  csrfToken: string;
+  onClose: () => void;
+  onSuccess: (login: string) => void;
+}
+
+type Phase =
+  | { kind: "starting" }
+  | {
+      kind: "waiting";
+      runId: string;
+      deviceCode: string;
+      verificationUri: string;
+    }
+  | { kind: "success"; login: string }
+  | { kind: "failed"; error: string };
+
+export function GhSignInModal({ csrfToken, onClose, onSuccess }: Props) {
+  const [phase, setPhase] = useState<Phase>({ kind: "starting" });
+  const [copied, setCopied] = useState(false);
+  const startedRef = useRef(false);
+
+  // Kick off the auth flow when the modal mounts (once).
+  useEffect(() => {
+    if (startedRef.current) return;
+    startedRef.current = true;
+
+    void (async () => {
+      try {
+        const res = await fetch("/api/github/auth/login", {
+          method: "POST",
+          headers: { "x-csrf-token": csrfToken },
+        });
+        const data = await res.json();
+        if (!res.ok) {
+          setPhase({
+            kind: "failed",
+            error: data.detail || data.error || "Sign-in failed",
+          });
+          return;
+        }
+        if (data.alreadyAuthenticated) {
+          setPhase({ kind: "success", login: data.login });
+          onSuccess(data.login);
+          return;
+        }
+        setPhase({
+          kind: "waiting",
+          runId: data.runId,
+          deviceCode: data.deviceCode,
+          verificationUri: data.verificationUri,
+        });
+      } catch (err) {
+        setPhase({ kind: "failed", error: (err as Error).message });
+      }
+    })();
+  }, [csrfToken, onSuccess]);
+
+  // Poll for completion while in the "waiting" phase.
+  useEffect(() => {
+    if (phase.kind !== "waiting") return;
+    let cancelled = false;
+    const runId = phase.runId;
+
+    const poll = async () => {
+      if (cancelled) return;
+      try {
+        const res = await fetch(
+          `/api/github/auth/poll?runId=${encodeURIComponent(runId)}`,
+        );
+        const data = await res.json();
+        if (cancelled) return;
+        if (data.state === "success") {
+          setPhase({ kind: "success", login: data.login || "" });
+          onSuccess(data.login || "");
+          return;
+        }
+        if (data.state === "failed") {
+          setPhase({ kind: "failed", error: data.error });
+          return;
+        }
+      } catch {
+        // Network blip - keep polling
+      }
+    };
+
+    const interval = setInterval(poll, 2500);
+    return () => {
+      cancelled = true;
+      clearInterval(interval);
+    };
+  }, [phase, onSuccess]);
+
+  const copyCode = async () => {
+    if (phase.kind !== "waiting") return;
+    try {
+      await navigator.clipboard.writeText(phase.deviceCode);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 1500);
+    } catch {
+      /* ignore */
+    }
+  };
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-bg/80 backdrop-blur-sm"
+      onClick={onClose}
+    >
+      <div
+        className="w-full max-w-md rounded-2xl border border-border bg-bg-elevated p-6 shadow-xl"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <header className="flex items-center gap-3">
+          <Github className="h-6 w-6 text-fg" />
+          <h2 className="display text-[20px] tracking-display-tight text-fg">
+            Sign in to GitHub
+          </h2>
+        </header>
+
+        {phase.kind === "starting" && (
+          <p className="mt-5 flex items-center gap-2 text-[14px] text-fg-muted">
+            <Loader2 className="h-4 w-4 animate-spin" />
+            Starting sign-in…
+          </p>
+        )}
+
+        {phase.kind === "waiting" && (
+          <>
+            <ol className="mt-5 space-y-4 text-[14px] text-fg">
+              <li>
+                <div className="flex items-baseline gap-2">
+                  <span className="text-fg-dim">1.</span>
+                  <span>Copy this one-time code:</span>
+                </div>
+                <button
+                  type="button"
+                  onClick={copyCode}
+                  className="mt-2 flex w-full items-center justify-between gap-3 rounded-lg border border-border bg-bg px-4 py-3 transition-colors hover:border-accent"
+                >
+                  <span className="mono text-[20px] tracking-widest text-fg">
+                    {phase.deviceCode}
+                  </span>
+                  <span className="flex items-center gap-1 text-[12px] text-fg-muted">
+                    {copied ? (
+                      <>
+                        <Check className="h-3.5 w-3.5" />
+                        copied
+                      </>
+                    ) : (
+                      <>
+                        <Copy className="h-3.5 w-3.5" />
+                        copy
+                      </>
+                    )}
+                  </span>
+                </button>
+              </li>
+
+              <li>
+                <div className="flex items-baseline gap-2">
+                  <span className="text-fg-dim">2.</span>
+                  <span>Open GitHub and paste the code:</span>
+                </div>
+                <a
+                  href={phase.verificationUri}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="mt-2 flex w-full items-center justify-center gap-2 rounded-lg bg-accent px-4 py-3 text-[14px] font-medium text-bg transition-colors hover:bg-accent-strong"
+                >
+                  Open GitHub in browser
+                  <ExternalLink className="h-4 w-4" />
+                </a>
+              </li>
+
+              <li>
+                <div className="flex items-baseline gap-2">
+                  <span className="text-fg-dim">3.</span>
+                  <span className="flex items-center gap-2">
+                    <Loader2 className="h-4 w-4 animate-spin text-fg-muted" />
+                    <span className="text-fg-muted">
+                      Waiting for you to authorize…
+                    </span>
+                  </span>
+                </div>
+              </li>
+            </ol>
+
+            <button
+              type="button"
+              onClick={onClose}
+              className="mt-6 w-full rounded-lg border border-border bg-bg px-4 py-2 text-[13px] text-fg-muted transition-colors hover:text-fg"
+            >
+              Cancel
+            </button>
+          </>
+        )}
+
+        {phase.kind === "success" && (
+          <div className="mt-5">
+            <p className="flex items-center gap-2 text-[14px] text-accent">
+              <Check className="h-4 w-4" />
+              Signed in{phase.login ? ` as ${phase.login}` : ""}.
+            </p>
+            <button
+              type="button"
+              onClick={onClose}
+              className="mt-4 w-full rounded-lg bg-accent px-4 py-2 text-[14px] font-medium text-bg transition-colors hover:bg-accent-strong"
+            >
+              Done
+            </button>
+          </div>
+        )}
+
+        {phase.kind === "failed" && (
+          <div className="mt-5">
+            <p className="text-[14px] text-accent-attention">
+              Sign-in failed.
+            </p>
+            <pre className="mono mt-2 max-h-32 overflow-auto whitespace-pre-wrap rounded bg-bg p-3 text-[11px] text-fg-muted">
+              {phase.error}
+            </pre>
+            <div className="mt-4 flex gap-2">
+              <button
+                type="button"
+                onClick={() => {
+                  startedRef.current = false;
+                  setPhase({ kind: "starting" });
+                }}
+                className="flex-1 rounded-lg bg-accent px-4 py-2 text-[14px] font-medium text-bg transition-colors hover:bg-accent-strong"
+              >
+                Try again
+              </button>
+              <button
+                type="button"
+                onClick={onClose}
+                className="flex-1 rounded-lg border border-border bg-bg px-4 py-2 text-[14px] text-fg-muted transition-colors hover:text-fg"
+              >
+                Close
+              </button>
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/components/RemoteReposSection.tsx
+++ b/components/RemoteReposSection.tsx
@@ -2,7 +2,8 @@
 
 import { useEffect, useState, useCallback } from "react";
 import { RemoteRepoCard, type RemoteRepoView } from "./RemoteRepoCard";
-import { ChevronDown } from "lucide-react";
+import { GhSignInModal } from "./GhSignInModal";
+import { ChevronDown, Github } from "lucide-react";
 
 interface ApiPayload {
   repos: RemoteRepoView[];
@@ -11,6 +12,24 @@ interface ApiPayload {
   error?: string;
   detail?: string;
   hint?: string;
+}
+
+// Heuristics for detecting "you need to sign in to GitHub" from the various
+// error shapes `gh` and the route can return. We treat these as a sign-in
+// problem (button) rather than a generic failure (cryptic pre block).
+function looksLikeAuthFailure(payload: ApiPayload): boolean {
+  const haystack = [payload.error, payload.detail, payload.hint]
+    .filter(Boolean)
+    .join(" ")
+    .toLowerCase();
+  if (!haystack) return false;
+  return (
+    haystack.includes("gh repo list failed") ||
+    haystack.includes("gh auth") ||
+    haystack.includes("not logged in") ||
+    haystack.includes("authentication required") ||
+    haystack.includes("unauthorized")
+  );
 }
 
 interface Props {
@@ -27,9 +46,10 @@ export function RemoteReposSection({ csrfToken, refreshKey = 0 }: Props) {
   const [repos, setRepos] = useState<RemoteRepoView[]>([]);
   const [cloneDir, setCloneDir] = useState<string>("~/repos");
   const [loadState, setLoadState] = useState<
-    "idle" | "loading" | "loaded" | "error"
+    "idle" | "loading" | "loaded" | "error" | "needs-auth"
   >("idle");
   const [errorBlock, setErrorBlock] = useState<string | null>(null);
+  const [signInOpen, setSignInOpen] = useState(false);
   // Collapsed by default — this is a secondary, exploratory section that
   // sits below the actionable groups. Users who want to clone something
   // will click in.
@@ -42,6 +62,13 @@ export function RemoteReposSection({ csrfToken, refreshKey = 0 }: Props) {
       const res = await fetch("/api/github/repos");
       const payload = (await res.json()) as ApiPayload;
       if (!res.ok) {
+        if (looksLikeAuthFailure(payload)) {
+          // No CLI hand-off: surface a single "Sign in to GitHub" button.
+          // Auto-expand so the button is visible without needing a click.
+          setLoadState("needs-auth");
+          setCollapsed(false);
+          return;
+        }
         setErrorBlock(
           [payload.error ?? "GitHub API failed", payload.hint, payload.detail]
             .filter(Boolean)
@@ -113,6 +140,22 @@ export function RemoteReposSection({ csrfToken, refreshKey = 0 }: Props) {
             </p>
           )}
 
+          {loadState === "needs-auth" && (
+            <div className="mt-3 flex flex-col items-start gap-3 rounded-xl border border-border bg-bg/40 p-4">
+              <p className="text-[14px] text-fg">
+                Sign in to GitHub to see repos you can clone.
+              </p>
+              <button
+                type="button"
+                onClick={() => setSignInOpen(true)}
+                className="flex items-center gap-2 rounded-lg bg-accent px-4 py-2 text-[14px] font-medium text-bg transition-colors hover:bg-accent-strong"
+              >
+                <Github className="h-4 w-4" />
+                Sign in to GitHub
+              </button>
+            </div>
+          )}
+
           {loadState === "error" && (
             <pre className="mono mt-3 whitespace-pre-wrap rounded bg-bg-elevated/80 p-3 text-[12px] text-accent-attention">
               {errorBlock}
@@ -140,6 +183,18 @@ export function RemoteReposSection({ csrfToken, refreshKey = 0 }: Props) {
             ))}
           </div>
         </>
+      )}
+
+      {signInOpen && (
+        <GhSignInModal
+          csrfToken={csrfToken}
+          onClose={() => setSignInOpen(false)}
+          onSuccess={() => {
+            // After successful auth, reload the repo list. The modal stays
+            // open showing "Done" until the user dismisses it.
+            void load();
+          }}
+        />
       )}
     </section>
   );

--- a/lib/gh/auth.ts
+++ b/lib/gh/auth.ts
@@ -1,0 +1,204 @@
+import { spawn } from "node:child_process";
+import { runGh } from "@/lib/git/exec";
+
+const DEVICE_CODE_RE = /code:\s*([A-Z0-9]{4}-[A-Z0-9]{4})/i;
+const ANSI_RE = /\x1b\[[0-9;]*m/g;
+
+export type AuthState =
+  | { state: "pending"; deviceCode: string; verificationUri: string }
+  | { state: "success"; login: string }
+  | { state: "failed"; error: string };
+
+interface SessionInternal {
+  state: AuthState;
+  startedAt: number;
+}
+
+const sessions = new Map<string, SessionInternal>();
+
+const VERIFICATION_URI = "https://github.com/login/device";
+
+function newRunId(): string {
+  return `gh-auth-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 8)}`;
+}
+
+export interface StartResult {
+  runId: string;
+  deviceCode: string;
+  verificationUri: string;
+}
+
+/**
+ * Spawn `gh auth login --web` and parse the device code from its stderr.
+ * Resolves once the device code is available so the UI can show it
+ * immediately. The OAuth completion runs in the background and is observable
+ * via `getAuthState(runId)`.
+ *
+ * Throws if `gh` itself can't be spawned (not installed, not on PATH).
+ */
+export function startGhAuthLogin(): Promise<StartResult> {
+  return new Promise((resolve, reject) => {
+    const runId = newRunId();
+    let stderrBuf = "";
+    let codeFound = false;
+    let stdinClosed = false;
+    let settled = false;
+
+    let child;
+    try {
+      child = spawn(
+        "gh",
+        [
+          "auth",
+          "login",
+          "--web",
+          "--hostname",
+          "github.com",
+          "--git-protocol",
+          "https",
+        ],
+        { stdio: ["pipe", "pipe", "pipe"], env: process.env },
+      );
+    } catch (err) {
+      reject(err);
+      return;
+    }
+
+    child.on("error", (err: NodeJS.ErrnoException) => {
+      if (err.code === "ENOENT" && !settled) {
+        settled = true;
+        reject(
+          new Error(
+            "GitHub CLI (gh) is not installed in this environment. The gitdash installer should have installed it — please run the installer again, or contact support.",
+          ),
+        );
+        return;
+      }
+      if (!settled) {
+        settled = true;
+        reject(err);
+      }
+      sessions.set(runId, {
+        state: { state: "failed", error: err.message },
+        startedAt: Date.now(),
+      });
+    });
+
+    child.stderr.on("data", (chunk: Buffer) => {
+      const text = chunk.toString("utf8").replace(ANSI_RE, "");
+      stderrBuf += text;
+
+      if (!codeFound) {
+        const m = DEVICE_CODE_RE.exec(text) ?? DEVICE_CODE_RE.exec(stderrBuf);
+        if (m && m[1]) {
+          codeFound = true;
+          const deviceCode = m[1].toUpperCase();
+          sessions.set(runId, {
+            state: {
+              state: "pending",
+              deviceCode,
+              verificationUri: VERIFICATION_URI,
+            },
+            startedAt: Date.now(),
+          });
+          if (!settled) {
+            settled = true;
+            resolve({ runId, deviceCode, verificationUri: VERIFICATION_URI });
+          }
+        }
+      }
+
+      // gh prompts "Press Enter to open ... in your browser". Send a newline
+      // so it stops blocking; the UI is what actually opens the browser.
+      if (!stdinClosed && /press enter/i.test(text)) {
+        try {
+          child.stdin.write("\n");
+        } catch {
+          /* ignore */
+        }
+      }
+    });
+
+    child.stdout.on("data", () => {
+      /* discard - everything useful goes to stderr */
+    });
+
+    child.on("exit", (code) => {
+      stdinClosed = true;
+      try {
+        child.stdin.end();
+      } catch {
+        /* ignore */
+      }
+
+      if (code === 0) {
+        sessions.set(runId, {
+          state: { state: "success", login: "" },
+          startedAt: Date.now(),
+        });
+      } else {
+        const errMsg = stderrBuf.trim() || `gh exited with code ${code}`;
+        sessions.set(runId, {
+          state: { state: "failed", error: errMsg },
+          startedAt: Date.now(),
+        });
+        if (!settled) {
+          settled = true;
+          reject(new Error(errMsg));
+        }
+      }
+    });
+
+    // Safety: if no device code arrives within 30s, give up so the UI doesn't
+    // hang forever waiting on a misbehaving gh binary.
+    setTimeout(() => {
+      if (!settled) {
+        settled = true;
+        try {
+          child.kill();
+        } catch {
+          /* ignore */
+        }
+        reject(
+          new Error(
+            "Timed out waiting for GitHub CLI to start the device-code flow.",
+          ),
+        );
+      }
+    }, 30_000).unref();
+  });
+}
+
+export function getAuthState(runId: string): AuthState | undefined {
+  return sessions.get(runId)?.state;
+}
+
+/**
+ * Returns the current GitHub login if `gh` is authenticated, or null.
+ * Used to short-circuit the sign-in flow when the user is already logged in.
+ */
+export async function isGhAuthenticated(): Promise<string | null> {
+  try {
+    const { stdout } = await runGh(["api", "user", "--jq", ".login"], {
+      timeoutMs: 10_000,
+    });
+    const login = stdout.trim();
+    return login || null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Garbage-collect sessions older than 30 minutes so the in-memory map
+ * doesn't grow unbounded across long-lived processes.
+ */
+setInterval(
+  () => {
+    const cutoff = Date.now() - 30 * 60_000;
+    for (const [id, s] of sessions.entries()) {
+      if (s.startedAt < cutoff) sessions.delete(id);
+    }
+  },
+  5 * 60_000,
+).unref?.();


### PR DESCRIPTION
Closes #129

## Summary
- **CLAUDE.md NORTH STAR rule** — explicit: any failure that requires a terminal command to recover is a P0 bug. Fix is always an in-UI button.
- **\`lib/gh/auth.ts\`** — spawns \`gh auth login --web\`, parses the device code from stderr, exposes session state via an in-memory map (auto-GC after 30 min).
- **POST \`/api/github/auth/login\`** — kicks off the flow, returns \`{runId, deviceCode, verificationUri}\`. Short-circuits with \`{alreadyAuthenticated: true}\` if gh is already logged in.
- **GET \`/api/github/auth/poll\`** — UI polls every 2.5s; returns \`pending | success | failed\`.
- **\`GhSignInModal.tsx\`** — Apple-style modal with copy-to-clipboard code + big "Open GitHub in browser" button + live waiting indicator + retry on failure.
- **\`RemoteReposSection.tsx\`** — auth-shaped errors now render the button instead of the cryptic \`<pre>\`. Auto-expands on detection so the button is visible without a click.

## Why
Was sending the user this on a fresh install:
> gh repo list failed
> Run \`gh auth status\` on the box. If unauthenticated, run \`gh auth login\`.

That violates the entire premise of gitdash. User correctly called it out and asked the rule be saved permanently.

## Test plan
- [ ] Fresh install where \`gh\` has never been authenticated → expand "on GitHub, not on this machine" → see "Sign in to GitHub" button (NOT the old error pre)
- [ ] Click button → modal opens with 8-char code (XXXX-XXXX) and "Open GitHub in browser" button
- [ ] Browser opens to https://github.com/login/device → enter code → authorize → modal auto-detects success and shows "Done"
- [ ] Click Done → repo list populates
- [ ] Force a failure (kill gh mid-flow) → modal shows error with "Try again" button
- [ ] If \`gh\` is already authenticated when you click the button: skips modal, just refreshes
- [ ] \`npm run typecheck\` passes
- [ ] \`npm run build\` produces both \`/api/github/auth/login\` and \`/api/github/auth/poll\` routes

## Follow-up not in this PR
- Bug #82 (systemd PATH issue → \`gh\` unreachable from service) should be fixed with the same north-star pattern: in-UI "Reconnect" button rather than a manual workaround.
- Other terminal-only error paths (push fails with scope error → "run \`gh auth refresh -s repo\`", port-in-use → "edit ~/.config/gitdash/env") should each get their own button-based recovery in follow-up issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)