### PR TITLE
feat(ui): plain-English '101' explainer under each section (#133)

### DIFF
--- a/components/Dashboard.tsx
+++ b/components/Dashboard.tsx
@@ -16,8 +16,11 @@ interface Group {
   kind: GroupKind;
   headline: string;
   body: string;
+  explainer: ExplainerSegment[];
   defaultCollapsed?: boolean;
 }
+
+export type ExplainerSegment = { text: string; bold?: boolean };
 
 function groupFor(repo: RepoView): GroupKind {
   const s = repo.derivedState;
@@ -42,7 +45,7 @@ function groupFor(repo: RepoView): GroupKind {
   return "clean";
 }
 
-function buildGroups(repos: RepoView[]): { kind: GroupKind; headline: string; body: string; repos: RepoView[]; defaultCollapsed: boolean }[] {
+function buildGroups(repos: RepoView[]): { kind: GroupKind; headline: string; body: string; explainer: ExplainerSegment[]; repos: RepoView[]; defaultCollapsed: boolean }[] {
   const buckets = new Map<GroupKind, RepoView[]>();
   for (const r of repos) {
     const g = groupFor(r);
@@ -63,6 +66,7 @@ function buildGroups(repos: RepoView[]): { kind: GroupKind; headline: string; bo
         kind,
         headline: headlineFor(kind, list.length),
         body: bodyFor(kind, list.length),
+        explainer: explainerFor(kind),
         repos: list,
         defaultCollapsed: false,
       };
@@ -82,6 +86,57 @@ function headlineFor(kind: GroupKind, n: number): string {
     case "clean": return n === 0
       ? "no updates needed"
       : `${plural === "repo" ? "needs" : "need"} no updates`;
+  }
+}
+
+// Plain-English "what does this mean?" copy for beginners. Always visible
+// under the section header so users who've never used git can still figure
+// out what each section is asking of them. Bolded segments map to the
+// actual button labels (Push / Pull / Commit / Merge / Publish to GitHub).
+function explainerFor(kind: GroupKind): ExplainerSegment[] {
+  switch (kind) {
+    case "push":
+      return [
+        { text: "Your computer has new work that GitHub doesn't have yet. Click " },
+        { text: "Push", bold: true },
+        { text: " to upload it so it's safe and other computers can see it." },
+      ];
+    case "pull":
+      return [
+        { text: "GitHub has new work that your computer doesn't have yet. Click " },
+        { text: "Pull", bold: true },
+        { text: " to download it." },
+      ];
+    case "diverged":
+      return [
+        { text: "Your computer and GitHub both have changes the other doesn't know about. You'll need to " },
+        { text: "Merge", bold: true },
+        { text: " them together." },
+      ];
+    case "dirty":
+      return [
+        { text: "You changed files but haven't told git to save them yet. Click " },
+        { text: "Commit & push", bold: true },
+        { text: " to save a snapshot and upload it." },
+      ];
+    case "attention":
+      return [
+        { text: "Something needs your eyes — a merge conflict or a step git can't auto-resolve. Open the folder and finish what you started." },
+      ];
+    case "local-only":
+      return [
+        { text: "Never connected to GitHub. Click " },
+        { text: "Publish to GitHub", bold: true },
+        { text: " to back it up online — defaults to private." },
+      ];
+    case "read-only":
+      return [
+        { text: "You can look at this repo but can't push to it. Probably not yours, or a fork without write access." },
+      ];
+    case "clean":
+      return [
+        { text: "Everything is in sync with GitHub. Nothing to do here." },
+      ];
   }
 }
 
@@ -253,6 +308,7 @@ export function Dashboard({ initialRepos, csrfToken }: Props) {
               kind={g.kind}
               headline={g.headline}
               body={g.body}
+              explainer={g.explainer}
               repos={g.repos}
               csrfToken={csrfToken}
               defaultCollapsed={g.defaultCollapsed}

--- a/components/RepoGroup.tsx
+++ b/components/RepoGroup.tsx
@@ -1,8 +1,9 @@
 "use client";
 
-import { useState } from "react";
+import { Fragment, useState } from "react";
 import type { RepoView } from "@/lib/state/store";
 import { RepoCard, ROW_GRID, type GroupKind } from "./RepoCard";
+import type { ExplainerSegment } from "./Dashboard";
 import { ChevronRight } from "lucide-react";
 import { cn } from "@/lib/utils";
 
@@ -10,6 +11,7 @@ interface Props {
   kind: GroupKind;
   headline: string;
   body: string;
+  explainer: ExplainerSegment[];
   repos: RepoView[];
   csrfToken: string;
   defaultCollapsed?: boolean;
@@ -47,6 +49,7 @@ export function RepoGroup({
   kind,
   headline,
   body,
+  explainer,
   repos,
   csrfToken,
   defaultCollapsed = false,
@@ -93,6 +96,13 @@ export function RepoGroup({
         <div className="flex min-w-0 flex-1 flex-col pt-1 sm:pt-2">
           <h2 className="display text-[18px] leading-tight text-fg sm:text-[22px]">{headline}</h2>
           <p className="mt-1 text-[12px] text-fg-muted sm:text-[13px]">{body}</p>
+          <p className="mt-2 text-[12px] leading-relaxed text-fg-dim sm:text-[12.5px]">
+            {explainer.map((seg, i) => (
+              <Fragment key={i}>
+                {seg.bold ? <span className="font-medium text-fg-muted">{seg.text}</span> : seg.text}
+              </Fragment>
+            ))}
+          </p>
         </div>
 
         {!isEmpty && (


### PR DESCRIPTION
## Summary

- Adds a third, always-visible line under each section header — a one-sentence \"this is what it means\" explainer in plain English
- Action verbs (**Push**, **Pull**, **Commit & push**, **Merge**, **Publish to GitHub**) are bolded and match the literal button labels
- Beginners can scan a section header and figure out what's being asked of them without knowing what \"push\" or \"upstream\" means

Closes #133

## Stacked on PR #134

This branch is cut from \`feature/10-local-only-section\` because the explainer for the \`local-only\` section depends on that GroupKind existing. **Merge #134 first, then this.** If #134 is rebased before merge, this branch will need a rebase too.

## Why a typed segment array (not raw HTML)

Bolded verbs needed inline emphasis. A \`dangerouslySetInnerHTML\` would have been smaller but worse for accessibility tooling and i18n later. \`ExplainerSegment[]\` keeps the strings searchable and lets the renderer pick the styling.

## Test plan

- [ ] Visit the dashboard
- [ ] Each populated section header now shows three lines: count + headline, the existing body copy, and the new explainer
- [ ] Bolded words in the explainer match the actual button labels in the section's rows
- [ ] Light + dark theme — explainer is muted but legible (uses \`text-fg-dim\` over \`text-fg-muted\`)
- [ ] Mobile (<sm) — explainer wraps cleanly under the headline
- [ ] Empty clean section (no repos) doesn't show the explainer (it shows the existing empty-state copy instead)

🤖 Generated with [Claude Code](https://claude.com/claude-code)