### PR TITLE
feat(security): flag prompt-injection patterns in commit-push preview

### DIFF
--- a/app/api/repos/[id]/changes/route.ts
+++ b/app/api/repos/[id]/changes/route.ts
@@ -4,6 +4,8 @@ import path from "node:path";
 import { bootstrap } from "@/lib/bootstrap";
 import { getRepoById } from "@/lib/db/repos";
 import { runGit } from "@/lib/git/exec";
+import { scanForPromptInjection } from "@/lib/security/prompt-injection";
+import type { PromptInjectionFinding } from "@/lib/security/prompt-injection";
 
 export const dynamic = "force-dynamic";
 export const runtime = "nodejs";
@@ -101,10 +103,28 @@ export async function GET(
 
   const suspicious = entries.filter((e) => e.reason !== null);
 
+  // Collect the relative paths and which ones are deleted (no file on disk)
+  const deletedPaths = new Set<string>(
+    entries.filter((e) => e.status.trim().startsWith("D")).map((e) => e.path),
+  );
+  const relPaths = entries.map((e) => e.path);
+
+  let promptInjectionFindings: PromptInjectionFinding[] = [];
+  let promptInjectionTruncated = false;
+  try {
+    const piResult = await scanForPromptInjection(relPaths, repoRoot, deletedPaths);
+    promptInjectionFindings = piResult.findings;
+    promptInjectionTruncated = piResult.truncated;
+  } catch {
+    // scanner errors never block the preview
+  }
+
   return NextResponse.json({
     files: entries,
     total: chunks.length,
     suspicious,
     truncated,
+    promptInjectionFindings,
+    promptInjectionTruncated,
   });
 }

--- a/components/ActionModal.tsx
+++ b/components/ActionModal.tsx
@@ -45,11 +45,21 @@ interface ChangeEntry {
   reason: "secret" | "large" | null;
 }
 
+interface PromptInjectionFinding {
+  path: string;
+  line: number;
+  snippet: string;
+  patternId: number;
+  patternLabel: string;
+}
+
 interface ChangesResponse {
   files: ChangeEntry[];
   total: number;
   suspicious: ChangeEntry[];
   truncated: boolean;
+  promptInjectionFindings: PromptInjectionFinding[];
+  promptInjectionTruncated: boolean;
 }
 
 export function ActionModal({ repo, action, csrfToken, onClose }: Props) {
@@ -399,6 +409,8 @@ function CommitPushConfirm({
 }) {
   const total = changes?.total ?? 0;
   const suspicious = changes?.suspicious ?? [];
+  const promptInjectionFindings = changes?.promptInjectionFindings ?? [];
+  const promptInjectionTruncated = changes?.promptInjectionTruncated ?? false;
   const submitLabel = pushAfter ? "Commit & push" : "Commit";
 
   return (
@@ -458,6 +470,13 @@ function CommitPushConfirm({
                 )}
               </div>
             </div>
+          )}
+
+          {promptInjectionFindings.length > 0 && (
+            <PromptInjectionFindingsSection
+              findings={promptInjectionFindings}
+              truncated={promptInjectionTruncated}
+            />
           )}
         </>
       )}
@@ -630,6 +649,63 @@ function PublishToGithubConfirm({
         >
           Publish
         </button>
+      </div>
+    </div>
+  );
+}
+
+function PromptInjectionFindingsSection({
+  findings,
+  truncated,
+}: {
+  findings: PromptInjectionFinding[];
+  truncated: boolean;
+}) {
+  const MAX_SHOW = 30;
+  const shown = findings.slice(0, MAX_SHOW);
+  const overflow = findings.length - shown.length;
+
+  return (
+    <div className="rounded-lg border border-yellow-500/30 bg-yellow-500/8 p-4">
+      <div className="flex gap-3">
+        <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0 text-yellow-400" />
+        <div className="min-w-0 flex-1 text-[12.5px] text-fg-muted">
+          <p className="font-medium text-fg">Possible prompt-injection patterns detected</p>
+          <p className="mt-0.5 text-[11.5px] text-fg-dim">
+            Text that tries to override an AI&rsquo;s instructions. These don&rsquo;t block your push — review if you didn&rsquo;t mean to commit them.
+          </p>
+
+          <ul className="mt-2 space-y-1.5">
+            {shown.map((f, i) => (
+              <li key={i} className="flex flex-col gap-0.5">
+                <div className="flex items-baseline gap-2 flex-wrap">
+                  <span className="mono text-[11px] text-yellow-400 shrink-0">
+                    {f.path}:{f.line}
+                  </span>
+                  <span className="rounded bg-fg/8 px-1 py-px text-[10px] uppercase tracking-wide text-fg-dim">
+                    {f.patternLabel}
+                  </span>
+                </div>
+                <span className="mono text-[11px] text-fg-dim truncate block" title={f.snippet}>
+                  {f.snippet}
+                </span>
+              </li>
+            ))}
+          </ul>
+
+          {overflow > 0 && (
+            <p className="mt-2 text-[11px] text-fg-dim">…and {overflow} more</p>
+          )}
+          {truncated && overflow === 0 && (
+            <p className="mt-2 text-[11px] text-fg-dim">(showing first {MAX_SHOW})</p>
+          )}
+
+          <p className="mt-3 text-[10.5px] text-fg-dim">
+            If a file is intentionally a prompt or eval, add{" "}
+            <code className="mono rounded bg-fg/8 px-1">gitdash:skip-prompt-injection</code>{" "}
+            anywhere in it to suppress this check.
+          </p>
+        </div>
       </div>
     </div>
   );

--- a/lib/security/prompt-injection.ts
+++ b/lib/security/prompt-injection.ts
@@ -1,0 +1,147 @@
+/**
+ * Prompt-injection pattern scanner for staged files.
+ *
+ * Reads each staged file through the shared staged-files filter and tests
+ * every non-empty line against a small set of high-signal regexes.  Returns
+ * informational findings only — nothing is blocked.
+ *
+ * Opt-out: if a file contains the literal string `gitdash:skip-prompt-injection`
+ * anywhere in its content, the file is skipped entirely.
+ */
+
+import { createHash } from "node:crypto";
+import { readStagedFiles } from "./staged-files";
+
+// ---------------------------------------------------------------------------
+// Patterns (v1 — conservative, high-signal only)
+// ---------------------------------------------------------------------------
+
+const PATTERNS: Array<{ id: PatternId; label: string; re: RegExp }> = [
+  {
+    id: 1,
+    label: "ignore-previous",
+    re: /\bignore (the |all |any )?(previous|prior|above) (instructions?|prompts?|messages?|directives?)\b/i,
+  },
+  {
+    id: 2,
+    label: "disregard-above",
+    re: /\bdisregard (the |all |any )?(above|previous|prior) (instructions?|prompts?|messages?|directives?)\b/i,
+  },
+  {
+    id: 3,
+    label: "you-are-now",
+    re: /\byou are now (a |an )?[A-Za-z]/i,
+  },
+  {
+    id: 4,
+    label: "from-now-on",
+    re: /\bfrom now on,?\s*(you (will|are|must|shall)|act as|behave as|pretend (to be|you are))\b/i,
+  },
+  {
+    id: 5,
+    label: "forget-everything",
+    re: /\b(forget|ignore) (everything|all) (you('?ve| have)? )?(been told|learned|know)\b/i,
+  },
+];
+
+type PatternId = 1 | 2 | 3 | 4 | 5;
+
+export interface PromptInjectionFinding {
+  path: string;
+  line: number;
+  snippet: string;
+  patternId: PatternId;
+  patternLabel: string;
+}
+
+const SKIP_MARKER = "gitdash:skip-prompt-injection";
+const MAX_FINDINGS = 30;
+const SNIPPET_MAX = 120;
+
+// ---------------------------------------------------------------------------
+// In-memory cache keyed by sha256(file content)
+// ---------------------------------------------------------------------------
+
+const cache = new Map<string, PromptInjectionFinding[]>();
+
+function cacheKey(content: string): string {
+  return createHash("sha256").update(content).digest("hex");
+}
+
+function scanContent(relPath: string, content: string): PromptInjectionFinding[] {
+  if (content.includes(SKIP_MARKER)) return [];
+
+  const key = cacheKey(content);
+  const cached = cache.get(key);
+  if (cached !== undefined) {
+    // Re-map to the current path (path is not part of the cache key)
+    return cached.map((f) => ({ ...f, path: relPath }));
+  }
+
+  const findings: PromptInjectionFinding[] = [];
+  const lines = content.split("\n");
+
+  outer: for (let i = 0; i < lines.length; i++) {
+    const lineText = lines[i]!;
+    for (const pattern of PATTERNS) {
+      if (pattern.re.test(lineText)) {
+        findings.push({
+          path: relPath,
+          line: i + 1, // 1-based
+          snippet: lineText.trim().slice(0, SNIPPET_MAX),
+          patternId: pattern.id,
+          patternLabel: pattern.label,
+        });
+        // One finding per line maximum; move to the next line
+        if (findings.length >= MAX_FINDINGS) break outer;
+        break;
+      }
+    }
+  }
+
+  // Cache the result without path so it can be reused for other paths with
+  // identical content (e.g. copied files).
+  cache.set(key, findings.map((f) => ({ ...f, path: "" })));
+  return findings;
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Scan staged files for prompt-injection patterns.
+ *
+ * Never throws — any internal error silently returns an empty array so it
+ * cannot block the commit-push preview.
+ */
+export async function scanForPromptInjection(
+  relPaths: string[],
+  repoRoot: string,
+  deletedPaths: Set<string>,
+): Promise<{ findings: PromptInjectionFinding[]; truncated: boolean }> {
+  try {
+    const stagedFiles = await readStagedFiles(relPaths, repoRoot, deletedPaths);
+    const allFindings: PromptInjectionFinding[] = [];
+    let truncated = false;
+
+    for (const file of stagedFiles) {
+      if (allFindings.length >= MAX_FINDINGS) {
+        truncated = true;
+        break;
+      }
+      const fileFindings = scanContent(file.relPath, file.content);
+      for (const f of fileFindings) {
+        allFindings.push(f);
+        if (allFindings.length >= MAX_FINDINGS) {
+          truncated = true;
+          break;
+        }
+      }
+    }
+
+    return { findings: allFindings, truncated };
+  } catch {
+    return { findings: [], truncated: false };
+  }
+}

--- a/lib/security/staged-files.ts
+++ b/lib/security/staged-files.ts
@@ -1,0 +1,80 @@
+/**
+ * Shared filter for staged-file scanners.
+ *
+ * Rules (same for all scanners — secret-scan, prompt-injection, etc.):
+ *  - Skip files > 1 MB
+ *  - Skip binary files (null byte in first 8 KB)
+ *  - Skip known lockfiles by name
+ *  - Skip deleted files (nothing to read)
+ */
+
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+
+const LOCK_FILES = new Set([
+  "package-lock.json",
+  "yarn.lock",
+  "pnpm-lock.yaml",
+  "bun.lock",
+  "Cargo.lock",
+  "Gemfile.lock",
+  "poetry.lock",
+  "composer.lock",
+]);
+
+const MAX_SCAN_SIZE = 1 * 1024 * 1024; // 1 MB
+const BINARY_PROBE = 8 * 1024; // 8 KB
+
+export interface StagedFile {
+  /** Relative path inside the repo */
+  relPath: string;
+  /** Absolute path on disk */
+  absPath: string;
+  /** Raw UTF-8 content of the file */
+  content: string;
+}
+
+/**
+ * Given a list of relative paths (as returned by `git status --porcelain`),
+ * resolve them against `repoRoot`, apply all skip filters, read the content,
+ * and return only the files that should be scanned.
+ *
+ * `deletedPaths` should be the set of paths whose porcelain status starts with
+ * 'D' — those files don't exist on disk and must be excluded.
+ */
+export async function readStagedFiles(
+  relPaths: string[],
+  repoRoot: string,
+  deletedPaths: Set<string>,
+): Promise<StagedFile[]> {
+  const repoRootNorm = repoRoot.endsWith(path.sep) ? repoRoot : repoRoot + path.sep;
+  const results: StagedFile[] = [];
+
+  for (const relPath of relPaths) {
+    if (deletedPaths.has(relPath)) continue;
+
+    const baseName = path.basename(relPath);
+    if (LOCK_FILES.has(baseName)) continue;
+
+    const absPath = path.resolve(repoRoot, relPath);
+    // Path traversal guard
+    if (absPath !== repoRoot && !absPath.startsWith(repoRootNorm)) continue;
+
+    let buf: Buffer;
+    try {
+      buf = await readFile(absPath);
+    } catch {
+      continue;
+    }
+
+    if (buf.length > MAX_SCAN_SIZE) continue;
+
+    // Binary probe — null byte in first 8 KB
+    const probe = buf.subarray(0, BINARY_PROBE);
+    if (probe.includes(0)) continue;
+
+    results.push({ relPath, absPath, content: buf.toString("utf8") });
+  }
+
+  return results;
+}


### PR DESCRIPTION
## Summary

- Adds `lib/security/prompt-injection.ts` — scans staged text files with 5 conservative regexes and returns findings
- Adds `lib/security/staged-files.ts` — shared filter helper (>1 MB skip, binary skip, lockfile skip, deleted-path skip) used by the scanner
- Extends `/api/repos/[id]/changes` response with `promptInjectionFindings` + `promptInjectionTruncated`
- Adds `PromptInjectionFindingsSection` component in `ActionModal.tsx` — yellow informational banner below the existing secret-name warnings

**Flag-only, not blocking** — consistent with the npm audit warning redesign in #93.  The section is informational; users can still commit and push regardless of findings.

Closes #96

## Patterns implemented

| ID | Label | Matches |
|----|-------|---------|
| 1 | `ignore-previous` | "ignore the previous instructions" and variants |
| 2 | `disregard-above` | "disregard the above directives" and variants |
| 3 | `you-are-now` | "You are now DAN" / "You are now an unrestricted AI" |
| 4 | `from-now-on` | "From now on, act as …" / "from now on you will …" |
| 5 | `forget-everything` | "forget everything you know" and variants |

**Opt-out:** add `gitdash:skip-prompt-injection` anywhere in a file to suppress scanning for that file (for system-prompt files, eval datasets, security-research docs, etc.).

## Test plan

- [ ] Open the commit-push modal on a repo with a staged file containing `ignore the previous instructions` — yellow banner should appear with the file path, line number, matched snippet, and `ignore-previous` label
- [ ] Add `gitdash:skip-prompt-injection` anywhere in that file, stage the change, re-open modal — banner disappears for that file
- [ ] Verify a repo with no suspicious staged files shows no banner
- [ ] Verify binary files, lockfiles, and files >1 MB are silently skipped
- [ ] Verify the commit/push buttons are not disabled — findings are informational only

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>