### PR TITLE
fix(windows): run gitdash through login shell so PATH resolves (#131)

### DIFF
--- a/scripts/quick-install.ps1
+++ b/scripts/quick-install.ps1
@@ -193,9 +193,14 @@ New-Item -ItemType Directory -Force -Path $shimDir | Out-Null
 # The shim forwards every argument verbatim to the gitdash binary inside the
 # default WSL distro. Using `wsl --` (no `-d`) means it works for whatever
 # distro the user actually has, not just Ubuntu.
+#
+# `bash -lc` runs a login shell so ~/.profile is sourced — that's what puts
+# ~/.local/bin (where the gitdash launcher lives) on PATH. Without -l, the
+# default non-interactive WSL shell sees an empty PATH for user binaries and
+# the very first `gitdash start` after install fails with "command not found".
 $shimContent = @'
 @echo off
-wsl -- gitdash %*
+wsl -- bash -lc "gitdash %*"
 '@
 Set-Content -Path $shimPath -Value $shimContent -Encoding ASCII
 Write-Ok "Shim written to $shimPath"


### PR DESCRIPTION
## Summary

- Windows shim now invokes `wsl -- bash -lc "gitdash %*"` instead of `wsl -- gitdash %*`
- Login shell sources `~/.profile`, which adds `~/.local/bin` (where the gitdash launcher lives) to PATH
- Without this, the very first `gitdash start` after install fails with `bash: gitdash: command not found` — a P0 per the NORTH STAR rule

Closes #131

## Test plan

- [ ] Fresh Windows VM with no WSL/Ubuntu
- [ ] Run the PowerShell one-liner from README
- [ ] Reboot, set Ubuntu user/pass, let installer auto-continue
- [ ] Once browser opens, close all PowerShell windows
- [ ] Open a fresh PowerShell window
- [ ] Run `gitdash start` → should NOT error; should be a no-op (already running) or restart cleanly
- [ ] Run `gitdash status` → should show service state, not "command not found"

🤖 Generated with [Claude Code](https://claude.com/claude-code)