### PR TITLE
fix(discover): never hide gitdash from its own dashboard

### DIFF
--- a/lib/scan/discover.ts
+++ b/lib/scan/discover.ts
@@ -54,7 +54,19 @@ const SYSTEM_REPO_HINTS = [
   /\/\.(nvm|mcp|codex|nemoclaw|openclaw|config|local|cache|claude|npm|pnpm-store|yarn|pyenv|rustup|cargo|rbenv|docker|vscode-server)\b/,
 ];
 
+// Captured once at module load. The launcher (`bin/gitdash`) cd's into the
+// project root before exec'ing next, so `process.cwd()` is the gitdash repo
+// path for any process serving the dashboard. Tests / scripts that import
+// this module from a different cwd will get a different self-path, which is
+// fine — the only effect is that those contexts won't apply the self-exempt.
+const SELF_REPO_PATH = path.resolve(process.cwd());
+
 export function isSystemRepoPath(repoPath: string): boolean {
+  // Never hide gitdash from its own dashboard. The default install location
+  // ~/.local/share/gitdash matches the /\.local\b/ system-repo hint, which
+  // would otherwise hide the user's primary tool until they discover the
+  // 'show system repos' toggle.
+  if (path.resolve(repoPath) === SELF_REPO_PATH) return false;
   return SYSTEM_REPO_HINTS.some((re) => re.test(repoPath));
 }
 


### PR DESCRIPTION
Closes #156

## Summary

The gitdash repo wasn't appearing in its own dashboard on installs that landed under `~/.local/share/gitdash` (the default for `quick-install.sh`). The path matches `SYSTEM_REPO_HINTS`'s `/\.local\b/` pattern, so `isSystemRepoPath` returned `true` and `showSystemRepos: false` (default) hid it.

`isSystemRepoPath` now short-circuits to `false` when the candidate path matches `process.cwd()` (the launcher cd's into the project root before exec'ing next, so `process.cwd()` is the gitdash install path). Captured once at module load.

## Why this approach

- Cheaper than threading the install path through `DiscoveryConfig` (existing config has no notion of "self").
- Robust to any future install location — works whether gitdash lives in `~/.local/share/gitdash`, `~/code/gitdash`, `/opt/gitdash`, or anywhere.
- Tests / scripts that import this module from a different cwd just won't apply the self-exempt, which is harmless.

## Test plan

- [ ] Install via `quick-install.sh` (or already there at `~/.local/share/gitdash`). Restart gitdash. Open the dashboard. **gitdash repo appears** in the appropriate bucket without flipping the system-repos toggle.
- [ ] `~/.nvm/.git` (if present) is still hidden by default — toggling system repos shows it.
- [ ] Existing DBs: `is_system_repo` flag updates on next discovery cycle (10 min). For instant effect, restart the service.

## Note for the user

This is the bug you hit on `192.168.1.247:7420`. Once merged + deployed on that server, gitdash will show itself without you needing to find the "show system repos" toggle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
