### PR TITLE
feat(actions): split commit & push into two buttons (#24)

### DIFF
--- a/app/api/repos/[id]/actions/[name]/route.ts
+++ b/app/api/repos/[id]/actions/[name]/route.ts
@@ -40,7 +40,7 @@ export async function POST(
 
   let commitMessage: string | undefined;
   let publish: PublishOptions | undefined;
-  if (name === "commit-push") {
+  if (name === "commit-push" || name === "commit") {
     try {
       const body = (await req.json()) as { commitMessage?: unknown };
       if (typeof body.commitMessage === "string") {

--- a/components/ActionModal.tsx
+++ b/components/ActionModal.tsx
@@ -29,6 +29,7 @@ const COPY: Record<string, { verb: string; confirm?: string }> = {
     confirm:
       "This will combine GitHub's new commits with yours, creating a merge commit. Conflicts (if any) will be left in your working tree for you to resolve.",
   },
+  commit: { verb: "Saving a commit locally" },
   "commit-push": { verb: "Committing and pushing to GitHub" },
   "publish-to-github": { verb: "Publishing this repo to GitHub" },
   "open-editor": { verb: "Opening in your editor" },
@@ -54,10 +55,12 @@ interface ChangesResponse {
 export function ActionModal({ repo, action, csrfToken, onClose }: Props) {
   const snap = repo.snapshot;
   const pushCount = snap?.remoteAhead ?? snap?.ahead ?? 0;
+  const isCommit = action === "commit";
   const isCommitPush = action === "commit-push";
+  const isCommitFlow = isCommit || isCommitPush;
   const isPublish = action === "publish-to-github";
   const needsConfirm =
-    isCommitPush ||
+    isCommitFlow ||
     isPublish ||
     action === "merge" ||
     (action === "push" && pushCount > DESTRUCTIVE_CONFIRMATION_LIMIT);
@@ -70,7 +73,7 @@ export function ActionModal({ repo, action, csrfToken, onClose }: Props) {
   const [publishVisibility, setPublishVisibility] = useState<"private" | "public">("private");
   const [publishDescription, setPublishDescription] = useState<string>("");
   const [changes, setChanges] = useState<ChangesResponse | null>(null);
-  const [changesLoading, setChangesLoading] = useState(isCommitPush);
+  const [changesLoading, setChangesLoading] = useState(isCommitFlow);
   const [mounted, setMounted] = useState(false);
   const logRef = useRef<HTMLPreElement | null>(null);
   const esRef = useRef<EventSource | null>(null);
@@ -153,9 +156,9 @@ export function ActionModal({ repo, action, csrfToken, onClose }: Props) {
     };
   }, [mounted]);
 
-  // Fetch changes preview when entering commit-push confirm
+  // Fetch changes preview when entering any commit-flow confirm
   useEffect(() => {
-    if (!isCommitPush || phase !== "confirm") return;
+    if (!isCommitFlow || phase !== "confirm") return;
     let cancelled = false;
     (async () => {
       try {
@@ -172,7 +175,7 @@ export function ActionModal({ repo, action, csrfToken, onClose }: Props) {
     return () => {
       cancelled = true;
     };
-  }, [isCommitPush, phase, repo.id]);
+  }, [isCommitFlow, phase, repo.id]);
 
   useEffect(() => {
     if (phase !== "running") return;
@@ -181,7 +184,7 @@ export function ActionModal({ repo, action, csrfToken, onClose }: Props) {
     async function run() {
       try {
         let body: Record<string, unknown> = {};
-        if (isCommitPush) {
+        if (isCommitFlow) {
           body = { commitMessage: commitMessage.trim() };
         } else if (isPublish) {
           body = {
@@ -239,7 +242,7 @@ export function ActionModal({ repo, action, csrfToken, onClose }: Props) {
     action,
     repo.id,
     csrfToken,
-    isCommitPush,
+    isCommitFlow,
     isPublish,
     commitMessage,
     publishName,
@@ -287,8 +290,9 @@ export function ActionModal({ repo, action, csrfToken, onClose }: Props) {
           </button>
         </header>
 
-        {phase === "confirm" && isCommitPush && (
+        {phase === "confirm" && isCommitFlow && (
           <CommitPushConfirm
+            pushAfter={isCommitPush}
             changes={changes}
             loading={changesLoading}
             commitMessage={commitMessage}
@@ -311,7 +315,7 @@ export function ActionModal({ repo, action, csrfToken, onClose }: Props) {
           />
         )}
 
-        {phase === "confirm" && !isCommitPush && !isPublish && (
+        {phase === "confirm" && !isCommitFlow && !isPublish && (
           <div className="flex flex-col gap-4 px-6 py-6">
             <p className="text-[14px] leading-relaxed text-fg-muted">
               {action === "merge"
@@ -377,6 +381,7 @@ export function ActionModal({ repo, action, csrfToken, onClose }: Props) {
 }
 
 function CommitPushConfirm({
+  pushAfter,
   changes,
   loading,
   commitMessage,
@@ -384,6 +389,7 @@ function CommitPushConfirm({
   onCancel,
   onConfirm,
 }: {
+  pushAfter: boolean;
   changes: ChangesResponse | null;
   loading: boolean;
   commitMessage: string;
@@ -393,6 +399,7 @@ function CommitPushConfirm({
 }) {
   const total = changes?.total ?? 0;
   const suspicious = changes?.suspicious ?? [];
+  const submitLabel = pushAfter ? "Commit & push" : "Commit";
 
   return (
     <div className="flex flex-col gap-5 overflow-y-auto px-6 py-6">
@@ -411,8 +418,13 @@ function CommitPushConfirm({
           <div>
             <p className="text-[14px] text-fg">
               <span className="display-italic text-fg">{total}</span>{" "}
-              file{total === 1 ? "" : "s"} will be committed and pushed to GitHub.
+              file{total === 1 ? "" : "s"} will be {pushAfter ? "committed and pushed to GitHub" : "saved as a commit on this computer"}.
             </p>
+            {!pushAfter && (
+              <p className="mt-1 text-[12px] text-fg-dim">
+                Nothing leaves your machine. Hit Push afterwards to upload to GitHub.
+              </p>
+            )}
             {changes.truncated && (
               <p className="mt-1 text-[11px] text-fg-dim">(showing first 500 — repo has more)</p>
             )}
@@ -439,9 +451,11 @@ function CommitPushConfirm({
                     </li>
                   ))}
                 </ul>
-                <p className="mt-2 text-[11.5px] text-fg-dim">
-                  These will be pushed to GitHub publicly if your repo is public. Make sure that's what you want.
-                </p>
+                {pushAfter && (
+                  <p className="mt-2 text-[11.5px] text-fg-dim">
+                    These will be pushed to GitHub publicly if your repo is public. Make sure that's what you want.
+                  </p>
+                )}
               </div>
             </div>
           )}
@@ -459,7 +473,7 @@ function CommitPushConfirm({
           className="rounded-lg border border-border bg-bg/60 px-3.5 py-2 text-[13.5px] text-fg placeholder:text-fg-dim focus:border-ring focus:outline-none"
         />
         <span className="text-[11px] text-fg-dim">
-          Leave blank to use the default. This is what shows up in your GitHub commit history.
+          Leave blank to use the default. This is what shows up in your {pushAfter ? "GitHub" : "local"} commit history.
         </span>
       </label>
 
@@ -479,7 +493,7 @@ function CommitPushConfirm({
             "disabled:cursor-not-allowed disabled:opacity-40",
           )}
         >
-          Commit &amp; push
+          {submitLabel}
         </button>
       </div>
     </div>

--- a/components/RepoCard.tsx
+++ b/components/RepoCard.tsx
@@ -48,23 +48,39 @@ export type GroupKind =
   | "clean";
 
 export const ROW_GRID =
-  "grid-cols-[minmax(180px,1.4fr)_120px_150px_minmax(200px,1.6fr)_80px_148px_104px]";
+  "grid-cols-[minmax(180px,1.4fr)_120px_150px_minmax(200px,1.6fr)_80px_220px_104px]";
 
-function primaryAction(
+interface ActionButton {
+  label: string;
+  action: string;
+  variant: "primary" | "secondary";
+}
+
+// Returns 0, 1, or 2 buttons. Dirty rows with a remote get two side by side
+// (Commit + Commit & push) so a failed push doesn't force the user to retype
+// their commit message — they just hit Push afterward.
+function primaryActions(
   kind: GroupKind,
   hasRemote: boolean,
   hasConflicts: boolean,
-): { label: string; action: string | null } {
-  // read-only repos never show an action button — gitdash can't push there.
-  if (kind === "read-only") return { label: "", action: null };
-  if (kind === "push") return { label: "Push", action: "push" };
-  if (kind === "pull") return { label: "Pull", action: "pull" };
-  if (kind === "diverged") return { label: "Merge", action: "merge" };
-  if (kind === "dirty" && !hasConflicts && hasRemote) {
-    return { label: "Commit & push", action: "commit-push" };
+): ActionButton[] {
+  if (kind === "read-only") return [];
+  if (kind === "push") return [{ label: "Push", action: "push", variant: "primary" }];
+  if (kind === "pull") return [{ label: "Pull", action: "pull", variant: "primary" }];
+  if (kind === "diverged") return [{ label: "Merge", action: "merge", variant: "primary" }];
+  if (kind === "dirty" && !hasConflicts) {
+    if (hasRemote) {
+      return [
+        { label: "Commit", action: "commit", variant: "secondary" },
+        { label: "Commit & push", action: "commit-push", variant: "primary" },
+      ];
+    }
+    return [{ label: "Commit", action: "commit", variant: "primary" }];
   }
-  if (kind === "local-only") return { label: "Publish to GitHub", action: "publish-to-github" };
-  return { label: "", action: null };
+  if (kind === "local-only") {
+    return [{ label: "Publish to GitHub", action: "publish-to-github", variant: "primary" }];
+  }
+  return [];
 }
 
 function relativeTime(unix: number | null | undefined): string {
@@ -78,7 +94,16 @@ function relativeTime(unix: number | null | undefined): string {
   return `${Math.floor(deltaSec / (86400 * 365))}y ago`;
 }
 
-function actionButtonClass(kind: GroupKind): string {
+function actionButtonClass(kind: GroupKind, variant: "primary" | "secondary"): string {
+  // Secondary variant is a quieter, outline-only style so two side-by-side
+  // buttons in the dirty row create a visual primary/secondary hierarchy
+  // (Commit & push wins; Commit is available but recedes).
+  if (variant === "secondary") {
+    return cn(
+      "shrink-0 whitespace-nowrap rounded-full border px-3 py-1 text-[12px] font-medium tracking-tight transition-all",
+      "border-border bg-transparent text-fg-muted hover:border-fg-muted hover:text-fg",
+    );
+  }
   return cn(
     "shrink-0 whitespace-nowrap rounded-full border px-3.5 py-1 text-[12px] font-medium tracking-tight transition-all",
     kind === "push" &&
@@ -119,7 +144,7 @@ export function RepoCard({ repo, kind, csrfToken, expanded, onToggle }: Props) {
   const newFiles = snap?.untracked ?? 0;
   const conflicts = snap?.conflicted ?? 0;
   const hasRemote = !!(ghUrl ?? snap?.remoteUrl);
-  const button = primaryAction(kind, hasRemote, conflicts > 0);
+  const buttons = primaryActions(kind, hasRemote, conflicts > 0);
   const prCount = snap?.openPrCount ?? 0;
 
   const handleRowClick = (e: React.MouseEvent) => {
@@ -190,16 +215,21 @@ export function RepoCard({ repo, kind, csrfToken, expanded, onToggle }: Props) {
           />
           <PrCell count={prCount} url={ghPrUrl} />
 
-          {button.action ? (
-            <button
-              onClick={(e) => {
-                e.stopPropagation();
-                setModalAction(button.action);
-              }}
-              className={cn(actionButtonClass(kind), "justify-self-start")}
-            >
-              {button.label}
-            </button>
+          {buttons.length > 0 ? (
+            <div className="flex flex-wrap items-center gap-1.5 justify-self-start">
+              {buttons.map((b) => (
+                <button
+                  key={b.action}
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    setModalAction(b.action);
+                  }}
+                  className={actionButtonClass(kind, b.variant)}
+                >
+                  {b.label}
+                </button>
+              ))}
+            </div>
           ) : (
             <span />
           )}
@@ -268,16 +298,21 @@ export function RepoCard({ repo, kind, csrfToken, expanded, onToggle }: Props) {
             </span>
           </div>
 
-          {button.action && (
-            <button
-              onClick={(e) => {
-                e.stopPropagation();
-                setModalAction(button.action);
-              }}
-              className={cn(actionButtonClass(kind), "h-11 self-start px-4 text-[13px] sm:h-10")}
-            >
-              {button.label}
-            </button>
+          {buttons.length > 0 && (
+            <div className="flex flex-wrap items-center gap-2">
+              {buttons.map((b) => (
+                <button
+                  key={b.action}
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    setModalAction(b.action);
+                  }}
+                  className={cn(actionButtonClass(kind, b.variant), "h-11 px-4 text-[13px] sm:h-10")}
+                >
+                  {b.label}
+                </button>
+              ))}
+            </div>
           )}
         </div>
 

--- a/lib/git/actions.ts
+++ b/lib/git/actions.ts
@@ -17,6 +17,7 @@ export type ActionName =
   | "stash-pop"
   | "open-editor"
   | "open-terminal"
+  | "commit"
   | "commit-push"
   | "publish-to-github";
 
@@ -77,15 +78,15 @@ export function startAction(opts: StartOptions): ActionRun {
   };
   runs.set(runId, run);
 
-  if (opts.action === "commit-push") {
+  if (opts.action === "commit-push" || opts.action === "commit") {
     const message = sanitizeCommitMessage(opts.commitMessage);
+    const pushAfter = opts.action === "commit-push";
     setImmediate(() => {
-      executeCommitPush(run, opts.repoPath, message, opts.branch).catch((err) => {
+      executeCommit(run, opts.repoPath, message, opts.branch, pushAfter).catch((err) => {
         run.emitter.emit("done", { exitCode: -1 });
         run.exitCode = -1;
         run.finishedAt = Date.now();
         recordRunFinish(run);
-        // surface error
         run.lines.push(`[fatal] ${(err as Error).message}`);
       });
     });
@@ -179,6 +180,8 @@ function buildArgs(action: ActionName, branch: string | null): string[] {
       return [];
     case "open-terminal":
       return [];
+    case "commit":
+      return [];
     case "commit-push":
       return [];
     case "publish-to-github":
@@ -219,6 +222,8 @@ function friendlyActionLabel(action: ActionName): string {
       return "Open editor";
     case "open-terminal":
       return "Open terminal";
+    case "commit":
+      return "Commit";
     case "commit-push":
       return "Commit & push";
     case "publish-to-github":
@@ -426,11 +431,12 @@ async function executePush(run: ActionRun, repoPath: string, branch: string | nu
   run.emitter.emit("done", { exitCode: 0 });
 }
 
-async function executeCommitPush(
+async function executeCommit(
   run: ActionRun,
   repoPath: string,
   message: string,
   branch: string | null,
+  pushAfter: boolean,
 ): Promise<void> {
   const emit = (text: string) => {
     run.lines.push(text);
@@ -453,8 +459,9 @@ async function executeCommitPush(
   const commitCode = await spawnGitStep(run, emit, ["commit", "-m", message], repoPath);
   if (commitCode !== 0) {
     if (commitCode === 1) {
-      // "nothing to commit" — treat as success, skip push
-      emit("[gitdash] nothing to commit; skipping push");
+      emit(pushAfter
+        ? "[gitdash] nothing to commit; skipping push"
+        : "[gitdash] nothing to commit");
       run.finishedAt = Date.now();
       run.exitCode = 0;
       recordRunFinish(run);
@@ -467,6 +474,15 @@ async function executeCommitPush(
     run.exitCode = commitCode;
     recordRunFinish(run);
     run.emitter.emit("done", { exitCode: commitCode });
+    return;
+  }
+
+  if (!pushAfter) {
+    emit("[gitdash] ✓ Commit created locally. Hit Push when you're ready to upload it to GitHub.");
+    run.finishedAt = Date.now();
+    run.exitCode = 0;
+    recordRunFinish(run);
+    run.emitter.emit("done", { exitCode: 0 });
     return;
   }
 
@@ -484,6 +500,7 @@ async function executeCommitPush(
   const pushCode = await spawnGitStep(run, emit, ["push"], repoPath);
   if (pushCode !== 0) {
     emit(`[gitdash] ✗ ${friendlyStepLabel("push")} didn't complete (exit ${pushCode}).`);
+    emit("[gitdash] hint: Your commit was saved locally. Once you fix the push issue (often a GitHub auth problem), click the Push button on this row to retry.");
     emitHint(emit, run.lines);
     run.finishedAt = Date.now();
     run.exitCode = pushCode;
@@ -695,6 +712,7 @@ const VALID_ACTIONS: ReadonlySet<string> = new Set([
   "stash-pop",
   "open-editor",
   "open-terminal",
+  "commit",
   "commit-push",
   "publish-to-github",
 ]);


### PR DESCRIPTION
## Summary

- Dirty rows with a remote now show **Commit** (secondary, outline) + **Commit & push** (primary) side-by-side
- ``Commit`` stages + commits locally, no push. Row transitions to ``ahead`` afterward — existing Push button takes over for retry
- Recoverable failures (push fails on SSH/branch-protection) no longer force the user to retype their commit message
- Backend: ``executeCommitPush`` refactored into ``executeCommit(pushAfter)``; new ``commit`` ActionName + VALID_ACTIONS entry; modal reuses ``CommitPushConfirm`` with a ``pushAfter`` prop
- Action grid column widened 148 → 220px; flex-wrap covers narrow widths

Closes #24

## Test plan

- [ ] Dirty row with remote: shows two buttons, Commit (outline) + Commit & push (filled)
- [ ] Click Commit → modal opens with file preview + message input, copy says \"saved as a commit on this computer\"
- [ ] Submit → ``git add -A`` + ``git commit -m`` runs, no push attempted, modal exits done with \"Commit created locally. Hit Push when you're ready\"
- [ ] Row updates to ``ahead`` after snapshot; Push button appears
- [ ] Click Push → uploads cleanly
- [ ] Dirty row with remote where commit-push fails on push (simulate by setting bad SSH origin): both succeed up to push, error surfaces, commit is saved, user can hit Push from the now-ahead row
- [ ] Dirty row WITHOUT remote: only Commit button shows (primary variant since it's the only action)
- [ ] Conflicts row: no buttons (unchanged)
- [ ] Mobile: buttons wrap cleanly
- [ ] Other rows (push, pull, merge, publish-to-github) unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)