### PR TITLE
feat(remote): classify gone vs unpushed-branch + auto-publish on push (#19)

### DIFF
--- a/components/Dashboard.tsx
+++ b/components/Dashboard.tsx
@@ -28,9 +28,12 @@ function groupFor(repo: RepoView): GroupKind {
   // (push / merge / commit-push) won't work on them. They go to their own
   // bucket so we don't tease the user with buttons that will fail.
   if (s === "read-only") return "read-only";
+  // 'gone' (repo missing on GitHub) lands in attention so the user notices
+  // and can fix the remote URL before doing more work that has nowhere to go.
+  if (s === "gone") return "attention";
   if (s === "weird") return "attention";
   if (s === "diverged") return "diverged";
-  if (s === "ahead") return "push";
+  if (s === "ahead" || s === "unpushed-branch") return "push";
   if (s === "behind") return "pull";
   if (s === "dirty") return "dirty";
   // Truly local repos (no upstream config at all) go to local-only so they

--- a/lib/gh/client.ts
+++ b/lib/gh/client.ts
@@ -2,7 +2,19 @@ import { runGh } from "@/lib/git/exec";
 import { getDb } from "@/lib/db/schema";
 import type { GitHubSlug } from "@/lib/scan/discover";
 
-export type RemoteState = "clean" | "ahead" | "behind" | "diverged" | "no-upstream" | "unknown";
+export type RemoteState =
+  | "clean"
+  | "ahead"
+  | "behind"
+  | "diverged"
+  | "no-upstream"
+  | "unknown"
+  // Repo itself is missing on GitHub (deleted, renamed, or made private and
+  // we can't see it). User has to update or remove the remote.
+  | "gone"
+  // Repo exists on GitHub but the local branch isn't on it yet. Click Push
+  // and gitdash will publish the branch with --set-upstream.
+  | "unpushed-branch";
 
 export interface RemoteComparison {
   state: RemoteState;
@@ -134,6 +146,35 @@ function parseIncludedResponse(raw: string): { statusCode: number; etag: string 
   return { statusCode, etag, body };
 }
 
+interface RepoMeta {
+  exists: boolean;
+  defaultBranch: string | null;
+}
+
+/**
+ * One-shot probe for repo existence + default branch. Used as a fallback
+ * when the per-branch SHA fetch comes back empty so we can disambiguate
+ * "branch isn't on remote yet" from "the whole repo is gone."
+ */
+async function fetchRepoMeta(slug: GitHubSlug): Promise<RepoMeta> {
+  try {
+    const res = await runGh([
+      "api",
+      "--method",
+      "GET",
+      `repos/${slug.owner}/${slug.name}`,
+    ], { timeoutMs: 15_000 });
+    const parsed = JSON.parse(res.stdout) as { default_branch?: string };
+    return { exists: true, defaultBranch: parsed.default_branch ?? null };
+  } catch (err) {
+    const stderr = (err as { stderr?: string }).stderr ?? "";
+    if (/\b404\b/.test(stderr)) return { exists: false, defaultBranch: null };
+    // 401/403/network — be conservative, assume the repo is fine and we just
+    // had an auth/transport blip.
+    return { exists: true, defaultBranch: null };
+  }
+}
+
 /**
  * Use the GitHub compare endpoint to get ahead/behind directly.
  * Falls back gracefully on auth errors.
@@ -146,6 +187,28 @@ export async function compareWithRemote(
   const now = Date.now();
   const remote = await fetchRemoteSha(slug, branch);
   if (!remote) {
+    // SHA fetch failed — could be the branch isn't on GitHub yet, or the
+    // repo is gone, or auth blip. Probe repo metadata to disambiguate.
+    const meta = await fetchRepoMeta(slug);
+    if (!meta.exists) {
+      return { state: "gone", ahead: 0, behind: 0, remoteSha: null, localSha, checkedAt: now };
+    }
+    if (meta.defaultBranch && meta.defaultBranch !== branch) {
+      // Repo exists. Try the default branch — if THAT works, only the
+      // local branch is missing on remote (unpushed). If even the default
+      // 404s, treat it as ambiguous (unknown).
+      const defaultRemote = await fetchRemoteSha(slug, meta.defaultBranch);
+      if (defaultRemote) {
+        return {
+          state: "unpushed-branch",
+          ahead: 0,
+          behind: 0,
+          remoteSha: null,
+          localSha,
+          checkedAt: now,
+        };
+      }
+    }
     return { state: "unknown", ahead: 0, behind: 0, remoteSha: null, localSha, checkedAt: now };
   }
   if (remote.sha === localSha) {

--- a/lib/git/actions.ts
+++ b/lib/git/actions.ts
@@ -288,6 +288,29 @@ function spawnGitStep(
 }
 
 /**
+ * Returns the args for `git push` for this branch. If the branch has no
+ * upstream configured, returns ["push", "-u", "origin", "HEAD"] so the
+ * branch publishes itself instead of failing with "no upstream branch."
+ * Otherwise plain ["push"]. Detached HEAD also gets plain push.
+ */
+async function buildPushArgs(repoPath: string, branch: string | null): Promise<string[]> {
+  if (!branch || branch === "(detached)") return ["push"];
+  try {
+    await execFileAsync(
+      "git",
+      ["-C", repoPath, "rev-parse", "--abbrev-ref", "--symbolic-full-name", "@{upstream}"],
+      { timeout: 5_000, env: { ...process.env, GIT_TERMINAL_PROMPT: "0" } },
+    );
+    return ["push"];
+  } catch {
+    // No upstream — publish the branch to origin. The user already clicked
+    // Push so consent for "this leaves my machine" is established; the
+    // -u flag wires up tracking so subsequent pushes are plain pushes.
+    return ["push", "-u", "origin", "HEAD"];
+  }
+}
+
+/**
  * Reads the tracked remote name for the given branch from git config.
  * Priority: branch.<branch>.pushRemote → branch.<branch>.remote → "origin"
  * Returns null when the branch or remote cannot be determined (detached HEAD etc.).
@@ -414,7 +437,11 @@ async function executePush(run: ActionRun, repoPath: string, branch: string | nu
     return;
   }
 
-  const pushCode = await spawnGitStep(run, emit, ["push"], repoPath);
+  const pushArgs = await buildPushArgs(repoPath, branch);
+  if (pushArgs.length > 1) {
+    emit(`[gitdash] Branch '${branch}' isn't on GitHub yet. Publishing it now.`);
+  }
+  const pushCode = await spawnGitStep(run, emit, pushArgs, repoPath);
   if (pushCode !== 0) {
     emit(`[gitdash] ✗ ${friendlyStepLabel("push")} didn't complete (exit ${pushCode}).`);
     emitHint(emit, run.lines);
@@ -497,7 +524,11 @@ async function executeCommit(
   }
 
   // --- push ---
-  const pushCode = await spawnGitStep(run, emit, ["push"], repoPath);
+  const pushArgs = await buildPushArgs(repoPath, branch);
+  if (pushArgs.length > 1) {
+    emit(`[gitdash] Branch '${branch}' isn't on GitHub yet. Publishing it now.`);
+  }
+  const pushCode = await spawnGitStep(run, emit, pushArgs, repoPath);
   if (pushCode !== 0) {
     emit(`[gitdash] ✗ ${friendlyStepLabel("push")} didn't complete (exit ${pushCode}).`);
     emit("[gitdash] hint: Your commit was saved locally. Once you fix the push issue (often a GitHub auth problem), click the Push button on this row to retry.");

--- a/lib/state/store.ts
+++ b/lib/state/store.ts
@@ -21,7 +21,13 @@ export type DerivedState =
   | "read-only"
   | "no-upstream"
   | "weird"
-  | "unknown";
+  | "unknown"
+  // Repo on GitHub is missing (deleted/renamed/private). User needs to fix
+  // the remote URL or remove tracking. Surfaced in attention.
+  | "gone"
+  // Local branch isn't on the remote yet. Push button will publish it
+  // with --set-upstream.
+  | "unpushed-branch";
 
 export function deriveState(row: RepoRow, snap: SnapshotRow | null): DerivedState {
   if (!snap) return "unknown";
@@ -35,10 +41,14 @@ export function deriveState(row: RepoRow, snap: SnapshotRow | null): DerivedStat
   // push/diverged/dirty would be a bait-and-switch. The row stays visible
   // but gets routed to its own bucket where action buttons are hidden.
   if (snap.canPush === false) return "read-only";
+  // 'gone' beats dirty too — local edits don't matter if there's nowhere
+  // to push them. User has to fix the remote first.
+  if (snap.remoteState === "gone") return "gone";
   if (dirty > 0) return "dirty";
   if (snap.remoteState === "diverged") return "diverged";
   if (snap.remoteState === "ahead" || snap.ahead > 0) return "ahead";
   if (snap.remoteState === "behind" || snap.behind > 0) return "behind";
+  if (snap.remoteState === "unpushed-branch") return "unpushed-branch";
   if (!snap.upstream && !snap.remoteState) return "no-upstream";
   if (snap.remoteState === "unknown") return "unknown";
   return "clean";


### PR DESCRIPTION
## Summary

- ``compareWithRemote`` falls back to ``repos/<owner>/<name>`` when the per-branch SHA fetch returns null
  - 404 on the repo → ``remoteState=gone`` (routes to **attention**)
  - Repo exists, default-branch SHA succeeds → ``remoteState=unpushed-branch`` (routes to **push**)
  - Both 404 → ``unknown`` (unchanged)
- ``executePush`` + ``executeCommit``'s push step check ``@{upstream}`` before pushing. No upstream → ``git push -u origin HEAD`` so beginners don't get the \"no upstream branch / open a terminal\" error
- New ``DerivedState`` values ``gone`` and ``unpushed-branch`` thread through ``deriveState`` and ``Dashboard.groupFor``
- One extra ``gh api`` call per affected repo per tick (cached repos skip via 304)

Closes #19

## Test plan

- [ ] Repo deleted on GitHub (or rename + don't update local remote): row lands in **attention** with ⚠ remote-stuck warning, can still Fetch / Open from the menu
- [ ] Repo exists on GitHub, local feature branch never pushed: row lands in **push** bucket
- [ ] Click Push on that unpushed branch: modal log shows \"Branch '<name>' isn't on GitHub yet. Publishing it now.\" then ``git push -u origin HEAD`` runs to success
- [ ] On next snapshot, branch shows tracking config + repo transitions to ``clean``
- [ ] Repo with origin tracking and pushed branch: behavior unchanged (plain ``git push``)
- [ ] Detached HEAD: plain ``git push`` (unchanged)
- [ ] Fork tracking upstream (issue #120 case): unaffected — still falls back to the right URL via the resolved tracked remote
- [ ] No regression on read-only repos (route still wins via ``canPush === false``)

🤖 Generated with [Claude Code](https://claude.com/claude-code)