### PR TITLE
feat(label): inline-editable machine label at top of dashboard (#154)

### DIFF
--- a/app/api/config/machine-label/route.ts
+++ b/app/api/config/machine-label/route.ts
@@ -1,0 +1,69 @@
+import { NextResponse } from "next/server";
+import { readFile, writeFile, mkdir } from "node:fs/promises";
+import { hostname } from "node:os";
+import path from "node:path";
+import { validateCsrf } from "@/lib/security/csrf";
+import { displayLabel } from "@/lib/security/label";
+
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
+
+function configPath(): string {
+  const xdg = process.env.XDG_CONFIG_HOME ?? path.join(process.env.HOME ?? ".", ".config");
+  return path.join(xdg, "gitdash", "config.json");
+}
+
+async function readConfig(): Promise<Record<string, unknown>> {
+  try {
+    const raw = await readFile(configPath(), "utf8");
+    return JSON.parse(raw) as Record<string, unknown>;
+  } catch {
+    return {};
+  }
+}
+
+async function writeConfig(data: Record<string, unknown>): Promise<void> {
+  const p = configPath();
+  await mkdir(path.dirname(p), { recursive: true });
+  await writeFile(p, JSON.stringify(data, null, 2) + "\n", "utf8");
+}
+
+export async function GET(): Promise<NextResponse> {
+  const config = await readConfig();
+  const stored = typeof config.machineLabel === "string" ? config.machineLabel : null;
+  const host = hostname();
+  const isDefault = !stored || stored.trim().length === 0;
+  const label = displayLabel(stored, host);
+  return NextResponse.json({ label, isDefault, hostname: host });
+}
+
+export async function PUT(req: Request): Promise<NextResponse> {
+  const csrf = req.headers.get("x-csrf-token");
+  if (!validateCsrf(csrf)) {
+    return NextResponse.json({ error: "invalid csrf" }, { status: 403 });
+  }
+
+  let body: { label?: unknown };
+  try {
+    body = (await req.json()) as { label?: unknown };
+  } catch {
+    return NextResponse.json({ error: "invalid JSON body" }, { status: 400 });
+  }
+
+  const raw = typeof body.label === "string" ? body.label.trim() : "";
+  const config = await readConfig();
+
+  if (raw.length === 0) {
+    // Unset — remove the key so hostname fallback takes over
+    delete config.machineLabel;
+  } else {
+    config.machineLabel = raw;
+  }
+
+  await writeConfig(config);
+
+  const host = hostname();
+  const isDefault = raw.length === 0;
+  const label = displayLabel(raw || null, host);
+  return NextResponse.json({ label, isDefault, hostname: host });
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -3,6 +3,10 @@ import { Instrument_Serif, Instrument_Sans, IBM_Plex_Mono } from "next/font/goog
 import "./globals.css";
 import { VersionBadge } from "@/components/VersionBadge";
 import { UpdateBanner } from "@/components/UpdateBanner";
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import { displayLabel } from "@/lib/security/label";
+import { hostname } from "node:os";
 
 const serif = Instrument_Serif({
   subsets: ["latin"],
@@ -26,10 +30,28 @@ const mono = IBM_Plex_Mono({
   display: "swap",
 });
 
-export const metadata: Metadata = {
-  title: "gitdash",
-  description: "Local git repo status dashboard",
-};
+async function getStoredLabel(): Promise<string | null> {
+  try {
+    const xdg = process.env.XDG_CONFIG_HOME ?? path.join(process.env.HOME ?? ".", ".config");
+    const configPath = path.join(xdg, "gitdash", "config.json");
+    const raw = await readFile(configPath, "utf8");
+    const parsed = JSON.parse(raw) as Record<string, unknown>;
+    return typeof parsed.machineLabel === "string" ? parsed.machineLabel : null;
+  } catch {
+    return null;
+  }
+}
+
+export async function generateMetadata(): Promise<Metadata> {
+  const stored = await getStoredLabel();
+  const label = displayLabel(stored, hostname());
+  const isDefault = !stored || stored.trim().length === 0;
+  const title = isDefault ? "gitdash" : `${label} · gitdash`;
+  return {
+    title,
+    description: "Local git repo status dashboard",
+  };
+}
 
 // Runs before paint to set the theme class — prevents the wrong-theme flash
 // on first render. Reads localStorage('gitdash-theme'), falls back to OS preference.

--- a/components/Dashboard.tsx
+++ b/components/Dashboard.tsx
@@ -1,12 +1,13 @@
 "use client";
 
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import type { RepoView } from "@/lib/state/store";
 import { RepoGroup } from "./RepoGroup";
 import type { GroupKind } from "./RepoCard";
 import { ThemeToggle } from "./ThemeToggle";
 import { RemoteReposSection } from "./RemoteReposSection";
 import { HealthBanner } from "./HealthBanner";
+import { Pencil } from "lucide-react";
 
 interface Props {
   initialRepos: RepoView[];
@@ -157,6 +158,132 @@ function bodyFor(kind: GroupKind, _n: number): string {
   }
 }
 
+// ---------------------------------------------------------------------------
+// Inline-editable machine label
+// ---------------------------------------------------------------------------
+
+interface MachineLabelEditorProps {
+  csrfToken: string;
+}
+
+function MachineLabelEditor({ csrfToken }: MachineLabelEditorProps) {
+  const [label, setLabel] = useState<string>("");
+  const [editing, setEditing] = useState(false);
+  const [draft, setDraft] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  // Fetch current label on mount
+  useEffect(() => {
+    fetch("/api/config/machine-label")
+      .then((r) => r.json())
+      .then((d: unknown) => {
+        const data = d as { label: string };
+        setLabel(data.label);
+        document.title = data.label ? `${data.label} · gitdash` : "gitdash";
+      })
+      .catch(() => {
+        // ignore — fallback stays as-is
+      });
+  }, []);
+
+  function startEditing() {
+    setDraft(label);
+    setError(null);
+    setEditing(true);
+    // Focus happens after re-render
+    setTimeout(() => {
+      inputRef.current?.select();
+    }, 0);
+  }
+
+  async function commitEdit() {
+    if (!editing) return;
+    setEditing(false);
+    const trimmed = draft.trim();
+    if (trimmed === label) return; // no change
+    try {
+      const res = await fetch("/api/config/machine-label", {
+        method: "PUT",
+        headers: {
+          "Content-Type": "application/json",
+          "x-csrf-token": csrfToken,
+        },
+        body: JSON.stringify({ label: trimmed }),
+      });
+      if (!res.ok) {
+        setError("Couldn't save — try again");
+        return;
+      }
+      const data = (await res.json()) as { label: string };
+      setLabel(data.label);
+      document.title = data.label ? `${data.label} · gitdash` : "gitdash";
+      setError(null);
+    } catch {
+      setError("Couldn't save — try again");
+    }
+  }
+
+  function cancelEdit() {
+    setEditing(false);
+    setDraft("");
+    setError(null);
+  }
+
+  function handleKeyDown(e: React.KeyboardEvent<HTMLInputElement>) {
+    if (e.key === "Enter") {
+      e.preventDefault();
+      void commitEdit();
+    } else if (e.key === "Escape") {
+      e.preventDefault();
+      cancelEdit();
+    }
+  }
+
+  if (editing) {
+    return (
+      <div className="flex flex-col gap-1">
+        <input
+          ref={inputRef}
+          autoFocus
+          type="text"
+          value={draft}
+          onChange={(e) => setDraft(e.target.value)}
+          onKeyDown={handleKeyDown}
+          onBlur={() => void commitEdit()}
+          maxLength={80}
+          className="display text-[36px] leading-none tracking-display-tight text-fg sm:text-[44px] bg-transparent border-b border-ring outline-none w-full max-w-xs"
+          aria-label="Machine label"
+        />
+        <p className="text-[11px] text-fg-dim">Enter to save · Esc to cancel</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex flex-col gap-1">
+      <button
+        type="button"
+        onClick={startEditing}
+        className="group flex items-center gap-2 text-left"
+        title="Click to rename this machine"
+      >
+        <h1 className="display text-[36px] leading-none tracking-display-tight text-fg sm:text-[44px]">
+          {label || "gitdash"}
+        </h1>
+        <Pencil
+          size={14}
+          className="text-fg-dim opacity-0 group-hover:opacity-60 transition-opacity mt-2 shrink-0"
+          aria-hidden
+        />
+      </button>
+      {error && (
+        <p className="text-[12px] text-accent-attention">{error}</p>
+      )}
+    </div>
+  );
+}
+
 export function Dashboard({ initialRepos, csrfToken }: Props) {
   const [repos, setRepos] = useState<RepoView[]>(initialRepos);
   const [showSystem, setShowSystem] = useState(false);
@@ -257,9 +384,7 @@ export function Dashboard({ initialRepos, csrfToken }: Props) {
     <main className="grain relative mx-auto max-w-[1280px] px-4 py-8 sm:px-10 sm:py-14">
       <header className="mb-8 flex flex-col gap-5 sm:mb-12 sm:gap-6 sm:flex-row sm:items-end sm:justify-between">
         <div>
-          <h1 className="display text-[36px] leading-none tracking-display-tight text-fg sm:text-[44px]">
-            gitdash
-          </h1>
+          <MachineLabelEditor csrfToken={csrfToken} />
           <p className="mt-3 max-w-lg text-[14px] text-fg-muted sm:text-[15px]">
             {actionableCount === 0 ? (
               <>Nothing urgent. <span className="display-italic text-fg">All caught up.</span></>

--- a/lib/scan/discover.ts
+++ b/lib/scan/discover.ts
@@ -10,6 +10,8 @@ export interface DiscoveryConfig {
   includeDotfilesAsRepoRoots: boolean;
   /** If false, the home-dir-as-repo and dotfile-tool repos are filtered out. */
   showSystemRepos: boolean;
+  /** Human-readable label for this machine shown in the dashboard title. */
+  machineLabel?: string;
 }
 
 export const DEFAULT_CONFIG: DiscoveryConfig = {

--- a/lib/security/label.ts
+++ b/lib/security/label.ts
@@ -1,0 +1,40 @@
+/**
+ * Sanitization helpers for machine labels.
+ *
+ * sanitizeLabel  — produces a branch-safe string (lowercase alnum + dash, max 40 chars).
+ * displayLabel   — returns the effective display label, falling back to a sanitized hostname.
+ */
+
+/**
+ * Convert an arbitrary string into a branch-name-safe slug.
+ * Rules:
+ *   - Lowercase
+ *   - Keep ASCII alphanumerics and hyphens; strip everything else
+ *   - Collapse consecutive hyphens into one
+ *   - Strip leading/trailing hyphens
+ *   - Truncate to 40 characters
+ */
+export function sanitizeLabel(input: string): string {
+  return input
+    .toLowerCase()
+    .replace(/[^a-z0-9-]+/g, "-") // non-alnum → hyphen
+    .replace(/-{2,}/g, "-")        // collapse runs
+    .replace(/^-+|-+$/g, "")       // trim edges
+    .slice(0, 40)
+    .replace(/-+$/g, "");          // re-trim after truncation
+}
+
+/**
+ * Return the display label for this machine.
+ * If `input` is a non-empty string after trimming, return it as-is (not sanitized —
+ * the user may have set a pretty name like "Chirag's Laptop").
+ * Otherwise fall back to a sanitized version of `hostnameFallback`.
+ */
+export function displayLabel(
+  input: string | null | undefined,
+  hostnameFallback: string,
+): string {
+  const trimmed = (input ?? "").trim();
+  if (trimmed.length > 0) return trimmed;
+  return sanitizeLabel(hostnameFallback) || hostnameFallback;
+}


### PR DESCRIPTION
Closes #154

## Summary

- Adds an inline-editable machine label at the top of the dashboard. Click the heading, type a new name, and press Enter (or blur) to save. Escape cancels.
- Persists to `~/.config/gitdash/config.json` under `machineLabel`. Empty/whitespace input falls back to a sanitized `os.hostname()`.
- Browser tab title updates live to `<label> · gitdash` (or just `gitdash` when using the hostname default).
- `lib/security/label.ts` exports `sanitizeLabel` (branch-name-safe slug) and `displayLabel` — both exported for future WIP-sync reuse.

## Test plan

- [ ] AC1: Click the heading → it becomes a text input with current value selected. Enter saves, Escape cancels, blur saves.
- [ ] AC2: After saving, check `~/.config/gitdash/config.json` — `machineLabel` key is present with the saved value. Setting to empty removes the key.
- [ ] AC3: After saving a label, browser tab title reads `<label> · gitdash`.
- [ ] AC4: With no `machineLabel` set, heading shows a sanitized `os.hostname()` (e.g. `my-laptop`).
- [ ] AC5: `sanitizeLabel('My Server!! 🚀')` → `'my-server'` (verify in `lib/security/label.ts` unit test or REPL).
- [ ] CSRF: A PUT without a valid `x-csrf-token` returns 403.
- [ ] Save failure: Disconnect network/kill server mid-save → inline error "Couldn't save — try again" appears, no crash.
