### PR TITLE
feat(local-only): new section + Publish to GitHub action (#10)

### DIFF
--- a/app/api/repos/[id]/actions/[name]/route.ts
+++ b/app/api/repos/[id]/actions/[name]/route.ts
@@ -2,7 +2,12 @@ import { NextResponse } from "next/server";
 import { bootstrap } from "@/lib/bootstrap";
 import { validateCsrf } from "@/lib/security/csrf";
 import { getRepoById, getSnapshot } from "@/lib/db/repos";
-import { isValidAction, startAction } from "@/lib/git/actions";
+import {
+  isValidAction,
+  isValidPublishName,
+  startAction,
+  type PublishOptions,
+} from "@/lib/git/actions";
 import { getScheduler } from "@/lib/scan/scheduler";
 
 export const dynamic = "force-dynamic";
@@ -34,6 +39,7 @@ export async function POST(
   }
 
   let commitMessage: string | undefined;
+  let publish: PublishOptions | undefined;
   if (name === "commit-push") {
     try {
       const body = (await req.json()) as { commitMessage?: unknown };
@@ -43,6 +49,22 @@ export async function POST(
     } catch {
       // empty body is fine; sanitizer will use default
     }
+  } else if (name === "publish-to-github") {
+    let body: { name?: unknown; visibility?: unknown; description?: unknown };
+    try {
+      body = (await req.json()) as typeof body;
+    } catch {
+      return NextResponse.json({ error: "publish requires a JSON body" }, { status: 400 });
+    }
+    if (typeof body.name !== "string" || !isValidPublishName(body.name)) {
+      return NextResponse.json(
+        { error: "invalid repository name (use letters, numbers, dots, dashes, underscores; 1-100 chars)" },
+        { status: 400 },
+      );
+    }
+    const visibility = body.visibility === "public" ? "public" : "private";
+    const description = typeof body.description === "string" ? body.description : undefined;
+    publish = { name: body.name, visibility, description };
   }
 
   const snap = getSnapshot(repoId);
@@ -54,6 +76,7 @@ export async function POST(
       action: name,
       branch: snap?.branch ?? null,
       commitMessage,
+      publish,
     });
   } catch (err) {
     return NextResponse.json({ error: String(err) }, { status: 400 });

--- a/app/globals.css
+++ b/app/globals.css
@@ -8,8 +8,10 @@
   Computed ratios (text on bg):
     LIGHT  fg 16.32 · fg-muted 11.99 · fg-dim 7.53
            push 7.58 · pull 8.72 · diverged 8.31 · attention 7.31 · dirty 7.09 · clean 7.68
+           local-only 7.45
     DARK   fg 17.06 · fg-muted 12.02 · fg-dim 8.12
            push 12.07 · pull 9.90 · diverged 9.41 · attention 10.59 · dirty 12.38 · clean 11.71
+           local-only 8.94
 */
 
 @layer base {
@@ -32,6 +34,7 @@
     --attention: 17 79% 33%;            /* #9A3412 orange-800 */
     --dirty: 26 84% 31%;                /* #92400E amber-800 */
     --clean: 162 88% 20%;               /* #065F46 emerald-800 — Purity green */
+    --local-only: 263 60% 32%;          /* violet-800 — distinct from the 6 state hues */
 
     /* Tint alphas */
     --tint-alpha: 0.06;
@@ -54,6 +57,7 @@
     --attention: 28 96% 73%;            /* #FDBA74 orange-300 */
     --dirty: 46 97% 65%;                /* #FCD34D amber-300 */
     --clean: 156 72% 67%;               /* #6EE7B7 emerald-300 */
+    --local-only: 263 90% 82%;          /* violet-300 */
 
     --tint-alpha: 0.10;
   }
@@ -108,4 +112,5 @@
   .tint-attention { background-color: hsl(var(--attention) / var(--tint-alpha)); }
   .tint-dirty     { background-color: hsl(var(--dirty) / var(--tint-alpha)); }
   .tint-clean     { background-color: hsl(var(--clean) / var(--tint-alpha)); }
+  .tint-local-only { background-color: hsl(var(--local-only) / var(--tint-alpha)); }
 }

--- a/components/ActionModal.tsx
+++ b/components/ActionModal.tsx
@@ -30,9 +30,12 @@ const COPY: Record<string, { verb: string; confirm?: string }> = {
       "This will combine GitHub's new commits with yours, creating a merge commit. Conflicts (if any) will be left in your working tree for you to resolve.",
   },
   "commit-push": { verb: "Committing and pushing to GitHub" },
+  "publish-to-github": { verb: "Publishing this repo to GitHub" },
   "open-editor": { verb: "Opening in your editor" },
   "open-terminal": { verb: "Opening a terminal" },
 };
+
+const PUBLISH_NAME_RE = /^[A-Za-z0-9][A-Za-z0-9._-]{0,99}$/;
 
 interface ChangeEntry {
   path: string;
@@ -52,8 +55,10 @@ export function ActionModal({ repo, action, csrfToken, onClose }: Props) {
   const snap = repo.snapshot;
   const pushCount = snap?.remoteAhead ?? snap?.ahead ?? 0;
   const isCommitPush = action === "commit-push";
+  const isPublish = action === "publish-to-github";
   const needsConfirm =
     isCommitPush ||
+    isPublish ||
     action === "merge" ||
     (action === "push" && pushCount > DESTRUCTIVE_CONFIRMATION_LIMIT);
 
@@ -61,6 +66,9 @@ export function ActionModal({ repo, action, csrfToken, onClose }: Props) {
   const [log, setLog] = useState<string[]>([]);
   const [exitCode, setExitCode] = useState<number | null>(null);
   const [commitMessage, setCommitMessage] = useState<string>("");
+  const [publishName, setPublishName] = useState<string>(repo.displayName);
+  const [publishVisibility, setPublishVisibility] = useState<"private" | "public">("private");
+  const [publishDescription, setPublishDescription] = useState<string>("");
   const [changes, setChanges] = useState<ChangesResponse | null>(null);
   const [changesLoading, setChangesLoading] = useState(isCommitPush);
   const [mounted, setMounted] = useState(false);
@@ -172,7 +180,16 @@ export function ActionModal({ repo, action, csrfToken, onClose }: Props) {
 
     async function run() {
       try {
-        const body = isCommitPush ? { commitMessage: commitMessage.trim() } : {};
+        let body: Record<string, unknown> = {};
+        if (isCommitPush) {
+          body = { commitMessage: commitMessage.trim() };
+        } else if (isPublish) {
+          body = {
+            name: publishName.trim(),
+            visibility: publishVisibility,
+            description: publishDescription.trim(),
+          };
+        }
         const res = await fetch(`/api/repos/${repo.id}/actions/${action}`, {
           method: "POST",
           headers: { "Content-Type": "application/json", "x-csrf-token": csrfToken },
@@ -217,7 +234,18 @@ export function ActionModal({ repo, action, csrfToken, onClose }: Props) {
       cancelled = true;
       esRef.current?.close();
     };
-  }, [phase, action, repo.id, csrfToken, isCommitPush, commitMessage]);
+  }, [
+    phase,
+    action,
+    repo.id,
+    csrfToken,
+    isCommitPush,
+    isPublish,
+    commitMessage,
+    publishName,
+    publishVisibility,
+    publishDescription,
+  ]);
 
   useEffect(() => {
     if (logRef.current) logRef.current.scrollTop = logRef.current.scrollHeight;
@@ -270,7 +298,20 @@ export function ActionModal({ repo, action, csrfToken, onClose }: Props) {
           />
         )}
 
-        {phase === "confirm" && !isCommitPush && (
+        {phase === "confirm" && isPublish && (
+          <PublishToGithubConfirm
+            name={publishName}
+            visibility={publishVisibility}
+            description={publishDescription}
+            onNameChange={setPublishName}
+            onVisibilityChange={setPublishVisibility}
+            onDescriptionChange={setPublishDescription}
+            onCancel={onClose}
+            onConfirm={() => setPhase("running")}
+          />
+        )}
+
+        {phase === "confirm" && !isCommitPush && !isPublish && (
           <div className="flex flex-col gap-4 px-6 py-6">
             <p className="text-[14px] leading-relaxed text-fg-muted">
               {action === "merge"
@@ -455,6 +496,128 @@ function FilePreview({ files }: { files: ChangeEntry[] }) {
         </li>
       ))}
     </ul>
+  );
+}
+
+function PublishToGithubConfirm({
+  name,
+  visibility,
+  description,
+  onNameChange,
+  onVisibilityChange,
+  onDescriptionChange,
+  onCancel,
+  onConfirm,
+}: {
+  name: string;
+  visibility: "private" | "public";
+  description: string;
+  onNameChange: (v: string) => void;
+  onVisibilityChange: (v: "private" | "public") => void;
+  onDescriptionChange: (v: string) => void;
+  onCancel: () => void;
+  onConfirm: () => void;
+}) {
+  const trimmedName = name.trim();
+  const nameValid = PUBLISH_NAME_RE.test(trimmedName);
+
+  return (
+    <div className="flex flex-col gap-5 overflow-y-auto px-6 py-6">
+      <p className="text-[13.5px] leading-relaxed text-fg-muted">
+        Gitdash will create a new repository on GitHub and push your current branch to it.
+        The repo will be <span className="font-medium text-fg">private by default</span> — only you can see it unless you switch to public.
+      </p>
+
+      <label className="flex flex-col gap-2">
+        <span className="text-[12px] uppercase tracking-wider text-fg-dim">Repository name</span>
+        <input
+          type="text"
+          value={name}
+          onChange={(e) => onNameChange(e.target.value)}
+          maxLength={100}
+          spellCheck={false}
+          className={cn(
+            "rounded-lg border bg-bg/60 px-3.5 py-2 text-[13.5px] text-fg placeholder:text-fg-dim focus:outline-none",
+            nameValid
+              ? "border-border focus:border-ring"
+              : "border-accent-attention/60 focus:border-accent-attention",
+          )}
+        />
+        {!nameValid && (
+          <span className="text-[11px] text-accent-attention">
+            Names can only use letters, numbers, dots, dashes, and underscores. Must start with a letter or number.
+          </span>
+        )}
+      </label>
+
+      <fieldset className="flex flex-col gap-2">
+        <legend className="text-[12px] uppercase tracking-wider text-fg-dim">Visibility</legend>
+        <div className="flex flex-col gap-2 sm:flex-row sm:gap-4">
+          <label className="flex cursor-pointer items-start gap-2.5 rounded-lg border border-border bg-bg/40 p-3 text-[13px] sm:flex-1">
+            <input
+              type="radio"
+              name="publish-visibility"
+              value="private"
+              checked={visibility === "private"}
+              onChange={() => onVisibilityChange("private")}
+              className="mt-0.5 accent-accent-local-only"
+            />
+            <span className="flex flex-col">
+              <span className="font-medium text-fg">Private</span>
+              <span className="text-[11.5px] text-fg-dim">Only you can see this repo. Recommended.</span>
+            </span>
+          </label>
+          <label className="flex cursor-pointer items-start gap-2.5 rounded-lg border border-border bg-bg/40 p-3 text-[13px] sm:flex-1">
+            <input
+              type="radio"
+              name="publish-visibility"
+              value="public"
+              checked={visibility === "public"}
+              onChange={() => onVisibilityChange("public")}
+              className="mt-0.5 accent-accent-local-only"
+            />
+            <span className="flex flex-col">
+              <span className="font-medium text-fg">Public</span>
+              <span className="text-[11.5px] text-fg-dim">Anyone on the internet can see it.</span>
+            </span>
+          </label>
+        </div>
+      </fieldset>
+
+      <label className="flex flex-col gap-2">
+        <span className="text-[12px] uppercase tracking-wider text-fg-dim">
+          Description <span className="text-fg-dim/70 normal-case tracking-normal">(optional)</span>
+        </span>
+        <input
+          type="text"
+          value={description}
+          onChange={(e) => onDescriptionChange(e.target.value)}
+          maxLength={350}
+          placeholder="What is this repo for?"
+          className="rounded-lg border border-border bg-bg/60 px-3.5 py-2 text-[13.5px] text-fg placeholder:text-fg-dim focus:border-ring focus:outline-none"
+        />
+      </label>
+
+      <div className="mt-1 flex justify-end gap-3">
+        <button
+          onClick={onCancel}
+          className="rounded-full border border-border px-4 py-1.5 text-[13px] font-medium text-fg-muted hover:border-fg-muted hover:text-fg"
+        >
+          Cancel
+        </button>
+        <button
+          onClick={onConfirm}
+          disabled={!nameValid}
+          className={cn(
+            "rounded-full border px-5 py-1.5 text-[13px] font-medium transition-all",
+            "border-accent-local-only/45 bg-accent-local-only/15 text-accent-local-only hover:bg-accent-local-only/25",
+            "disabled:cursor-not-allowed disabled:opacity-40",
+          )}
+        >
+          Publish
+        </button>
+      </div>
+    </div>
   );
 }
 

--- a/components/Dashboard.tsx
+++ b/components/Dashboard.tsx
@@ -30,11 +30,15 @@ function groupFor(repo: RepoView): GroupKind {
   if (s === "ahead") return "push";
   if (s === "behind") return "pull";
   if (s === "dirty") return "dirty";
-  // Everything else (clean, no-upstream, unknown) → "no updates needed".
-  // Comparison failures and missing remotes default to clean rather than
-  // surfacing an "unknown" bucket the user can't act on. If the comparison
-  // is truly stale and a real divergence is hiding, the user'll find out
-  // when they hit Fetch in the row's ⋯ menu.
+  // Truly local repos (no upstream config at all) go to local-only so they
+  // get a "Publish to GitHub" affordance instead of being invisible inside
+  // the clean bucket. We don't route `unknown` here — that means the remote
+  // check just hasn't completed yet, and pretending it's local would tell
+  // the user to publish a repo that may already be on GitHub.
+  if (s === "no-upstream") return "local-only";
+  // Everything else (clean, unknown) → "no updates needed". Comparison
+  // failures default to clean rather than surfacing an "unknown" bucket
+  // the user can't act on.
   return "clean";
 }
 
@@ -48,7 +52,7 @@ function buildGroups(repos: RepoView[]): { kind: GroupKind; headline: string; bo
     buckets.set(g, arr);
   }
 
-  const ordered: GroupKind[] = ["attention", "diverged", "push", "pull", "dirty", "read-only", "clean"];
+  const ordered: GroupKind[] = ["attention", "diverged", "push", "pull", "dirty", "local-only", "read-only", "clean"];
   // "clean" always renders (with an empty-state placeholder when count = 0)
   return ordered
     .filter((k) => k === "clean" || (buckets.get(k) ?? []).length > 0)
@@ -73,6 +77,7 @@ function headlineFor(kind: GroupKind, n: number): string {
     case "push": return `${plural === "repo" ? "wants" : "want"} to be pushed`;
     case "pull": return `${plural === "repo" ? "has" : "have"} incoming changes`;
     case "dirty": return `${plural === "repo" ? "has" : "have"} unsaved changes`;
+    case "local-only": return `${plural === "repo" ? "isn't" : "aren't"} on GitHub yet`;
     case "read-only": return `read-only — you can't push here`;
     case "clean": return n === 0
       ? "no updates needed"
@@ -87,6 +92,7 @@ function bodyFor(kind: GroupKind, _n: number): string {
     case "push": return "You've committed work locally that GitHub doesn't have yet. Hit the button to send it up.";
     case "pull": return "Someone (possibly another machine of yours) pushed commits to GitHub. Download them to catch up.";
     case "dirty": return "Files you've edited but haven't committed. Click Open folder to see what changed and commit from your editor. Gitdash doesn't commit for you.";
+    case "local-only": return "Local repos with no GitHub remote configured. Click Publish to GitHub to create a private repo and back up your work — defaults are safe (private, push current branch).";
     case "read-only": return "Repos where your GitHub account doesn't have push access. They might have local edits — that's fine — but gitdash won't show push, merge, or commit-push buttons because they would just fail.";
     case "clean": return "These repos are in sync — nothing to push or pull. If a comparison is stale or you suspect the data is wrong, hit Fetch in the row's ⋯ menu to re-check.";
   }

--- a/components/RepoCard.tsx
+++ b/components/RepoCard.tsx
@@ -14,7 +14,15 @@ import {
   RefreshCw,
 } from "lucide-react";
 
-export type GroupKind = "push" | "pull" | "diverged" | "attention" | "dirty" | "read-only" | "clean";
+export type GroupKind =
+  | "push"
+  | "pull"
+  | "diverged"
+  | "attention"
+  | "dirty"
+  | "local-only"
+  | "read-only"
+  | "clean";
 
 export const ROW_GRID =
   "grid-cols-[minmax(180px,1.4fr)_120px_150px_minmax(200px,1.6fr)_80px_148px_104px]";
@@ -32,6 +40,7 @@ function primaryAction(
   if (kind === "dirty" && !hasConflicts && hasRemote) {
     return { label: "Commit & push", action: "commit-push" };
   }
+  if (kind === "local-only") return { label: "Publish to GitHub", action: "publish-to-github" };
   return { label: "", action: null };
 }
 
@@ -57,6 +66,8 @@ function actionButtonClass(kind: GroupKind): string {
       "border-accent-diverged/35 bg-accent-diverged/10 text-accent-diverged hover:border-accent-diverged/55 hover:bg-accent-diverged/20",
     kind === "dirty" &&
       "border-accent-dirty/35 bg-accent-dirty/10 text-accent-dirty hover:border-accent-dirty/55 hover:bg-accent-dirty/20",
+    kind === "local-only" &&
+      "border-accent-local-only/35 bg-accent-local-only/10 text-accent-local-only hover:border-accent-local-only/55 hover:bg-accent-local-only/20",
   );
 }
 

--- a/components/RepoGroup.tsx
+++ b/components/RepoGroup.tsx
@@ -23,6 +23,7 @@ const TINT: Record<GroupKind, string> = {
   diverged: "tint-diverged",
   attention: "tint-attention",
   dirty: "tint-dirty",
+  "local-only": "tint-local-only",
   "read-only": "tint-clean",
   clean: "tint-clean",
 };
@@ -33,6 +34,7 @@ const ACCENT: Record<GroupKind, string> = {
   diverged: "text-accent-diverged",
   attention: "text-accent-attention",
   dirty: "text-accent-dirty",
+  "local-only": "text-accent-local-only",
   "read-only": "text-fg-muted",
   clean: "text-accent-clean",
 };

--- a/lib/git/actions.ts
+++ b/lib/git/actions.ts
@@ -17,7 +17,20 @@ export type ActionName =
   | "stash-pop"
   | "open-editor"
   | "open-terminal"
-  | "commit-push";
+  | "commit-push"
+  | "publish-to-github";
+
+export interface PublishOptions {
+  name: string;
+  visibility: "private" | "public";
+  description?: string;
+}
+
+const PUBLISH_NAME_RE = /^[A-Za-z0-9][A-Za-z0-9._-]{0,99}$/;
+
+export function isValidPublishName(name: string): boolean {
+  return PUBLISH_NAME_RE.test(name);
+}
 
 export interface ActionRun {
   id: string;
@@ -44,6 +57,7 @@ interface StartOptions {
   action: ActionName;
   branch: string | null;
   commitMessage?: string;
+  publish?: PublishOptions;
 }
 
 export function startAction(opts: StartOptions): ActionRun {
@@ -72,6 +86,29 @@ export function startAction(opts: StartOptions): ActionRun {
         run.finishedAt = Date.now();
         recordRunFinish(run);
         // surface error
+        run.lines.push(`[fatal] ${(err as Error).message}`);
+      });
+    });
+    getDb().prepare(
+      "INSERT INTO actions_log (repo_id, action, started_at) VALUES (?, ?, ?)",
+    ).run(opts.repoId, opts.action, run.startedAt);
+    return run;
+  }
+
+  if (opts.action === "publish-to-github") {
+    if (!opts.publish) {
+      throw new Error("publish-to-github requires publish options");
+    }
+    if (!isValidPublishName(opts.publish.name)) {
+      throw new Error("invalid repository name");
+    }
+    const publish = opts.publish;
+    setImmediate(() => {
+      executePublishToGithub(run, opts.repoPath, publish).catch((err) => {
+        run.emitter.emit("done", { exitCode: -1 });
+        run.exitCode = -1;
+        run.finishedAt = Date.now();
+        recordRunFinish(run);
         run.lines.push(`[fatal] ${(err as Error).message}`);
       });
     });
@@ -144,6 +181,8 @@ function buildArgs(action: ActionName, branch: string | null): string[] {
       return [];
     case "commit-push":
       return [];
+    case "publish-to-github":
+      return [];
   }
 }
 
@@ -182,6 +221,8 @@ function friendlyActionLabel(action: ActionName): string {
       return "Open terminal";
     case "commit-push":
       return "Commit & push";
+    case "publish-to-github":
+      return "Publish to GitHub";
   }
 }
 
@@ -457,6 +498,107 @@ async function executeCommitPush(
   run.emitter.emit("done", { exitCode: 0 });
 }
 
+async function executePublishToGithub(
+  run: ActionRun,
+  repoPath: string,
+  opts: PublishOptions,
+): Promise<void> {
+  const emit = (text: string) => {
+    run.lines.push(text);
+    run.emitter.emit("line", text);
+  };
+
+  // Defensive: bail if repo already has an origin remote — gh repo create
+  // would error out and the user would be confused. This catches the case
+  // where a transient `unknown` remoteState landed the repo in local-only
+  // even though it actually has a remote configured.
+  try {
+    const result = await execFileAsync("git", ["-C", repoPath, "config", "--get", "remote.origin.url"], {
+      timeout: 5_000,
+      env: { ...process.env, GIT_TERMINAL_PROMPT: "0" },
+    });
+    const url = result.stdout.trim();
+    if (url) {
+      emit(`[gitdash] ✗ This repo already has an 'origin' remote: ${url}`);
+      emit("[gitdash] hint: Refresh the row to update its connection status — it may already be linked to GitHub.");
+      run.finishedAt = Date.now();
+      run.exitCode = 1;
+      recordRunFinish(run);
+      run.emitter.emit("done", { exitCode: 1 });
+      return;
+    }
+  } catch {
+    // No origin remote — proceed.
+  }
+
+  const visibilityFlag = opts.visibility === "public" ? "--public" : "--private";
+  const args = [
+    "repo",
+    "create",
+    opts.name,
+    visibilityFlag,
+    `--source=${repoPath}`,
+    "--remote=origin",
+    "--push",
+  ];
+  if (opts.description && opts.description.trim()) {
+    args.push(`--description=${opts.description.trim().slice(0, 350)}`);
+  }
+
+  const code = await spawnGhStep(run, emit, args);
+  run.finishedAt = Date.now();
+  run.exitCode = code;
+  recordRunFinish(run);
+  if (code === 0) {
+    emit(`[gitdash] ✓ Repository created and pushed to GitHub.`);
+  } else {
+    emit(`[gitdash] ✗ ${friendlyStepLabel("publish")} didn't complete (exit ${code}).`);
+    emitHint(emit, run.lines);
+  }
+  run.emitter.emit("done", { exitCode: code });
+}
+
+function spawnGhStep(
+  run: ActionRun,
+  emit: (text: string) => void,
+  args: string[],
+): Promise<number> {
+  return new Promise<number>((resolve) => {
+    emit(`$ gh ${args.join(" ")}`);
+    const child = spawn("gh", args, {
+      env: { ...process.env, GIT_TERMINAL_PROMPT: "0" },
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    run.child = child;
+    const onData = (chunk: Buffer) => {
+      for (const line of chunk.toString("utf8").split(/\r?\n/)) {
+        if (line.length > 0) emit(line);
+      }
+    };
+    child.stdout?.on("data", onData);
+    child.stderr?.on("data", onData);
+    const timer = setTimeout(() => {
+      emit("[timeout] SIGTERM");
+      child.kill("SIGTERM");
+      setTimeout(() => child.kill("SIGKILL"), 3_000);
+    }, 120_000);
+    child.on("close", (c) => {
+      clearTimeout(timer);
+      resolve(c ?? -1);
+    });
+    child.on("error", (err) => {
+      clearTimeout(timer);
+      const errno = err as NodeJS.ErrnoException;
+      if (errno.code === "ENOENT") {
+        emit("[gitdash] hint: GitHub CLI ('gh') isn't installed or isn't on PATH. Install it from https://cli.github.com.");
+      } else {
+        emit(`[error] ${err.message}`);
+      }
+      resolve(-1);
+    });
+  });
+}
+
 function getEditor(): string {
   return process.env.GITDASH_EDITOR || "code";
 }
@@ -554,6 +696,7 @@ const VALID_ACTIONS: ReadonlySet<string> = new Set([
   "open-editor",
   "open-terminal",
   "commit-push",
+  "publish-to-github",
 ]);
 
 export function isValidAction(value: string): value is ActionName {

--- a/lib/git/error-hints.ts
+++ b/lib/git/error-hints.ts
@@ -127,6 +127,8 @@ export function friendlyStepLabel(label: string): string {
       return "Syncing with remote";
     case "push":
       return "Pushing to GitHub";
+    case "publish":
+      return "Publishing to GitHub";
     default:
       return label;
   }

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -32,6 +32,7 @@ const config: Config = {
           attention: "hsl(var(--attention))",
           dirty: "hsl(var(--dirty))",
           clean: "hsl(var(--clean))",
+          "local-only": "hsl(var(--local-only))",
         },
       },
       letterSpacing: {


### PR DESCRIPTION
## Summary

- New \`local-only\` section between **dirty** and **read-only** for repos with no upstream config — they were previously hidden inside the clean bucket
- Primary action is **Publish to GitHub**: a modal-confirmed \`gh repo create --source --remote=origin --push\` with private/public toggle (defaults to private) and optional description
- New violet accent (AAA contrast verified) keeps it visually distinct from the existing 6 state colours
- Defensive origin-check before invoking \`gh\` in case the row is misclassified

Closes #10

## Notes on routing

Only \`derivedState === \"no-upstream\"\` routes here — \`unknown\` stays in clean. Mapping \`unknown\` would mislabel repos whose remote check just hasn't completed yet, and the Publish action would collide with their existing remote. The defensive origin-check in \`executePublishToGithub\` backs this up if the routing is ever loosened.

## Test plan

- [ ] Take a folder without git: \`mkdir ~/test-publish && cd ~/test-publish && git init && echo hello > README.md && git add . && git commit -m initial\`
- [ ] Wait for gitdash to discover it (or hit the discovery cycle)
- [ ] Confirm it shows up in the new **Local-only** section with a violet accent and a "Publish to GitHub" button
- [ ] Click Publish → modal opens with name pre-filled, Private selected
- [ ] Submit → \`gh repo create\` runs, output streams in the modal, exit 0 on success
- [ ] On next snapshot the repo moves out of Local-only into clean (or push, depending on local commits)
- [ ] Visit the new repo on GitHub and confirm it's private and contains the README commit
- [ ] Repeat with **Public** selected — confirm visibility on github.com
- [ ] Validate name input: try \`bad name with spaces\` — Publish button should disable with red helper text
- [ ] Edge case: take a repo that already has \`origin\` configured but is in the local-only bucket (force this by deleting the snapshot row) → click Publish → modal log should show "This repo already has an 'origin' remote" hint, no \`gh\` call
- [ ] Cancel from the modal — no side effects
- [ ] Without \`gh\` installed: action errors with "GitHub CLI ('gh') isn't installed" hint

🤖 Generated with [Claude Code](https://claude.com/claude-code)