### PR TITLE
fix(autoheal): never show "Application error: a client-side exception"

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -127,6 +127,33 @@ Edit `lib/db/schema.ts` (add to `CREATE TABLE` — there's no migrations system,
 
 When extending: keep these guards. Don't reach for `bash -c`, don't bypass the allowlists.
 
+## Auto-heal contract — NEVER show "Application error: a client-side exception"
+
+That bare Next.js error page is a North Star violation: a beginner stuck on it has nothing to click. Four layers prevent it from ever being seen, and you must keep all four working when you change client code:
+
+1. **`app/global-error.tsx`** — root error boundary. Replaces Next's default. Detects `ChunkLoadError` (or any chunk-load pattern) via `lib/autoheal.ts::isChunkLoadError` and hard-reloads immediately. For other errors, shows a friendly UI and auto-reloads after 5s.
+2. **`app/error.tsx`** — page-level boundary. Same contract, with `reset()` exposed as a soft retry. Catches errors thrown inside the dashboard tree.
+3. **`components/ChunkErrorGuard.tsx`** — mounted once in `app/layout.tsx`. Subscribes to `window.error` and `window.unhandledrejection` to catch async chunk failures (lazy `import()`, dynamic CSS) that bypass React boundaries because they happen outside the render cycle.
+4. **`components/UpdateBanner.tsx` + `next.config.mjs::generateBuildId`** — `BUILD_ID` is pinned to `<commit>-<builtAt>`. The banner polls `/api/version` every 30s; on commit mismatch it auto-`hardReload`s after 5s, so a stale tab can't keep pointing at chunk hashes the new build deleted.
+
+All four call into `lib/autoheal.ts`, which provides:
+
+- `isChunkLoadError(err)` — pattern-matches the known ChunkLoadError shapes.
+- `tryConsumeReloadBudget()` — sessionStorage-backed reload-loop guard. Caps auto-reloads at 3 inside a 30s window so a truly broken build can't spin the browser. After the budget is exhausted, the boundaries fall back to the friendly UI ("Auto-reload paused — click Reload to try once more").
+- `hardReload()` — `window.location.replace` with a cache-busting `_gitdash_heal=<ts>` query so proxies / disk cache can't keep handing back the stale HTML.
+
+**When adding new client features:**
+- Don't catch errors silently in a way that hides them from the boundaries — let them bubble so the auto-heal can run.
+- If you add a new lazy `import()` or dynamic chunk, you don't need to do anything special; `ChunkErrorGuard` already covers it.
+- If you bump the version-poll interval or move `/api/version`, update `UpdateBanner` and re-test the auto-reload path.
+- `lib/autoheal.ts` must remain client-safe (no `node:` imports). It's imported by both server-rendered (`global-error.tsx`) and client (`UpdateBanner`, boundaries) code.
+
+**How to verify locally** (do this before merging anything that touches the auto-heal layer):
+1. Build, start, open the dashboard.
+2. Throw a synthetic error from a component (`throw new Error('boom')`) → `app/error.tsx` should render with auto-reload countdown.
+3. Throw `new Error('ChunkLoadError: Loading chunk 5 failed')` from a component → page should hard-reload within ~1s.
+4. Trigger the reload-loop guard (throw on every render) → after 3 reloads in 30s the friendly UI sticks instead of looping.
+
 ## Things that bite
 
 - The scheduler/watcher/store singletons live on `globalThis` via `Symbol.for(...)` keys to survive Next.js HMR. Don't `new Scheduler()` directly anywhere else.
@@ -134,3 +161,5 @@ When extending: keep these guards. Don't reach for `bash -c`, don't bypass the a
 - `next start` (and `bin/gitdash start`) loads the build artifact ONCE at boot. After `npm run build`, the running process must be restarted to pick up changes — there's no hot reload. Killing the listener PID and re-running `bin/gitdash start` is the supported flow.
 - `gh` ETag cache lives in the SQLite DB. If you wipe the DB, expect a brief burst of full GitHub API calls until ETags re-populate.
 - Repos with `.git` as a *file* (worktrees) are handled in `detectWeirdFlags` — preserve that path resolution if you touch it.
+- **`JSON.parse` on external data is always wrapped in try/catch.** Includes SSE event payloads, `fetch().then(r => r.json())`, `localStorage`, and any `postMessage` handler. A single malformed frame must not throw out of an event listener. The Dashboard SSE handlers (`components/Dashboard.tsx:192-205`) are the canonical pattern: try/catch + `console.error` + drop the frame. Without this guard the auto-heal boundary catches the throw, but you eat a full reload for what could have been a one-frame skip.
+- **`productionBrowserSourceMaps: true` stays on in `next.config.mjs`.** Self-hosted, LAN-only tool, no public attack surface. Debugging a beginner's "it crashed" report on a minified stack is impossible. The 20% bundle-size hit is worth it. Don't turn it off "to ship faster".

--- a/app/error.tsx
+++ b/app/error.tsx
@@ -1,0 +1,77 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { hardReload, isChunkLoadError, tryConsumeReloadBudget } from "@/lib/autoheal";
+
+// Page-level error boundary. Catches errors thrown inside the dashboard tree
+// (anything below RootLayout). Same auto-heal contract as global-error.tsx
+// but renders inside the existing layout chrome, and exposes reset() so a
+// soft retry is possible without a full page reload.
+export default function PageError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  const chunk = isChunkLoadError(error);
+  const [secondsLeft, setSecondsLeft] = useState(chunk ? 0 : 5);
+
+  useEffect(() => {
+    if (typeof console !== "undefined") {
+      console.error("[gitdash] page error boundary tripped:", error);
+    }
+
+    if (chunk) {
+      if (tryConsumeReloadBudget()) {
+        hardReload();
+        return;
+      }
+      return;
+    }
+
+    if (!tryConsumeReloadBudget()) return;
+    const tick = setInterval(() => {
+      setSecondsLeft((s) => {
+        if (s <= 1) {
+          clearInterval(tick);
+          hardReload();
+          return 0;
+        }
+        return s - 1;
+      });
+    }, 1_000);
+    return () => clearInterval(tick);
+  }, [chunk, error]);
+
+  return (
+    <main className="grain relative mx-auto flex min-h-[60vh] max-w-[640px] flex-col items-center justify-center gap-5 px-4 py-16 text-center sm:py-24">
+      <h1 className="display text-[28px] tracking-display-tight text-fg sm:text-[32px]">
+        {chunk ? "Reloading…" : "Something glitched."}
+      </h1>
+      <p className="max-w-md text-[14px] leading-relaxed text-fg-muted sm:text-[15px]">
+        {chunk
+          ? "gitdash was just updated — refreshing to pick up the new version."
+          : secondsLeft > 0
+            ? `Auto-reloading in ${secondsLeft}s. If it keeps happening, try again from the dashboard.`
+            : "Auto-reload paused after a few attempts. Click Reload to try once more."}
+      </p>
+      <div className="flex flex-wrap items-center justify-center gap-3">
+        <button
+          type="button"
+          onClick={() => hardReload()}
+          className="rounded-full bg-accent-clean px-5 py-2 text-[13px] font-semibold text-bg transition-colors hover:opacity-90"
+        >
+          Reload now
+        </button>
+        <button
+          type="button"
+          onClick={() => reset()}
+          className="rounded-full border border-border px-5 py-2 text-[13px] font-medium text-fg-muted transition-colors hover:border-fg-muted hover:text-fg"
+        >
+          Try again
+        </button>
+      </div>
+    </main>
+  );
+}

--- a/app/global-error.tsx
+++ b/app/global-error.tsx
@@ -1,0 +1,118 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { hardReload, isChunkLoadError, tryConsumeReloadBudget } from "@/lib/autoheal";
+
+// Root-level error boundary. Catches anything that escapes layout.tsx — e.g.
+// a render error in the dashboard tree or a chunk failure during initial
+// hydration. Without this file, Next.js shows the bare "Application error"
+// page, which is exactly what we're trying to eliminate.
+//
+// Behavior:
+//   - ChunkLoadError → hard-reload immediately (within budget). The new HTML
+//     will reference fresh hashes.
+//   - Anything else → friendly UI + Reload button + auto-reload after 5s.
+//   - Loop guard: third reload in 30s shows the friendly UI instead, so a
+//     truly broken build can't spin the browser forever.
+export default function GlobalError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  const chunk = isChunkLoadError(error);
+  const [secondsLeft, setSecondsLeft] = useState(chunk ? 0 : 5);
+
+  useEffect(() => {
+    if (typeof window !== "undefined" && typeof console !== "undefined") {
+      console.error("[gitdash] global error boundary tripped:", error);
+    }
+
+    if (chunk) {
+      if (tryConsumeReloadBudget()) {
+        hardReload();
+        return;
+      }
+      return;
+    }
+
+    if (!tryConsumeReloadBudget()) return;
+    const tick = setInterval(() => {
+      setSecondsLeft((s) => {
+        if (s <= 1) {
+          clearInterval(tick);
+          hardReload();
+          return 0;
+        }
+        return s - 1;
+      });
+    }, 1_000);
+    return () => clearInterval(tick);
+  }, [chunk, error]);
+
+  return (
+    <html lang="en">
+      <body
+        style={{
+          margin: 0,
+          minHeight: "100vh",
+          display: "grid",
+          placeItems: "center",
+          fontFamily:
+            "ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif",
+          background: "#0b0d0c",
+          color: "#e8efe9",
+          padding: "24px",
+        }}
+      >
+        <div style={{ maxWidth: 480, textAlign: "center" }}>
+          <h1 style={{ fontSize: 28, fontWeight: 500, margin: "0 0 12px" }}>
+            {chunk ? "Reloading…" : "Something glitched."}
+          </h1>
+          <p style={{ fontSize: 15, lineHeight: 1.55, color: "#9aa6a0", margin: "0 0 24px" }}>
+            {chunk
+              ? "gitdash was just updated — refreshing to pick up the new version."
+              : secondsLeft > 0
+                ? `Auto-reloading in ${secondsLeft}s. If it keeps happening, try again from the dashboard.`
+                : "Auto-reload paused after a few attempts. Click Reload to try once more."}
+          </p>
+          <div style={{ display: "flex", gap: 12, justifyContent: "center" }}>
+            <button
+              type="button"
+              onClick={() => hardReload()}
+              style={{
+                background: "#3aa688",
+                color: "#0b0d0c",
+                border: 0,
+                borderRadius: 999,
+                padding: "10px 20px",
+                fontSize: 14,
+                fontWeight: 600,
+                cursor: "pointer",
+              }}
+            >
+              Reload now
+            </button>
+            <button
+              type="button"
+              onClick={() => reset()}
+              style={{
+                background: "transparent",
+                color: "#9aa6a0",
+                border: "1px solid #2a3431",
+                borderRadius: 999,
+                padding: "10px 20px",
+                fontSize: 14,
+                fontWeight: 500,
+                cursor: "pointer",
+              }}
+            >
+              Try again
+            </button>
+          </div>
+        </div>
+      </body>
+    </html>
+  );
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -3,6 +3,7 @@ import { Instrument_Serif, Instrument_Sans, IBM_Plex_Mono } from "next/font/goog
 import "./globals.css";
 import { VersionBadge } from "@/components/VersionBadge";
 import { UpdateBanner } from "@/components/UpdateBanner";
+import { ChunkErrorGuard } from "@/components/ChunkErrorGuard";
 
 const serif = Instrument_Serif({
   subsets: ["latin"],
@@ -46,6 +47,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
         <script dangerouslySetInnerHTML={{ __html: themeBootScript }} />
       </head>
       <body suppressHydrationWarning>
+        <ChunkErrorGuard />
         {children}
         <UpdateBanner />
         <VersionBadge />

--- a/components/ChunkErrorGuard.tsx
+++ b/components/ChunkErrorGuard.tsx
@@ -1,0 +1,39 @@
+"use client";
+
+import { useEffect } from "react";
+import { hardReload, isChunkLoadError, tryConsumeReloadBudget } from "@/lib/autoheal";
+
+// Catches async chunk-load failures that bypass React error boundaries.
+// React boundaries only see render-time errors; if a lazy import() promise or
+// dynamic chunk fetch rejects outside the render cycle the error reaches
+// `window.onerror` / `window.onunhandledrejection` instead. Without this guard
+// those failures still produce the bare "Application error" page after Next's
+// internal recovery gives up.
+//
+// Mount once at the layout root.
+export function ChunkErrorGuard() {
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+
+    const handleError = (event: ErrorEvent) => {
+      if (!isChunkLoadError(event.error ?? event.message)) return;
+      if (!tryConsumeReloadBudget()) return;
+      hardReload();
+    };
+
+    const handleRejection = (event: PromiseRejectionEvent) => {
+      if (!isChunkLoadError(event.reason)) return;
+      if (!tryConsumeReloadBudget()) return;
+      hardReload();
+    };
+
+    window.addEventListener("error", handleError);
+    window.addEventListener("unhandledrejection", handleRejection);
+    return () => {
+      window.removeEventListener("error", handleError);
+      window.removeEventListener("unhandledrejection", handleRejection);
+    };
+  }, []);
+
+  return null;
+}

--- a/components/Dashboard.tsx
+++ b/components/Dashboard.tsx
@@ -190,12 +190,20 @@ export function Dashboard({ initialRepos, csrfToken }: Props) {
         setConnected(true);
       });
       source.addEventListener("snapshot", (ev) => {
-        const data = JSON.parse((ev as MessageEvent).data) as { repos: RepoView[] };
-        setRepos(data.repos);
+        try {
+          const data = JSON.parse((ev as MessageEvent).data) as { repos: RepoView[] };
+          setRepos(data.repos);
+        } catch (err) {
+          console.error("[gitdash] dropped malformed snapshot SSE frame:", err);
+        }
       });
       source.addEventListener("bulk", (ev) => {
-        const data = JSON.parse((ev as MessageEvent).data) as { repos: RepoView[] };
-        setRepos(data.repos);
+        try {
+          const data = JSON.parse((ev as MessageEvent).data) as { repos: RepoView[] };
+          setRepos(data.repos);
+        } catch (err) {
+          console.error("[gitdash] dropped malformed bulk SSE frame:", err);
+        }
       });
       source.addEventListener("update", async () => {
         try {

--- a/components/UpdateBanner.tsx
+++ b/components/UpdateBanner.tsx
@@ -2,11 +2,14 @@
 
 import { useEffect, useState } from "react";
 import { cn } from "@/lib/utils";
+import { hardReload, tryConsumeReloadBudget } from "@/lib/autoheal";
 
 const BUNDLED_COMMIT = process.env.NEXT_PUBLIC_GITDASH_COMMIT ?? "";
+const AUTO_RELOAD_AFTER_MS = 5_000;
 
 export function UpdateBanner() {
   const [serverCommit, setServerCommit] = useState<string | null>(null);
+  const [autoReloadAt, setAutoReloadAt] = useState<number | null>(null);
 
   useEffect(() => {
     // Don't poll if we have nothing to compare against (e.g. tarball install)
@@ -47,11 +50,28 @@ export function UpdateBanner() {
     };
   }, []);
 
-  // No BUNDLED_COMMIT means we can't compare — render nothing
-  if (!BUNDLED_COMMIT) return null;
+  const mismatch = !!(BUNDLED_COMMIT && serverCommit && serverCommit !== BUNDLED_COMMIT);
 
-  // Still loading or commits match — no banner needed
-  if (!serverCommit || serverCommit === BUNDLED_COMMIT) return null;
+  useEffect(() => {
+    if (!mismatch) {
+      setAutoReloadAt(null);
+      return;
+    }
+    // Auto-reload onto the new build so a stale tab can't keep loading dead
+    // chunk hashes. The reload-budget guard prevents loops if the mismatch
+    // somehow persists across reloads.
+    if (!tryConsumeReloadBudget()) return;
+    const fireAt = Date.now() + AUTO_RELOAD_AFTER_MS;
+    setAutoReloadAt(fireAt);
+    const t = setTimeout(() => hardReload(), AUTO_RELOAD_AFTER_MS);
+    return () => clearTimeout(t);
+  }, [mismatch]);
+
+  if (!mismatch) return null;
+
+  const secondsLeft = autoReloadAt
+    ? Math.max(0, Math.ceil((autoReloadAt - Date.now()) / 1_000))
+    : null;
 
   return (
     <div
@@ -63,16 +83,19 @@ export function UpdateBanner() {
       )}
       role="status"
     >
-      <span>A new version of gitdash is available.</span>
+      <span>
+        New gitdash version detected
+        {secondsLeft !== null ? ` — reloading in ${secondsLeft}s.` : "."}
+      </span>
       <button
         type="button"
-        onClick={() => window.location.reload()}
+        onClick={() => hardReload()}
         className={cn(
           "rounded-md bg-accent-positive px-3 py-1 text-sm font-medium",
           "text-bg hover:opacity-90",
         )}
       >
-        Reload
+        Reload now
       </button>
     </div>
   );

--- a/lib/autoheal.ts
+++ b/lib/autoheal.ts
@@ -1,0 +1,129 @@
+// Client-only helpers for auto-healing transient client-side failures.
+//
+// Two failure modes drive most "Application error: a client-side exception"
+// pages:
+//   1. Stale chunks — after a rebuild the running next-server (or a long-lived
+//      tab) tries to load /_next/static/chunks/<old-hash>.js which 404s and
+//      throws ChunkLoadError. The fix is a hard reload; the new HTML points at
+//      the new hashes.
+//   2. Genuine bugs — anything else. We can't recover, but we can replace the
+//      bare Next.js fallback with a friendly UI + Reload + delayed auto-reload.
+//
+// The reload-loop guard caps total auto-reloads at 3 inside a 30s window so a
+// truly broken build can't spin the browser forever — the third hit shows the
+// friendly UI instead.
+//
+// All functions here are SSR-safe (guarded by typeof window).
+"use client";
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+const RELOAD_BUDGET_KEY = "gitdash:autoheal:reloads";
+const RELOAD_WINDOW_MS = 30_000;
+const RELOAD_BUDGET = 3;
+
+const CHUNK_PATTERN =
+  /chunkloaderror|loading chunk|loading css chunk|failed to fetch dynamically imported module|error loading dynamically imported module/i;
+
+interface ReloadBudget {
+  count: number;
+  firstAt: number;
+}
+
+function readBudget(): ReloadBudget {
+  if (typeof window === "undefined") return { count: 0, firstAt: 0 };
+  try {
+    const raw = window.sessionStorage.getItem(RELOAD_BUDGET_KEY);
+    if (!raw) return { count: 0, firstAt: 0 };
+    const parsed = JSON.parse(raw) as ReloadBudget;
+    if (Date.now() - parsed.firstAt > RELOAD_WINDOW_MS) {
+      return { count: 0, firstAt: 0 };
+    }
+    return parsed;
+  } catch {
+    return { count: 0, firstAt: 0 };
+  }
+}
+
+function writeBudget(b: ReloadBudget): void {
+  if (typeof window === "undefined") return;
+  try {
+    window.sessionStorage.setItem(RELOAD_BUDGET_KEY, JSON.stringify(b));
+  } catch {
+    // sessionStorage may be unavailable (private mode, etc.) — without it the
+    // loop guard degrades to "always allowed", which is acceptable.
+  }
+}
+
+export function isChunkLoadError(err: unknown): boolean {
+  if (!err) return false;
+  const msg =
+    err instanceof Error
+      ? `${err.name} ${err.message}`
+      : typeof err === "string"
+        ? err
+        : (() => {
+            try {
+              return JSON.stringify(err);
+            } catch {
+              return String(err);
+            }
+          })();
+  return CHUNK_PATTERN.test(msg);
+}
+
+/**
+ * Returns true if the caller is allowed to auto-reload right now. Increments
+ * the budget. Returns false once the cap is hit so the UI can fall back to
+ * "show the friendly error and let the human decide".
+ */
+export function tryConsumeReloadBudget(): boolean {
+  if (typeof window === "undefined") return false;
+  const budget = readBudget();
+  const now = Date.now();
+  if (budget.count === 0 || now - budget.firstAt > RELOAD_WINDOW_MS) {
+    writeBudget({ count: 1, firstAt: now });
+    return true;
+  }
+  if (budget.count >= RELOAD_BUDGET) return false;
+  writeBudget({ count: budget.count + 1, firstAt: budget.firstAt });
+  return true;
+}
+
+/**
+ * Hard-reload with a cache-bust query so intermediaries (proxies, service
+ * workers, the browser disk cache) can't keep handing back the stale HTML.
+ * Strips any prior _gitdash_heal param to avoid stacking.
+ */
+export function hardReload(): void {
+  if (typeof window === "undefined") return;
+  try {
+    const url = new URL(window.location.href);
+    url.searchParams.delete("_gitdash_heal");
+    url.searchParams.set("_gitdash_heal", String(Date.now()));
+    window.location.replace(url.toString());
+  } catch {
+    window.location.reload();
+  }
+}

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -24,6 +24,17 @@ const nextConfig = {
   serverExternalPackages: ["better-sqlite3", "chokidar"],
   typescript: { ignoreBuildErrors: false },
   eslint: { ignoreDuringBuilds: false },
+  // Self-hosted, LAN-only tool — minified stack traces are useless when
+  // debugging a beginner's "Application error" report. Adds ~20% to bundle
+  // size; worth it for the diagnostic value.
+  productionBrowserSourceMaps: true,
+  // Pin BUILD_ID to the commit + buildAt timestamp so chunk hashes stay
+  // stable for a given commit (deterministic) but change when the build
+  // changes. Combined with the UpdateBanner version poll, this lets stale
+  // tabs auto-reload onto the new build instead of crashing on missing
+  // chunks. Falls back to Next's default when no commit is available
+  // (tarball install, dirty checkout, etc.).
+  generateBuildId: async () => (commit ? `${commit}-${builtAt}` : null),
   env: {
     NEXT_PUBLIC_GITDASH_VERSION: version,
     NEXT_PUBLIC_GITDASH_COMMIT: commit,


### PR DESCRIPTION
Closes #148

## Summary

Layered defense so a stale-tab browser, a transient chunk failure, or a render bug can never strand a beginner on Next.js's bare error page (the one with no buttons to click). Four layers, all calling into a single shared helper:

- **`app/global-error.tsx`** + **`app/error.tsx`** — root + page error boundaries. Detect `ChunkLoadError` and hard-reload immediately. For other errors: friendly UI + auto-reload after 5s + manual Reload button. Reload-loop guard caps auto-reloads at 3 in 30s, then the friendly UI sticks.
- **`components/ChunkErrorGuard.tsx`** — `window.error` / `unhandledrejection` listener for async chunk failures that bypass React boundaries (lazy `import()`, dynamic CSS). Mounted once in `app/layout.tsx`.
- **`next.config.mjs`** — `generateBuildId` pinned to `<commit>-<builtAt>` so chunk hashes are deterministic per commit. `productionBrowserSourceMaps: true` so future client-exception reports are debuggable.
- **`components/UpdateBanner.tsx`** — on `/api/version` mismatch, auto-reload after 5s instead of waiting for a click. Shares the reload-budget so it can't spin.
- **`lib/autoheal.ts`** — shared `isChunkLoadError`, `tryConsumeReloadBudget`, `hardReload` (cache-busted via `_gitdash_heal=<ts>` query string).
- **`components/Dashboard.tsx`** — defensive `try`/`catch` around SSE `JSON.parse` so a malformed frame can't crash the dashboard.
- **`CLAUDE.md`** — new "Auto-heal contract" section documents the four layers, why they exist, and what to keep working when changing client code.

## Why

User report: \"Application error: a client-side exception\" was appearing on `192.168.1.6:7420` regularly enough that they flagged it as a permanent-fix priority. Root cause is the JS counterpart to #147 — after a rebuild, a stale tab tries to load `/_next/static/chunks/<old-hash>.js`, the chunk 404s, `ChunkLoadError` throws, and with no error boundary Next.js renders its bare fallback. That fallback violates the North Star (no buttons → user has to know to hard-reload, hit a different browser, or open DevTools).

## Test plan

- [ ] **Synthetic render error.** Temporarily add `throw new Error('boom')` to `Dashboard.tsx` → page renders `app/error.tsx` with countdown, auto-reloads after 5s, then offers \"Try again\" once budget is exhausted.
- [ ] **Synthetic chunk error.** `throw new Error('ChunkLoadError: Loading chunk 5 failed')` from a component → page hard-reloads within ~1s. URL shows `?_gitdash_heal=<ts>`.
- [ ] **Reload-loop guard.** Throw on every render → after 3 reloads in 30s the friendly UI sticks instead of looping. `sessionStorage['gitdash:autoheal:reloads']` shows `{count: 3, ...}`.
- [ ] **Real-world stale build.** Rebuild while a tab is open → `UpdateBanner` shows \"New gitdash version detected — reloading in Xs\" and the page reloads onto the new build.
- [ ] **No banner without commit.** Tarball install (no `NEXT_PUBLIC_GITDASH_COMMIT`) → no banner, no reload (existing behavior preserved).

🤖 Generated with [Claude Code](https://claude.com/claude-code)