### PR TITLE
fix(remote): resolve push target from branch config, not origin (#120)

### DIFF
--- a/lib/git/status.ts
+++ b/lib/git/status.ts
@@ -100,13 +100,44 @@ export function parsePorcelainV2(raw: string): LocalStatus {
   };
 }
 
+/**
+ * Resolves the URL of the remote that `git push` would target for the given
+ * branch. Mirrors git's own resolution order:
+ *   branch.<name>.pushRemote → branch.<name>.remote → "origin"
+ *
+ * Falls back to remote.origin.url for detached HEAD or when no branch-level
+ * config exists. Returns null when the resolved remote isn't configured.
+ *
+ * Inputs come from a single `git config --list` dump so the whole resolution
+ * runs without extra subprocess calls. Section + variable names are
+ * normalized lowercase by --list; the subsection (branch / remote name) is
+ * case-sensitive per git's config rules.
+ */
+export function resolveTrackedRemoteUrl(configDump: string, branch: string | null): string | null {
+  const map = new Map<string, string>();
+  for (const line of configDump.split("\n")) {
+    const idx = line.indexOf("=");
+    if (idx === -1) continue;
+    map.set(line.slice(0, idx), line.slice(idx + 1));
+  }
+
+  let remoteName = "origin";
+  if (branch) {
+    const pushRemote = map.get(`branch.${branch}.pushremote`);
+    const remote = map.get(`branch.${branch}.remote`);
+    remoteName = pushRemote ?? remote ?? "origin";
+  }
+
+  return map.get(`remote.${remoteName}.url`) ?? null;
+}
+
 export interface CollectSnapshotOptions {
   path: string;
   timeoutMs?: number;
 }
 
 export async function collectSnapshot({ path: repoPath, timeoutMs = 15_000 }: CollectSnapshotOptions): Promise<RepoSnapshot> {
-  const [statusRes, logRes, remoteRes] = await Promise.allSettled([
+  const [statusRes, logRes, configRes] = await Promise.allSettled([
     runGit(["status", "--porcelain=v2", "--branch", "--untracked-files=normal"], {
       cwd: repoPath,
       mode: "read",
@@ -117,7 +148,12 @@ export async function collectSnapshot({ path: repoPath, timeoutMs = 15_000 }: Co
       mode: "read",
       timeoutMs,
     }),
-    runGit(["config", "--get", "remote.origin.url"], {
+    // Pull the whole config in one shot so we can resolve the *actual*
+    // push target (branch.<name>.pushRemote → branch.<name>.remote →
+    // origin) instead of assuming origin. Otherwise a fork that tracks
+    // upstream gets origin's permissions queried, push button shows up,
+    // and the push 403s — see issue #120.
+    runGit(["config", "--list"], {
       cwd: repoPath,
       mode: "read",
       timeoutMs,
@@ -140,8 +176,8 @@ export async function collectSnapshot({ path: repoPath, timeoutMs = 15_000 }: Co
     }
   }
 
-  const remoteUrl = remoteRes.status === "fulfilled"
-    ? remoteRes.value.stdout.trim() || null
+  const remoteUrl = configRes.status === "fulfilled"
+    ? resolveTrackedRemoteUrl(configRes.value.stdout, status.branch)
     : null;
 
   if (status.upstream && status.upstreamSha === null) {


### PR DESCRIPTION
## Summary

- ``collectSnapshot`` previously read ``remote.origin.url`` unconditionally, so gitdash queried origin's permissions even when ``git push`` would target a different remote (forks tracking upstream were the live repro)
- Push button showed up because ``canPush`` came back true on origin, then the actual push to the tracked remote 403'd
- Now reads ``git config --list`` once and resolves the URL via the same order git push uses: ``branch.<name>.pushRemote`` → ``branch.<name>.remote`` → ``origin``
- Slug, ahead/behind, canPush, and PR count all flow from this corrected URL

Closes #120

## Test plan

- [ ] ``cd /home/cchhita/atem-mcp-server`` (fork: origin=imwebdev, upstream=guycochran, branch.main.remote=upstream)
- [ ] Wait for next snapshot tick
- [ ] Confirm ``snap.remoteUrl`` resolves to the upstream URL (via DB inspection or refresh button)
- [ ] Confirm ``can_push=0`` in the DB row, repo lands in **read-only** bucket, no push button shown
- [ ] Take any normal repo where origin == push target — confirm behavior unchanged (push button still shown when ahead)
- [ ] Take a repo with no upstream config at all — falls back to ``origin``, behavior unchanged
- [ ] Take a detached-HEAD repo — falls back to ``origin``, no crash
- [ ] No measurable I/O regression (single ``git config --list`` replaces single ``git config --get``)

🤖 Generated with [Claude Code](https://claude.com/claude-code)