### PR TITLE
fix(install): pin systemd PATH so gh and install-time node resolve (#82)

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -106,11 +106,35 @@ npm run build
 # ─────────────────────────────────────────────────────────
 step "4/6 Configuration"
 mkdir -p "$CONFIG_DIR"
+
+# Pin the node that built the native modules (e.g. better-sqlite3) so the
+# systemd service uses the same node binary at runtime — otherwise systemd's
+# minimal PATH (/usr/bin:/bin) picks up a system node with a mismatched
+# NODE_MODULE_VERSION and the .node files fail to load (ERR_DLOPEN_FAILED).
+#
+# Also include $HOME/.local/bin so `gh` (typically installed there) is
+# reachable from the service — without this the clone-section returns 502
+# with `spawn gh ENOENT` even though `gh` is happy from an interactive shell.
+NODE_DIR="$(dirname "$(command -v node 2>/dev/null || echo /usr/bin/node)")"
+SERVICE_PATH="$NODE_DIR:$HOME/.local/bin:/usr/local/bin:/usr/bin:/bin"
+
+# Always rewrite the env file so PATH stays current with the install-time
+# node — but preserve the existing CSRF token (rotating it would break any
+# already-loaded browser tab).
 if [[ -f "$ENV_FILE" ]]; then
-  dim "  Config exists at $ENV_FILE — keeping existing CSRF token"
+  EXISTING_CSRF="$(grep -E '^GITDASH_CSRF_TOKEN=' "$ENV_FILE" | head -1 | cut -d= -f2- || true)"
+  if [[ -n "$EXISTING_CSRF" ]]; then
+    CSRF_TOKEN="$EXISTING_CSRF"
+    dim "  Config exists at $ENV_FILE — keeping CSRF token, refreshing PATH"
+  else
+    CSRF_TOKEN=$(node -e 'console.log(require("crypto").randomBytes(24).toString("base64url"))')
+    dim "  Config exists at $ENV_FILE — generating CSRF token, refreshing PATH"
+  fi
 else
   CSRF_TOKEN=$(node -e 'console.log(require("crypto").randomBytes(24).toString("base64url"))')
-  cat > "$ENV_FILE" <<EOF
+fi
+
+cat > "$ENV_FILE" <<EOF
 # gitdash environment — sourced by the systemd service.
 # Edit values below to override defaults. Restart the service after changes:
 #   systemctl --user restart gitdash
@@ -121,10 +145,15 @@ GITDASH_BIND=0.0.0.0
 # GITDASH_EDITOR=code
 # GITDASH_TERMINAL=x-terminal-emulator
 # GITDASH_DB=$HOME/.local/state/gitdash/gitdash.sqlite
+
+# Pin the node used at install time — prevents better-sqlite3 /
+# NODE_MODULE_VERSION mismatch when systemd's minimal PATH would
+# otherwise pick up an older apt-installed node. Also adds
+# \$HOME/.local/bin so gh (and other user-installed CLIs) resolve.
+PATH=$SERVICE_PATH
 EOF
-  chmod 600 "$ENV_FILE"
-  green "  Wrote $ENV_FILE (mode 600)"
-fi
+chmod 600 "$ENV_FILE"
+green "  Wrote $ENV_FILE (mode 600; PATH pinned to $NODE_DIR)"
 
 # ─────────────────────────────────────────────────────────
 step "5/6 Installing systemd user service"


### PR DESCRIPTION
## Summary

- ``install.sh`` now writes ``PATH=`` to ``$ENV_FILE`` with the install-time node dir + ``\$HOME/.local/bin`` + standard system dirs
- Without this, the systemd ``--user`` service inherited only ``/usr/bin:/bin``, so:
  1. ``gh`` (in ``~/.local/bin``) was unreachable → ``/api/github/repos`` returned **502** with ``spawn gh ENOENT``
  2. systemd could pick up a system node with mismatched ``NODE_MODULE_VERSION`` against ``better-sqlite3`` → ``ERR_DLOPEN_FAILED``
- Mirrors the fix in ``scripts/quick-install.sh`` (PR #67) and extends it with ``\$HOME/.local/bin``
- Re-runs preserve the existing CSRF token (no broken browser tabs)

Closes #82

## Test plan

- [ ] Fresh install on a box with nvm node + ``gh`` in ``~/.local/bin``: ``./install.sh && curl -s -o /dev/null -w \"%{http_code}\\n\" http://127.0.0.1:7420/api/github/repos`` → 200
- [ ] ``journalctl --user -u gitdash -b`` shows no ``spawn gh ENOENT`` and no ``NODE_MODULE_VERSION`` errors
- [ ] Re-run ``./install.sh`` against existing config: PATH line updates, CSRF token preserved (no logout from existing browser tabs)
- [ ] ``cat ~/.config/gitdash/env`` shows ``PATH=<node-dir>:/home/<user>/.local/bin:/usr/local/bin:/usr/bin:/bin``
- [ ] Clone section in the dashboard now lists \"On GitHub, not on this machine\" repos (was empty before)

🤖 Generated with [Claude Code](https://claude.com/claude-code)