### PR TITLE
fix(auth): Connect GitHub now actually fixes missing scopes

### DIFF
--- a/app/api/github/auth/login/route.ts
+++ b/app/api/github/auth/login/route.ts
@@ -1,7 +1,20 @@
 import { NextResponse, type NextRequest } from "next/server";
 import { bootstrap } from "@/lib/bootstrap";
 import { validateCsrf } from "@/lib/security/csrf";
-import { startGhAuthLogin, isGhAuthenticated } from "@/lib/gh/auth";
+import {
+  startGhAuthLogin,
+  startGhAuthRefresh,
+  isGhAuthenticated,
+  getGhAuthScopes,
+} from "@/lib/gh/auth";
+
+// Scopes gitdash needs to do its job: `repo` for push/clone of private
+// repos, `workflow` so pushing branches with workflow files isn't blocked.
+// `gh auth login` requests these by default; users who installed gh through
+// other tools may have a token with fewer scopes. The health banner detects
+// that case and surfaces "Connect GitHub" — which lands here and runs
+// `gh auth refresh -s <missing>` to add the scopes without re-doing login.
+const REQUIRED_SCOPES = ["repo", "workflow"];
 
 export async function POST(req: NextRequest) {
   await bootstrap();
@@ -11,18 +24,41 @@ export async function POST(req: NextRequest) {
   }
 
   const existing = await isGhAuthenticated();
-  if (existing) {
+
+  if (!existing) {
+    try {
+      const result = await startGhAuthLogin();
+      return NextResponse.json(result);
+    } catch (err) {
+      const message = (err as Error).message ?? String(err);
+      return NextResponse.json(
+        {
+          error: "could not start GitHub sign-in",
+          detail: message.slice(0, 500),
+        },
+        { status: 502 },
+      );
+    }
+  }
+
+  // Authenticated — check scopes. If the token is missing any required
+  // scope, drive `gh auth refresh -s <missing>` through the same device
+  // flow so GitHub prompts the user to grant the additional scopes.
+  const scopes = await getGhAuthScopes();
+  const missing = REQUIRED_SCOPES.filter((s) => !scopes.includes(s));
+
+  if (missing.length === 0) {
     return NextResponse.json({ alreadyAuthenticated: true, login: existing });
   }
 
   try {
-    const result = await startGhAuthLogin();
-    return NextResponse.json(result);
+    const result = await startGhAuthRefresh(missing);
+    return NextResponse.json({ ...result, refreshing: true, missingScopes: missing });
   } catch (err) {
     const message = (err as Error).message ?? String(err);
     return NextResponse.json(
       {
-        error: "could not start GitHub sign-in",
+        error: "could not start GitHub scope upgrade",
         detail: message.slice(0, 500),
       },
       { status: 502 },

--- a/components/HealthBanner.tsx
+++ b/components/HealthBanner.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useCallback, useEffect, useState } from "react";
-import { AlertOctagon, AlertTriangle, RefreshCw, X } from "lucide-react";
+import { AlertOctagon, AlertTriangle, Check, RefreshCw, X } from "lucide-react";
 import { GhSignInModal } from "./GhSignInModal";
 import { cn } from "@/lib/utils";
 
@@ -31,6 +31,7 @@ interface Props {
 export function HealthBanner({ csrfToken }: Props) {
   const [warnings, setWarnings] = useState<HealthWarning[]>([]);
   const [loading, setLoading] = useState(false);
+  const [justChecked, setJustChecked] = useState(false);
   const [dismissed, setDismissed] = useState<Set<string>>(() => {
     if (typeof window === "undefined") return new Set();
     try {
@@ -42,13 +43,17 @@ export function HealthBanner({ csrfToken }: Props) {
   });
   const [signInOpen, setSignInOpen] = useState(false);
 
-  const fetchHealth = useCallback(async () => {
+  const fetchHealth = useCallback(async (opts?: { surfaceFeedback?: boolean }) => {
     setLoading(true);
     try {
       const res = await fetch("/api/health", { cache: "no-store" });
       if (res.ok) {
         const data = (await res.json()) as HealthResult;
         setWarnings(data.warnings);
+        if (opts?.surfaceFeedback) {
+          setJustChecked(true);
+          setTimeout(() => setJustChecked(false), 2_000);
+        }
       }
     } catch {
       // Network blip — keep last state, banner UI shows stale until next tick.
@@ -99,15 +104,27 @@ export function HealthBanner({ csrfToken }: Props) {
         <div className="flex items-center justify-end">
           <button
             type="button"
-            onClick={() => void fetchHealth()}
+            onClick={() => void fetchHealth({ surfaceFeedback: true })}
             disabled={loading}
             className={cn(
-              "inline-flex items-center gap-1.5 rounded-full border border-border px-3 py-1 text-[11px] font-medium text-fg-muted transition-colors hover:border-fg-muted hover:text-fg",
+              "inline-flex items-center gap-1.5 rounded-full border px-3 py-1 text-[11px] font-medium transition-colors",
+              justChecked
+                ? "border-accent-clean/45 bg-accent-clean/10 text-accent-clean"
+                : "border-border text-fg-muted hover:border-fg-muted hover:text-fg",
               loading && "opacity-60",
             )}
           >
-            <RefreshCw className={cn("h-3 w-3", loading && "animate-spin")} />
-            Re-check
+            {justChecked ? (
+              <>
+                <Check className="h-3 w-3" />
+                Checked just now
+              </>
+            ) : (
+              <>
+                <RefreshCw className={cn("h-3 w-3", loading && "animate-spin")} />
+                Re-check
+              </>
+            )}
           </button>
         </div>
       </section>

--- a/lib/gh/auth.ts
+++ b/lib/gh/auth.ts
@@ -1,5 +1,5 @@
 import { spawn } from "node:child_process";
-import { runGh } from "@/lib/git/exec";
+import { runGh, GitCommandError } from "@/lib/git/exec";
 
 const DEVICE_CODE_RE = /code:\s*([A-Z0-9]{4}-[A-Z0-9]{4})/i;
 const ANSI_RE = /\x1b\[[0-9;]*m/g;
@@ -29,14 +29,18 @@ export interface StartResult {
 }
 
 /**
- * Spawn `gh auth login --web` and parse the device code from its stderr.
- * Resolves once the device code is available so the UI can show it
- * immediately. The OAuth completion runs in the background and is observable
- * via `getAuthState(runId)`.
+ * Spawn a `gh auth ...` command that drives the OAuth device flow and parse
+ * the device code from its stderr. Resolves once the device code is available
+ * so the UI can show it immediately. The OAuth completion runs in the
+ * background and is observable via `getAuthState(runId)`.
+ *
+ * Used for both initial login (`gh auth login --web`) and scope upgrades
+ * (`gh auth refresh -s <scopes>`) — the device-flow output format is the
+ * same in both cases.
  *
  * Throws if `gh` itself can't be spawned (not installed, not on PATH).
  */
-export function startGhAuthLogin(): Promise<StartResult> {
+function spawnGhAuthDeviceFlow(ghArgs: string[]): Promise<StartResult> {
   return new Promise((resolve, reject) => {
     const runId = newRunId();
     let stderrBuf = "";
@@ -46,19 +50,10 @@ export function startGhAuthLogin(): Promise<StartResult> {
 
     let child;
     try {
-      child = spawn(
-        "gh",
-        [
-          "auth",
-          "login",
-          "--web",
-          "--hostname",
-          "github.com",
-          "--git-protocol",
-          "https",
-        ],
-        { stdio: ["pipe", "pipe", "pipe"], env: process.env },
-      );
+      child = spawn("gh", ghArgs, {
+        stdio: ["pipe", "pipe", "pipe"],
+        env: process.env,
+      });
     } catch (err) {
       reject(err);
       return;
@@ -169,6 +164,46 @@ export function startGhAuthLogin(): Promise<StartResult> {
   });
 }
 
+/**
+ * Initial sign-in for an unauthenticated machine. Drives `gh auth login`
+ * through the OAuth device flow.
+ */
+export function startGhAuthLogin(): Promise<StartResult> {
+  return spawnGhAuthDeviceFlow([
+    "auth",
+    "login",
+    "--web",
+    "--hostname",
+    "github.com",
+    "--git-protocol",
+    "https",
+  ]);
+}
+
+/**
+ * Scope upgrade for an already-authenticated machine. `gh auth refresh -s`
+ * goes through the same device flow but the GitHub authorize page asks the
+ * user to grant the additional scopes on top of what they already have.
+ *
+ * This is what powers the "Connect GitHub" button on the
+ * `gh-missing-repo-scope` health warning.
+ */
+export function startGhAuthRefresh(scopes: string[]): Promise<StartResult> {
+  if (scopes.length === 0) {
+    return Promise.reject(
+      new Error("startGhAuthRefresh requires at least one scope"),
+    );
+  }
+  return spawnGhAuthDeviceFlow([
+    "auth",
+    "refresh",
+    "--hostname",
+    "github.com",
+    "-s",
+    scopes.join(","),
+  ]);
+}
+
 export function getAuthState(runId: string): AuthState | undefined {
   return sessions.get(runId)?.state;
 }
@@ -187,6 +222,37 @@ export async function isGhAuthenticated(): Promise<string | null> {
   } catch {
     return null;
   }
+}
+
+/**
+ * Returns the OAuth scopes currently granted to `gh`'s stored token. Parses
+ * the `Token scopes:` line from `gh auth status`. Returns an empty array if
+ * gh isn't authenticated, isn't installed, or the line can't be parsed.
+ */
+export async function getGhAuthScopes(): Promise<string[]> {
+  // `gh auth status` writes the scope line to stderr by design and exits 0
+  // when authenticated. When not authenticated it exits 1 — runGh throws a
+  // GitCommandError in that case, but the error carries the captured output
+  // so we can still parse from it (and return [] if the line isn't there).
+  let text: string;
+  try {
+    const { stdout, stderr } = await runGh(["auth", "status"], {
+      timeoutMs: 10_000,
+    });
+    text = `${stdout}\n${stderr}`;
+  } catch (err) {
+    if (err instanceof GitCommandError) {
+      text = `${err.stdout}\n${err.stderr}`;
+    } else {
+      return [];
+    }
+  }
+  const m = text.match(/Token scopes?:\s*(.+)/i);
+  if (!m || !m[1]) return [];
+  return m[1]
+    .split(",")
+    .map((s) => s.trim().replace(/^['"]|['"]$/g, ""))
+    .filter(Boolean);
 }
 
 /**


### PR DESCRIPTION
Closes #150

## Summary

The "Connect GitHub" button on the `gh-missing-repo-scope` warning was a no-op. Trace: modal POSTs to `/api/github/auth/login` → route's `isGhAuthenticated()` check returned the user's login (they ARE authed, just missing the scope) → route returned `alreadyAuthenticated: true` → modal flashed success and closed → banner re-fetched → scope still missing → warning came back. From the user's POV the click did nothing.

Now the route distinguishes "authed with full scopes" from "authed but under-scoped" and runs `gh auth refresh -s <missing>` through the device flow when scopes are missing. GitHub's authorize page asks the user to grant the additional scope; once they do, the banner re-checks and the warning is gone.

## Changes

- **`lib/gh/auth.ts`** — extracted `spawnGhAuthDeviceFlow(ghArgs)` from `startGhAuthLogin` so the same device-code parsing pipeline drives both initial login and scope refresh. Added `startGhAuthRefresh(scopes)` and `getGhAuthScopes()` (parses `Token scopes:` from `gh auth status`, tolerant of non-zero exits when not authenticated).
- **`app/api/github/auth/login/route.ts`** — `REQUIRED_SCOPES = ["repo", "workflow"]`. Branches:
  - Not authed → `startGhAuthLogin` (existing path).
  - Authed AND has all required scopes → `alreadyAuthenticated` (existing short-circuit, now correct).
  - Authed but missing scopes → `startGhAuthRefresh(missing)` — same modal device-flow UI, GitHub prompts to grant missing scopes.
- **`components/HealthBanner.tsx`** — Re-check button now shows a brief "✓ Checked just now" pill for 2s after a successful re-check. Click no longer feels invisible when the warning state is unchanged.

## Test plan

- [ ] **Missing scope (the reported bug).** With a token that has `gist, workflow` but not `repo` (`gh auth login -s gist,workflow` from a test account, then back out one scope to repro), banner shows `gh-missing-repo-scope`. Click Connect GitHub → modal shows a device code (does **not** flash and close). Open `https://github.com/login/device`, paste code, GitHub asks "gh wants additional access to: repo" → authorize. Modal shows success, banner re-checks, warning is gone.
- [ ] **Already fully authed.** With `repo, workflow` already present, the banner shouldn't show the warning at all. If you force-show the modal, the route returns `alreadyAuthenticated: true` and the modal closes immediately.
- [ ] **Not authed.** With `gh auth logout`, banner shows `gh-not-authenticated`. Click Connect GitHub → existing full `gh auth login` flow runs (unchanged behavior).
- [ ] **Re-check feedback.** Click Re-check → button briefly shows "✓ Checked just now" in green, then returns to default. Works whether or not the warnings changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
