### PR TITLE
feat(security): post-pull alert when pulled changes touch sensitive paths

### DIFF
--- a/app/api/repos/[id]/pull-alerts/[alertId]/dismiss/route.ts
+++ b/app/api/repos/[id]/pull-alerts/[alertId]/dismiss/route.ts
@@ -1,0 +1,42 @@
+import { NextResponse } from "next/server";
+import { bootstrap } from "@/lib/bootstrap";
+import { validateCsrf } from "@/lib/security/csrf";
+import { getRepoById } from "@/lib/db/repos";
+import { dismissAlert } from "@/lib/db/alerts";
+
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
+
+export async function POST(
+  req: Request,
+  ctx: { params: Promise<{ id: string; alertId: string }> },
+) {
+  await bootstrap();
+
+  const csrf = req.headers.get("x-csrf-token");
+  if (!validateCsrf(csrf)) {
+    return NextResponse.json({ error: "invalid csrf" }, { status: 403 });
+  }
+
+  const { id, alertId } = await ctx.params;
+  const repoId = Number(id);
+  const alertIdNum = Number(alertId);
+  if (!Number.isInteger(repoId) || repoId <= 0) {
+    return NextResponse.json({ error: "invalid repo id" }, { status: 400 });
+  }
+  if (!Number.isInteger(alertIdNum) || alertIdNum <= 0) {
+    return NextResponse.json({ error: "invalid alert id" }, { status: 400 });
+  }
+
+  const repo = getRepoById(repoId);
+  if (!repo || repo.deletedAt !== null) {
+    return NextResponse.json({ error: "repo not found" }, { status: 404 });
+  }
+
+  const ok = dismissAlert(alertIdNum, Date.now());
+  if (!ok) {
+    return NextResponse.json({ error: "alert not found or already dismissed" }, { status: 404 });
+  }
+
+  return NextResponse.json({ ok: true });
+}

--- a/app/api/repos/[id]/pull-alerts/route.ts
+++ b/app/api/repos/[id]/pull-alerts/route.ts
@@ -1,0 +1,28 @@
+import { NextResponse } from "next/server";
+import { bootstrap } from "@/lib/bootstrap";
+import { getRepoById } from "@/lib/db/repos";
+import { getUnacknowledgedAlerts } from "@/lib/db/alerts";
+
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
+
+export async function GET(
+  _req: Request,
+  ctx: { params: Promise<{ id: string }> },
+) {
+  await bootstrap();
+
+  const { id } = await ctx.params;
+  const repoId = Number(id);
+  if (!Number.isInteger(repoId) || repoId <= 0) {
+    return NextResponse.json({ error: "invalid repo id" }, { status: 400 });
+  }
+
+  const repo = getRepoById(repoId);
+  if (!repo || repo.deletedAt !== null) {
+    return NextResponse.json({ error: "repo not found" }, { status: 404 });
+  }
+
+  const alerts = getUnacknowledgedAlerts(repoId);
+  return NextResponse.json({ alerts });
+}

--- a/app/api/repos/route.ts
+++ b/app/api/repos/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from "next/server";
 import { bootstrap } from "@/lib/bootstrap";
 import { getStore } from "@/lib/state/store";
+import { getUnacknowledgedAlertCounts } from "@/lib/db/alerts";
 
 export const dynamic = "force-dynamic";
 export const runtime = "nodejs";
@@ -10,5 +11,10 @@ export async function GET(req: Request) {
   const url = new URL(req.url);
   const includeSystem = url.searchParams.get("showSystem") === "1";
   const repos = getStore().snapshot(includeSystem);
-  return NextResponse.json({ repos });
+  const alertCounts = getUnacknowledgedAlertCounts(repos.map((r) => r.id));
+  const reposWithAlerts = repos.map((r) => ({
+    ...r,
+    pullAlertCount: alertCounts.get(r.id) ?? 0,
+  }));
+  return NextResponse.json({ repos: reposWithAlerts });
 }

--- a/components/ActionModal.tsx
+++ b/components/ActionModal.tsx
@@ -52,6 +52,11 @@ interface ChangesResponse {
   truncated: boolean;
 }
 
+interface PullFinding {
+  path: string;
+  reason: string;
+}
+
 export function ActionModal({ repo, action, csrfToken, onClose }: Props) {
   const snap = repo.snapshot;
   const pushCount = snap?.remoteAhead ?? snap?.ahead ?? 0;
@@ -74,6 +79,7 @@ export function ActionModal({ repo, action, csrfToken, onClose }: Props) {
   const [publishDescription, setPublishDescription] = useState<string>("");
   const [changes, setChanges] = useState<ChangesResponse | null>(null);
   const [changesLoading, setChangesLoading] = useState(isCommitFlow);
+  const [pullFindings, setPullFindings] = useState<PullFinding[]>([]);
   const [mounted, setMounted] = useState(false);
   const logRef = useRef<HTMLPreElement | null>(null);
   const esRef = useRef<EventSource | null>(null);
@@ -216,8 +222,11 @@ export function ActionModal({ repo, action, csrfToken, onClose }: Props) {
           setLog((l) => [...l, data.text]);
         });
         es.addEventListener("done", (ev: MessageEvent) => {
-          const data = JSON.parse(ev.data) as { exitCode: number };
+          const data = JSON.parse(ev.data) as { exitCode: number; pullFindings?: PullFinding[] };
           setExitCode(data.exitCode);
+          if (data.pullFindings && data.pullFindings.length > 0) {
+            setPullFindings(data.pullFindings);
+          }
           setPhase(data.exitCode === 0 ? "done" : "error");
           es.close();
         });
@@ -353,6 +362,10 @@ export function ActionModal({ repo, action, csrfToken, onClose }: Props) {
           </pre>
         )}
 
+        {phase === "done" && pullFindings.length > 0 && (
+          <PullFindingsAlert findings={pullFindings} />
+        )}
+
         {phase !== "confirm" && (
           <footer className="flex items-center justify-between px-6 py-3 text-[12px]">
             <div className={cn(
@@ -378,6 +391,32 @@ export function ActionModal({ repo, action, csrfToken, onClose }: Props) {
   );
 
   return createPortal(dialog, document.body);
+}
+
+function PullFindingsAlert({ findings }: { findings: PullFinding[] }) {
+  return (
+    <div className="border-t border-accent-attention/30 bg-accent-attention/8 px-6 py-4">
+      <div className="flex gap-3">
+        <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0 text-accent-attention" />
+        <div className="min-w-0">
+          <p className="text-[13px] font-medium text-fg">
+            Review these changes before running any setup
+          </p>
+          <p className="mt-0.5 text-[12px] text-fg-muted">
+            The pull brought in files that can run code on your computer. You don&apos;t have to do anything right now — just don&apos;t run install or setup commands until you&apos;ve taken a look.
+          </p>
+          <ul className="mt-2.5 space-y-2">
+            {findings.map((f) => (
+              <li key={f.path} className="text-[12px]">
+                <span className="mono text-accent-attention">{f.path}</span>
+                <span className="ml-2 text-fg-muted">— {f.reason}</span>
+              </li>
+            ))}
+          </ul>
+        </div>
+      </div>
+    </div>
+  );
 }
 
 function CommitPushConfirm({

--- a/components/RepoCard.tsx
+++ b/components/RepoCard.tsx
@@ -4,12 +4,14 @@ import { cn } from "@/lib/utils";
 import type { RepoView } from "@/lib/state/store";
 import { ActionModal } from "./ActionModal";
 import { RowDetail } from "./RowDetail";
-import { useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import {
+  AlertTriangle,
   ChevronDown,
   ExternalLink,
   GitPullRequest,
   RefreshCw,
+  X,
 } from "lucide-react";
 
 type PillTone = "push" | "pull" | "clean" | "dirty" | "attention" | "neutral";
@@ -129,7 +131,9 @@ interface Props {
 
 export function RepoCard({ repo, kind, csrfToken, expanded, onToggle }: Props) {
   const [modalAction, setModalAction] = useState<string | null>(null);
+  const [pullAlertOpen, setPullAlertOpen] = useState(false);
   const snap = repo.snapshot;
+  const pullAlertCount = repo.pullAlertCount ?? 0;
 
   const ghOwner = repo.githubOwner;
   const ghName = repo.githubName;
@@ -215,24 +219,33 @@ export function RepoCard({ repo, kind, csrfToken, expanded, onToggle }: Props) {
           />
           <PrCell count={prCount} url={ghPrUrl} />
 
-          {buttons.length > 0 ? (
-            <div className="flex flex-wrap items-center gap-1.5 justify-self-start">
-              {buttons.map((b) => (
-                <button
-                  key={b.action}
-                  onClick={(e) => {
-                    e.stopPropagation();
-                    setModalAction(b.action);
-                  }}
-                  className={actionButtonClass(kind, b.variant)}
-                >
-                  {b.label}
-                </button>
-              ))}
-            </div>
-          ) : (
-            <span />
-          )}
+          <div className="flex flex-wrap items-center gap-1.5 justify-self-start">
+            {buttons.map((b) => (
+              <button
+                key={b.action}
+                onClick={(e) => {
+                  e.stopPropagation();
+                  setModalAction(b.action);
+                }}
+                className={actionButtonClass(kind, b.variant)}
+              >
+                {b.label}
+              </button>
+            ))}
+            {pullAlertCount > 0 && (
+              <button
+                onClick={(e) => {
+                  e.stopPropagation();
+                  setPullAlertOpen(true);
+                }}
+                className="inline-flex items-center gap-1 whitespace-nowrap rounded-full border border-accent-attention/40 bg-accent-attention/10 px-2.5 py-1 text-[11px] font-medium text-accent-attention hover:bg-accent-attention/20"
+                aria-label="Review pulled changes"
+              >
+                <AlertTriangle className="h-3 w-3" />
+                Review pulled changes
+              </button>
+            )}
+          </div>
 
           <RowIcons
             ghUrl={ghUrl}
@@ -298,7 +311,7 @@ export function RepoCard({ repo, kind, csrfToken, expanded, onToggle }: Props) {
             </span>
           </div>
 
-          {buttons.length > 0 && (
+          {(buttons.length > 0 || pullAlertCount > 0) && (
             <div className="flex flex-wrap items-center gap-2">
               {buttons.map((b) => (
                 <button
@@ -312,6 +325,19 @@ export function RepoCard({ repo, kind, csrfToken, expanded, onToggle }: Props) {
                   {b.label}
                 </button>
               ))}
+              {pullAlertCount > 0 && (
+                <button
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    setPullAlertOpen(true);
+                  }}
+                  className="inline-flex h-11 items-center gap-1.5 whitespace-nowrap rounded-full border border-accent-attention/40 bg-accent-attention/10 px-4 text-[13px] font-medium text-accent-attention hover:bg-accent-attention/20 sm:h-10"
+                  aria-label="Review pulled changes"
+                >
+                  <AlertTriangle className="h-3.5 w-3.5" />
+                  Review pulled changes
+                </button>
+              )}
             </div>
           )}
         </div>
@@ -327,7 +353,154 @@ export function RepoCard({ repo, kind, csrfToken, expanded, onToggle }: Props) {
           onClose={() => setModalAction(null)}
         />
       )}
+
+      {pullAlertOpen && (
+        <PullAlertModal
+          repoId={repo.id}
+          csrfToken={csrfToken}
+          onClose={() => setPullAlertOpen(false)}
+        />
+      )}
     </>
+  );
+}
+
+interface PullFinding {
+  path: string;
+  reason: string;
+}
+
+interface PullAlertResponse {
+  alerts: Array<{ id: number; repoId: number; createdAt: number; acknowledgedAt: number | null; findings: PullFinding[] }>;
+}
+
+function PullAlertModal({
+  repoId,
+  csrfToken,
+  onClose,
+}: {
+  repoId: number;
+  csrfToken: string;
+  onClose: () => void;
+}) {
+  const [alerts, setAlerts] = useState<PullAlertResponse["alerts"]>([]);
+  const [loading, setLoading] = useState(true);
+  const [dismissing, setDismissing] = useState<number | null>(null);
+  const dialogRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    fetch(`/api/repos/${repoId}/pull-alerts`)
+      .then((r) => r.json() as Promise<PullAlertResponse>)
+      .then((data) => {
+        if (!cancelled) setAlerts(data.alerts);
+      })
+      .catch(() => {})
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [repoId]);
+
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") onClose();
+    };
+    document.addEventListener("keydown", onKey);
+    return () => document.removeEventListener("keydown", onKey);
+  }, [onClose]);
+
+  const allFindings = alerts.flatMap((a) => a.findings);
+  const latestAlertId = alerts[0]?.id ?? null;
+
+  const handleDismiss = async () => {
+    if (!latestAlertId) return;
+    setDismissing(latestAlertId);
+    try {
+      await fetch(`/api/repos/${repoId}/pull-alerts/${latestAlertId}/dismiss`, {
+        method: "POST",
+        headers: { "x-csrf-token": csrfToken },
+      });
+      onClose();
+    } catch {
+      setDismissing(null);
+    }
+  };
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 p-4 backdrop-blur-sm animate-fade-up"
+      onClick={onClose}
+    >
+      <div
+        ref={dialogRef}
+        role="dialog"
+        aria-modal="true"
+        aria-label="Review pulled changes"
+        className="flex max-h-[min(80vh,640px)] w-full max-w-lg flex-col overflow-hidden rounded-2xl border border-border bg-bg-elevated shadow-2xl"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <header className="flex items-center justify-between border-b border-border-subtle px-5 py-4">
+          <div className="flex items-center gap-2.5">
+            <AlertTriangle className="h-4 w-4 shrink-0 text-accent-attention" />
+            <h2 className="text-[15px] font-medium text-fg">Review before running setup</h2>
+          </div>
+          <button
+            onClick={onClose}
+            aria-label="Close"
+            className="inline-flex h-11 w-11 items-center justify-center rounded-full text-fg-muted hover:bg-bg-hover hover:text-fg sm:h-8 sm:w-8"
+          >
+            <X className="h-4 w-4" />
+          </button>
+        </header>
+
+        <div className="flex-1 overflow-y-auto px-5 py-4">
+          {loading && (
+            <p className="text-[13px] text-fg-dim">Loading…</p>
+          )}
+
+          {!loading && allFindings.length === 0 && (
+            <p className="text-[13px] text-fg-muted">No unreviewed changes.</p>
+          )}
+
+          {!loading && allFindings.length > 0 && (
+            <>
+              <p className="text-[13px] leading-relaxed text-fg-muted">
+                The last pull brought in files that can run code on your computer. Don&apos;t run any install or setup commands until you&apos;ve reviewed what changed.
+              </p>
+              <ul className="mt-3 space-y-3">
+                {allFindings.map((f, i) => (
+                  <li key={i} className="rounded-lg border border-border-subtle bg-bg px-4 py-3">
+                    <p className="mono text-[12px] font-medium text-accent-attention">{f.path}</p>
+                    <p className="mt-1 text-[12px] text-fg-muted">{f.reason}</p>
+                  </li>
+                ))}
+              </ul>
+            </>
+          )}
+        </div>
+
+        <footer className="flex items-center justify-end gap-3 border-t border-border-subtle px-5 py-3">
+          <button
+            onClick={onClose}
+            className="rounded-full border border-border px-4 py-1.5 text-[13px] font-medium text-fg-muted hover:border-fg-muted hover:text-fg"
+          >
+            Close
+          </button>
+          {allFindings.length > 0 && (
+            <button
+              onClick={handleDismiss}
+              disabled={dismissing !== null}
+              className="rounded-full border border-accent-attention/45 bg-accent-attention/10 px-4 py-1.5 text-[13px] font-medium text-accent-attention hover:bg-accent-attention/20 disabled:cursor-not-allowed disabled:opacity-40"
+            >
+              {dismissing !== null ? "Dismissing…" : "Got it, dismiss"}
+            </button>
+          )}
+        </footer>
+      </div>
+    </div>
   );
 }
 

--- a/lib/db/alerts.ts
+++ b/lib/db/alerts.ts
@@ -1,0 +1,80 @@
+import { getDb } from "./schema";
+import type { PullFinding } from "@/lib/security/post-pull";
+
+export interface PullAlertRow {
+  id: number;
+  repoId: number;
+  createdAt: number;
+  acknowledgedAt: number | null;
+  findings: PullFinding[];
+}
+
+interface PullAlertRaw {
+  id: number;
+  repo_id: number;
+  created_at: number;
+  acknowledged_at: number | null;
+  findings_json: string;
+}
+
+function rawToAlert(r: PullAlertRaw): PullAlertRow {
+  let findings: PullFinding[] = [];
+  try {
+    findings = JSON.parse(r.findings_json) as PullFinding[];
+  } catch {
+    findings = [];
+  }
+  return {
+    id: r.id,
+    repoId: r.repo_id,
+    createdAt: r.created_at,
+    acknowledgedAt: r.acknowledged_at,
+    findings,
+  };
+}
+
+export function insertPullAlert(repoId: number, findings: PullFinding[], now: number): void {
+  const db = getDb();
+  db.prepare(
+    "DELETE FROM pull_alerts WHERE repo_id = ? AND acknowledged_at IS NULL",
+  ).run(repoId);
+  db.prepare(
+    "INSERT INTO pull_alerts (repo_id, created_at, findings_json) VALUES (?, ?, ?)",
+  ).run(repoId, now, JSON.stringify(findings));
+}
+
+export function getUnacknowledgedAlerts(repoId: number): PullAlertRow[] {
+  const rows = getDb()
+    .prepare<[number], PullAlertRaw>(
+      "SELECT * FROM pull_alerts WHERE repo_id = ? AND acknowledged_at IS NULL ORDER BY created_at DESC",
+    )
+    .all(repoId);
+  return rows.map(rawToAlert);
+}
+
+export function dismissAlert(alertId: number, now: number): boolean {
+  const result = getDb()
+    .prepare("UPDATE pull_alerts SET acknowledged_at = ? WHERE id = ? AND acknowledged_at IS NULL")
+    .run(now, alertId);
+  return result.changes > 0;
+}
+
+export function getUnacknowledgedAlertCount(repoId: number): number {
+  const row = getDb()
+    .prepare<[number], { cnt: number }>(
+      "SELECT COUNT(*) AS cnt FROM pull_alerts WHERE repo_id = ? AND acknowledged_at IS NULL",
+    )
+    .get(repoId);
+  return row?.cnt ?? 0;
+}
+
+export function getUnacknowledgedAlertCounts(repoIds: number[]): Map<number, number> {
+  if (repoIds.length === 0) return new Map();
+  const placeholders = repoIds.map(() => "?").join(",");
+  const rows = getDb()
+    .prepare<number[], { repo_id: number; cnt: number }>(
+      `SELECT repo_id, COUNT(*) AS cnt FROM pull_alerts WHERE repo_id IN (${placeholders}) AND acknowledged_at IS NULL GROUP BY repo_id`,
+    )
+    .all(...repoIds);
+  return new Map(rows.map((r) => [r.repo_id, r.cnt]));
+}

--- a/lib/db/schema.ts
+++ b/lib/db/schema.ts
@@ -82,6 +82,16 @@ function migrate(db: Database.Database): void {
       truncated_output TEXT
     );
     CREATE INDEX IF NOT EXISTS idx_actions_repo ON actions_log(repo_id, started_at DESC);
+
+    CREATE TABLE IF NOT EXISTS pull_alerts (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      repo_id INTEGER NOT NULL,
+      created_at INTEGER NOT NULL,
+      acknowledged_at INTEGER,
+      findings_json TEXT NOT NULL,
+      FOREIGN KEY (repo_id) REFERENCES repos(id) ON DELETE CASCADE
+    );
+    CREATE INDEX IF NOT EXISTS idx_pull_alerts_repo_unack ON pull_alerts(repo_id, acknowledged_at);
   `);
 
   // Idempotent column-add migrations. SQLite has no IF NOT EXISTS on ADD

--- a/lib/git/actions.ts
+++ b/lib/git/actions.ts
@@ -5,6 +5,8 @@ import { randomUUID } from "node:crypto";
 import { assertSafeRef } from "./exec";
 import { translateGitError, friendlyStepLabel } from "./error-hints";
 import { getDb } from "@/lib/db/schema";
+import { classifyPulledChanges } from "@/lib/security/post-pull";
+import { insertPullAlert } from "@/lib/db/alerts";
 
 const execFileAsync = promisify(execFile);
 
@@ -106,6 +108,23 @@ export function startAction(opts: StartOptions): ActionRun {
     const publish = opts.publish;
     setImmediate(() => {
       executePublishToGithub(run, opts.repoPath, publish).catch((err) => {
+        run.emitter.emit("done", { exitCode: -1 });
+        run.exitCode = -1;
+        run.finishedAt = Date.now();
+        recordRunFinish(run);
+        run.lines.push(`[fatal] ${(err as Error).message}`);
+      });
+    });
+    getDb().prepare(
+      "INSERT INTO actions_log (repo_id, action, started_at) VALUES (?, ?, ?)",
+    ).run(opts.repoId, opts.action, run.startedAt);
+    return run;
+  }
+
+  // pull gets special treatment: capture pre-pull HEAD so we can diff after.
+  if (opts.action === "pull") {
+    setImmediate(() => {
+      executePull(run, opts.repoPath, opts.repoId).catch((err) => {
         run.emitter.emit("done", { exitCode: -1 });
         run.exitCode = -1;
         run.finishedAt = Date.now();
@@ -419,6 +438,58 @@ async function executeFetchRebase(
   emit("[gitdash] ✗ Rebase had conflicts — repo restored to pre-pull state.");
   emitHint(emit, run.lines);
   return false;
+}
+
+async function executePull(run: ActionRun, repoPath: string, repoId: number): Promise<void> {
+  const emit = (text: string) => {
+    run.lines.push(text);
+    run.emitter.emit("line", text);
+  };
+
+  let oldHead: string | null = null;
+  try {
+    const result = await execFileAsync(
+      "git",
+      ["-C", repoPath, "rev-parse", "HEAD"],
+      { timeout: 5_000, env: { ...process.env, GIT_TERMINAL_PROMPT: "0" } },
+    );
+    oldHead = result.stdout.trim() || null;
+  } catch {
+    // non-fatal; classifier will be skipped
+  }
+
+  const code = await spawnGitStep(run, emit, ["pull", "--ff-only"], repoPath);
+
+  run.finishedAt = Date.now();
+  run.exitCode = code;
+  recordRunFinish(run);
+
+  if (code === 0 && oldHead) {
+    try {
+      const result = await execFileAsync(
+        "git",
+        ["-C", repoPath, "rev-parse", "HEAD"],
+        { timeout: 5_000, env: { ...process.env, GIT_TERMINAL_PROMPT: "0" } },
+      );
+      const newHead = result.stdout.trim();
+      if (newHead && newHead !== oldHead) {
+        const findings = await classifyPulledChanges(repoPath, oldHead, newHead);
+        if (findings.length > 0) {
+          insertPullAlert(repoId, findings, Date.now());
+          run.emitter.emit("done", { exitCode: 0, pullFindings: findings });
+          return;
+        }
+      }
+    } catch {
+      // classifier failure must never block a successful pull
+    }
+  }
+
+  if (code !== 0) {
+    emit(`[gitdash] ✗ ${friendlyActionLabel("pull")} didn't complete (exit ${code}).`);
+    emitHint(emit, run.lines);
+  }
+  run.emitter.emit("done", { exitCode: code });
 }
 
 /** Standalone push action: fetch-rebase → push. */

--- a/lib/security/post-pull.ts
+++ b/lib/security/post-pull.ts
@@ -1,0 +1,173 @@
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+
+const execFileAsync = promisify(execFile);
+
+export interface PullFinding {
+  path: string;
+  reason: string;
+}
+
+async function gitShow(repoPath: string, ref: string, filePath: string): Promise<string | null> {
+  try {
+    const { stdout } = await execFileAsync(
+      "git",
+      ["-C", repoPath, "show", `${ref}:${filePath}`],
+      { timeout: 10_000, env: { ...process.env, GIT_TERMINAL_PROMPT: "0" } },
+    );
+    return stdout;
+  } catch {
+    return null;
+  }
+}
+
+async function packageJsonScriptsChanged(
+  repoPath: string,
+  oldHead: string,
+  newHead: string,
+  filePath: string,
+): Promise<boolean> {
+  const [oldContent, newContent] = await Promise.all([
+    gitShow(repoPath, oldHead, filePath),
+    gitShow(repoPath, newHead, filePath),
+  ]);
+  if (!newContent) return false;
+  if (!oldContent) return true;
+
+  let oldScripts: Record<string, unknown> = {};
+  let newScripts: Record<string, unknown> = {};
+  try {
+    const oldPkg = JSON.parse(oldContent) as Record<string, unknown>;
+    oldScripts = (typeof oldPkg.scripts === "object" && oldPkg.scripts !== null)
+      ? (oldPkg.scripts as Record<string, unknown>)
+      : {};
+  } catch {
+    return true;
+  }
+  try {
+    const newPkg = JSON.parse(newContent) as Record<string, unknown>;
+    newScripts = (typeof newPkg.scripts === "object" && newPkg.scripts !== null)
+      ? (newPkg.scripts as Record<string, unknown>)
+      : {};
+  } catch {
+    return true;
+  }
+
+  const allKeys = new Set([...Object.keys(oldScripts), ...Object.keys(newScripts)]);
+  for (const key of allKeys) {
+    if (oldScripts[key] !== newScripts[key]) return true;
+  }
+  return false;
+}
+
+function classifyPath(filePath: string): string | null {
+  const lower = filePath.toLowerCase();
+  const parts = filePath.split("/");
+  const topLevel = parts[0] ?? "";
+  const topLevelLower = topLevel.toLowerCase();
+
+  if (topLevelLower === "package.json") return "__package_json__";
+
+  if (parts[0] === ".github") {
+    if (parts[1] === "workflows") {
+      return "A CI/CD workflow changed — it controls what happens automatically every time code is pushed. Review before pushing to make sure you understand what will run.";
+    }
+    return "A GitHub configuration file changed — these files control automation, issue templates, and security settings for the project.";
+  }
+
+  if (parts[0] === ".husky") {
+    return "A Git hook changed — these scripts run automatically on your computer when you commit or push. Review before committing to make sure you're OK with what will run.";
+  }
+
+  if (parts[0] === "scripts") {
+    return "A project script changed — these are programs that can run on your computer. Review before running any setup or build commands.";
+  }
+
+  if (parts[0] === ".devcontainer") {
+    return "A dev container configuration changed — this controls the environment that gets built when you open the project in a container. Review before opening.";
+  }
+
+  if (/^dockerfile(\..*)?$/i.test(topLevel)) {
+    return "The Dockerfile changed — this controls what gets built into containers for this project. Review before building.";
+  }
+
+  if (
+    topLevelLower === "docker-compose.yml" ||
+    topLevelLower === "docker-compose.yaml" ||
+    topLevelLower === "compose.yml" ||
+    topLevelLower === "compose.yaml"
+  ) {
+    return "The Docker Compose file changed — this defines the services that run when you start the project. Review before running.";
+  }
+
+  if (
+    topLevelLower === ".gitlab-ci.yml" ||
+    topLevelLower === "bitbucket-pipelines.yml" ||
+    topLevelLower === "azure-pipelines.yml"
+  ) {
+    return "A CI/CD pipeline file changed — it controls what runs automatically on every push. Review before pushing.";
+  }
+
+  if (parts[0] === ".circleci" && parts[1] === "config.yml") {
+    return "The CircleCI config changed — it controls what runs automatically on every push. Review before pushing.";
+  }
+
+  if (
+    topLevelLower === "install.sh" ||
+    topLevelLower === "setup.sh" ||
+    topLevelLower === "bootstrap.sh" ||
+    topLevelLower === "makefile"
+  ) {
+    return "An install or setup script changed — don't run it until you've reviewed what it does. It can make changes to your computer.";
+  }
+
+  return null;
+}
+
+export async function classifyPulledChanges(
+  repoPath: string,
+  oldHead: string,
+  newHead: string,
+): Promise<PullFinding[]> {
+  let changedFiles: string[] = [];
+  try {
+    const { stdout } = await execFileAsync(
+      "git",
+      ["-C", repoPath, "diff", `${oldHead}..${newHead}`, "--name-only"],
+      { timeout: 30_000, env: { ...process.env, GIT_TERMINAL_PROMPT: "0" } },
+    );
+    changedFiles = stdout.split("\n").map((l) => l.trim()).filter(Boolean);
+  } catch {
+    return [];
+  }
+
+  if (changedFiles.length === 0) return [];
+
+  const findings: PullFinding[] = [];
+  const seen = new Set<string>();
+
+  for (const filePath of changedFiles) {
+    const label = classifyPath(filePath);
+    if (!label) continue;
+
+    if (label === "__package_json__") {
+      const changed = await packageJsonScriptsChanged(repoPath, oldHead, newHead, filePath);
+      if (!changed) continue;
+      const key = "package.json:scripts";
+      if (seen.has(key)) continue;
+      seen.add(key);
+      findings.push({
+        path: filePath,
+        reason:
+          "The npm scripts in package.json changed — running 'npm install' or 'npm run' could now execute different code on your computer. Check what changed before installing.",
+      });
+      continue;
+    }
+
+    if (seen.has(filePath)) continue;
+    seen.add(filePath);
+    findings.push({ path: filePath, reason: label });
+  }
+
+  return findings;
+}

--- a/lib/state/store.ts
+++ b/lib/state/store.ts
@@ -10,6 +10,7 @@ export interface RepoView {
   githubName: string | null;
   snapshot: SnapshotRow | null;
   derivedState: DerivedState;
+  pullAlertCount?: number;
 }
 
 export type DerivedState =


### PR DESCRIPTION
## Summary

- After a successful `git pull`, scan the pulled diff for files that could run code on the user's machine (npm scripts, CI workflows, husky hooks, Dockerfiles, install scripts, etc.)
- If sensitive-path changes are found, persist them in a new `pull_alerts` DB table and surface them in two places: the pull modal's closing screen and a dismissible badge on the repo row
- Warning stays visible until the user clicks "Got it, dismiss" — the badge disappears immediately on dismiss

## Files changed

| File | Role |
|------|------|
| `lib/security/post-pull.ts` (new, ~140 lines) | Classifier: `classifyPulledChanges(repoPath, oldHead, newHead)` — diffs changed files, checks sensitive path patterns, deep-checks `package.json` scripts |
| `lib/db/alerts.ts` (new, ~75 lines) | DB helpers: `insertPullAlert`, `getUnacknowledgedAlerts`, `dismissAlert`, `getUnacknowledgedAlertCounts` |
| `lib/db/schema.ts` | Adds `pull_alerts` table + index (via `CREATE TABLE IF NOT EXISTS`) |
| `lib/git/actions.ts` | `executePull()` — captures pre-pull HEAD, spawns `git pull --ff-only`, runs classifier on success, emits `{ exitCode, pullFindings }` in the SSE `done` event |
| `lib/state/store.ts` | Adds optional `pullAlertCount` field to `RepoView` |
| `app/api/repos/route.ts` | Includes `pullAlertCount` in the repos list response |
| `app/api/repos/[id]/pull-alerts/route.ts` (new) | `GET` — list unacknowledged alerts |
| `app/api/repos/[id]/pull-alerts/[alertId]/dismiss/route.ts` (new) | `POST` (CSRF-gated) — dismiss an alert |
| `components/ActionModal.tsx` | Renders `PullFindingsAlert` section in the done phase when findings arrive via SSE |
| `components/RepoCard.tsx` | Dismissible "Review pulled changes" badge + `PullAlertModal` popover with findings list and dismiss button |

## Test plan

1. Find a repo that has incoming commits (or create one: push a commit with a modified `package.json` scripts block from another machine/clone)
2. Click **Pull** on a repo where the incoming diff includes one of:
   - A `package.json` with a changed `scripts` entry
   - A file in `.github/workflows/`
   - A file in `.husky/`
   - An `install.sh` or `setup.sh`
3. **Pass**: Pull modal shows a yellow "Review these changes before running any setup" section listing the sensitive files with beginner-friendly reasons
4. **Pass**: After closing the modal, the repo row shows a yellow "Review pulled changes" badge
5. Click the badge → popover opens with the same findings list + "Got it, dismiss" button
6. **Pass**: Clicking "Got it, dismiss" closes the popover and the badge disappears from the row
7. Pull a repo where only non-sensitive files changed (e.g. only `.ts` source files)
8. **Pass**: No yellow badge, no alert section in the modal

Closes #95

🤖 Generated with [Claude Code](https://claude.com/claude-code)