### PR TITLE
feat(bulk): one-click Pull All for repos in the behind bucket

### DIFF
--- a/app/api/bulk/[runId]/stream/route.ts
+++ b/app/api/bulk/[runId]/stream/route.ts
@@ -1,0 +1,88 @@
+import { bootstrap } from "@/lib/bootstrap";
+import { getBulkRun } from "@/lib/bulk/store";
+
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
+
+export async function GET(
+  req: Request,
+  ctx: { params: Promise<{ runId: string }> },
+) {
+  await bootstrap();
+
+  const { runId } = await ctx.params;
+  const run = getBulkRun(runId);
+  if (!run) {
+    return new Response(
+      JSON.stringify({ error: "run not found" }),
+      { status: 404, headers: { "Content-Type": "application/json" } },
+    );
+  }
+
+  const encoder = new TextEncoder();
+
+  const stream = new ReadableStream({
+    start(controller) {
+      const send = (event: string, data: unknown) => {
+        try {
+          controller.enqueue(
+            encoder.encode(`event: ${event}\ndata: ${JSON.stringify(data)}\n\n`),
+          );
+        } catch {
+          // stream already closed
+        }
+      };
+
+      // Replay any statuses that already progressed before the client connected
+      for (const repo of run.repos) {
+        const status = run.statuses.get(repo.id);
+        if (!status) continue;
+        if (status.phase === "pulling") {
+          send("start", { repoId: repo.id, name: repo.name });
+        } else if (status.phase === "done") {
+          send("start", { repoId: repo.id, name: repo.name });
+          send("done", { repoId: repo.id });
+        } else if (status.phase === "failed") {
+          send("start", { repoId: repo.id, name: repo.name });
+          send("error", { repoId: repo.id, message: status.message });
+        }
+      }
+
+      // Forward live events
+      const onStart = (data: { repoId: number; name: string }) => send("start", data);
+      const onDone = (data: { repoId: number }) => send("done", data);
+      const onError = (data: { repoId: number; message: string }) => send("error", data);
+      const onSummary = (data: { ok: number; failed: Array<{ name: string; message: string }> }) => {
+        send("summary", data);
+        cleanup();
+        try { controller.close(); } catch { /* already closed */ }
+      };
+
+      run.emitter.on("start", onStart);
+      run.emitter.on("done", onDone);
+      run.emitter.on("error", onError);
+      run.emitter.on("summary", onSummary);
+
+      const cleanup = () => {
+        run.emitter.off("start", onStart);
+        run.emitter.off("done", onDone);
+        run.emitter.off("error", onError);
+        run.emitter.off("summary", onSummary);
+      };
+
+      req.signal.addEventListener("abort", () => {
+        cleanup();
+        try { controller.close(); } catch { /* already closed */ }
+      });
+    },
+  });
+
+  return new Response(stream, {
+    headers: {
+      "Content-Type": "text/event-stream; charset=utf-8",
+      "Cache-Control": "no-store",
+      "Connection": "keep-alive",
+      "X-Accel-Buffering": "no",
+    },
+  });
+}

--- a/app/api/bulk/pull/route.ts
+++ b/app/api/bulk/pull/route.ts
@@ -1,0 +1,186 @@
+import { NextResponse } from "next/server";
+import { spawn } from "node:child_process";
+import { randomBytes } from "node:crypto";
+import { EventEmitter } from "node:events";
+import pLimit from "p-limit";
+import { bootstrap } from "@/lib/bootstrap";
+import { validateCsrf } from "@/lib/security/csrf";
+import { getStore } from "@/lib/state/store";
+import { getScheduler } from "@/lib/scan/scheduler";
+import { getDb } from "@/lib/db/schema";
+import { setBulkRun, gcBulkRuns, type BulkRun, type RepoRunStatus } from "@/lib/bulk/store";
+
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
+
+// ---------------------------------------------------------------------------
+// Plain-English error translation
+// ---------------------------------------------------------------------------
+function friendlyPullError(stderr: string): string {
+  if (
+    stderr.includes("Not possible to fast-forward") ||
+    stderr.includes("Cannot fast-forward")
+  ) {
+    return "Has changes the bulk pull can't safely combine — open the repo to handle";
+  }
+  if (stderr.includes("CONFLICT")) {
+    return "Has changes the bulk pull can't safely combine — open the repo to handle";
+  }
+  if (
+    stderr.includes("Permission denied") ||
+    stderr.includes("authentication") ||
+    stderr.includes("could not read Username")
+  ) {
+    return "GitHub authentication failed — check that gh is signed in";
+  }
+  if (stderr.includes("no tracking information") || stderr.includes("no upstream")) {
+    return "No upstream branch configured — open the repo to set one up";
+  }
+  const trimmed = stderr.trim().split("\n").pop() ?? stderr.trim();
+  return trimmed.slice(0, 200) || "Pull failed — open the repo to see what went wrong";
+}
+
+// ---------------------------------------------------------------------------
+// Single-repo pull (ff-only, no shell)
+// ---------------------------------------------------------------------------
+function pullRepo(
+  run: BulkRun,
+  repoId: number,
+  repoPath: string,
+  repoName: string,
+): Promise<void> {
+  return new Promise<void>((resolve) => {
+    run.statuses.set(repoId, { phase: "pulling" });
+    run.emitter.emit("start", { repoId, name: repoName });
+
+    const stderrLines: string[] = [];
+
+    const child = spawn("git", ["-C", repoPath, "pull", "--ff-only"], {
+      env: {
+        ...process.env,
+        GIT_TERMINAL_PROMPT: "0",
+        GIT_ASKPASS: "/bin/echo",
+      },
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+
+    child.stderr?.on("data", (chunk: Buffer) => {
+      for (const line of chunk.toString("utf8").split(/\r?\n/)) {
+        if (line.trim()) stderrLines.push(line);
+      }
+    });
+
+    const timer = setTimeout(() => {
+      child.kill("SIGTERM");
+      setTimeout(() => child.kill("SIGKILL"), 3_000);
+    }, 120_000);
+
+    child.on("close", (code) => {
+      clearTimeout(timer);
+
+      // Log to actions_log (best-effort)
+      try {
+        const now = Date.now();
+        getDb()
+          .prepare(
+            "INSERT INTO actions_log (repo_id, action, started_at, finished_at, exit_code, truncated_output) VALUES (?, ?, ?, ?, ?, ?)",
+          )
+          .run(
+            repoId,
+            "pull",
+            now,
+            now,
+            code ?? -1,
+            stderrLines.slice(-50).join("\n"),
+          );
+      } catch {
+        // best-effort
+      }
+
+      if (code === 0) {
+        run.statuses.set(repoId, { phase: "done" });
+        run.emitter.emit("done", { repoId });
+        // Trigger a local snapshot so the UI row updates
+        getScheduler()?.collectOne(repoId).catch(() => {});
+      } else {
+        const message = friendlyPullError(stderrLines.join("\n"));
+        run.statuses.set(repoId, { phase: "failed", message });
+        run.emitter.emit("error", { repoId, message });
+      }
+      resolve();
+    });
+
+    child.on("error", (err) => {
+      clearTimeout(timer);
+      const message = `Could not run git: ${err.message}`;
+      run.statuses.set(repoId, { phase: "failed", message });
+      run.emitter.emit("error", { repoId, message });
+      resolve();
+    });
+  });
+}
+
+// ---------------------------------------------------------------------------
+// POST /api/bulk/pull
+// ---------------------------------------------------------------------------
+export async function POST(req: Request) {
+  await bootstrap();
+
+  const csrf = req.headers.get("x-csrf-token");
+  if (!validateCsrf(csrf)) {
+    return NextResponse.json({ error: "invalid csrf" }, { status: 403 });
+  }
+
+  gcBulkRuns();
+
+  const store = getStore();
+  const allRepos = store.snapshot(false);
+  const behindRepos = allRepos.filter((r) => r.derivedState === "behind");
+
+  if (behindRepos.length === 0) {
+    return NextResponse.json({ error: "no repos are behind" }, { status: 422 });
+  }
+  if (behindRepos.length > 50) {
+    return NextResponse.json(
+      {
+        error: `${behindRepos.length} repos are behind — narrow scope first (max 50 per bulk pull)`,
+      },
+      { status: 422 },
+    );
+  }
+
+  const bulkRunId = randomBytes(16).toString("base64url");
+  const run: BulkRun = {
+    repos: behindRepos.map((r) => ({ id: r.id, name: r.displayName, path: r.repoPath })),
+    statuses: new Map<number, RepoRunStatus>(behindRepos.map((r) => [r.id, { phase: "queued" }])),
+    emitter: new EventEmitter(),
+    startedAt: Date.now(),
+  };
+  // Allow many listeners (one per SSE subscriber)
+  run.emitter.setMaxListeners(20);
+
+  setBulkRun(bulkRunId, run);
+
+  // Execute pulls concurrently (limit 4), non-blocking
+  const limit = pLimit(4);
+  void Promise.all(
+    run.repos.map((r) => limit(() => pullRepo(run, r.id, r.path, r.name))),
+  ).then(() => {
+    const ok = run.repos.filter((r) => {
+      const s = run.statuses.get(r.id);
+      return s?.phase === "done";
+    });
+    const failed = run.repos
+      .filter((r) => {
+        const s = run.statuses.get(r.id);
+        return s?.phase === "failed";
+      })
+      .map((r) => {
+        const s = run.statuses.get(r.id) as { phase: "failed"; message: string };
+        return { name: r.name, message: s.message };
+      });
+    run.emitter.emit("summary", { ok: ok.length, failed });
+  });
+
+  return NextResponse.json({ bulkRunId });
+}

--- a/components/BulkActionModal.tsx
+++ b/components/BulkActionModal.tsx
@@ -1,0 +1,225 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+
+interface RepoInfo {
+  id: number;
+  name: string;
+}
+
+interface Props {
+  bulkRunId: string;
+  repos: RepoInfo[];
+  onClose: () => void;
+}
+
+type RowPhase = "queued" | "pulling" | "done" | "failed";
+
+interface RowState {
+  phase: RowPhase;
+  message?: string;
+}
+
+interface SummaryState {
+  ok: number;
+  failed: Array<{ name: string; message: string }>;
+}
+
+const TIMEOUT_MS = 60_000;
+
+function PhasePill({ phase }: { phase: RowPhase }) {
+  switch (phase) {
+    case "queued":
+      return (
+        <span className="inline-flex items-center rounded-full bg-bg-elevated px-2 py-0.5 text-[11px] font-medium text-fg-dim">
+          queued
+        </span>
+      );
+    case "pulling":
+      return (
+        <span className="inline-flex items-center gap-1 rounded-full bg-accent-push/15 px-2 py-0.5 text-[11px] font-medium text-accent-push">
+          <span className="h-1.5 w-1.5 animate-pulse rounded-full bg-accent-push" />
+          pulling…
+        </span>
+      );
+    case "done":
+      return (
+        <span className="inline-flex items-center gap-1 rounded-full bg-accent-clean/15 px-2 py-0.5 text-[11px] font-medium text-accent-clean">
+          done ✓
+        </span>
+      );
+    case "failed":
+      return (
+        <span className="inline-flex items-center gap-1 rounded-full bg-accent-attention/15 px-2 py-0.5 text-[11px] font-medium text-accent-attention">
+          failed ✗
+        </span>
+      );
+  }
+}
+
+export function BulkActionModal({ bulkRunId, repos, onClose }: Props) {
+  const [rowStates, setRowStates] = useState<Map<number, RowState>>(
+    () => new Map(repos.map((r) => [r.id, { phase: "queued" }])),
+  );
+  const [summary, setSummary] = useState<SummaryState | null>(null);
+  const [timedOut, setTimedOut] = useState(false);
+  const [showFailures, setShowFailures] = useState(false);
+  const esRef = useRef<EventSource | null>(null);
+  const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const isDone = summary !== null || timedOut;
+
+  useEffect(() => {
+    const es = new EventSource(`/api/bulk/${bulkRunId}/stream`);
+    esRef.current = es;
+
+    const update = (id: number, patch: Partial<RowState>) => {
+      setRowStates((prev) => {
+        const next = new Map(prev);
+        next.set(id, { ...(prev.get(id) ?? { phase: "queued" }), ...patch });
+        return next;
+      });
+    };
+
+    es.addEventListener("start", (ev) => {
+      try {
+        const data = JSON.parse((ev as MessageEvent).data) as { repoId: number; name: string };
+        update(data.repoId, { phase: "pulling" });
+      } catch {
+        // malformed frame — ignore, don't crash
+      }
+    });
+
+    es.addEventListener("done", (ev) => {
+      try {
+        const data = JSON.parse((ev as MessageEvent).data) as { repoId: number };
+        update(data.repoId, { phase: "done" });
+      } catch {
+        // ignore
+      }
+    });
+
+    es.addEventListener("error", (ev) => {
+      try {
+        const data = JSON.parse((ev as MessageEvent).data) as { repoId: number; message: string };
+        update(data.repoId, { phase: "failed", message: data.message });
+      } catch {
+        // ignore
+      }
+    });
+
+    es.addEventListener("summary", (ev) => {
+      try {
+        const data = JSON.parse((ev as MessageEvent).data) as SummaryState;
+        setSummary(data);
+      } catch {
+        // ignore
+      }
+      es.close();
+      if (timeoutRef.current) clearTimeout(timeoutRef.current);
+    });
+
+    // Safety timeout: close and allow dismiss if stream stalls
+    timeoutRef.current = setTimeout(() => {
+      setTimedOut(true);
+      es.close();
+    }, TIMEOUT_MS);
+
+    return () => {
+      es.close();
+      if (timeoutRef.current) clearTimeout(timeoutRef.current);
+    };
+  }, [bulkRunId]);
+
+  const rows = repos.map((r) => ({
+    ...r,
+    state: rowStates.get(r.id) ?? { phase: "queued" as RowPhase },
+  }));
+
+  return (
+    // Backdrop
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 p-4 backdrop-blur-sm"
+      onClick={(e) => {
+        if (isDone && e.target === e.currentTarget) onClose();
+      }}
+    >
+      <div className="flex w-full max-w-lg flex-col gap-5 rounded-2xl border border-border bg-bg p-6 shadow-2xl">
+        <header className="flex items-center justify-between gap-4">
+          <h2 className="display text-[20px] tracking-display-tight text-fg">
+            Pull All
+          </h2>
+          {!isDone && (
+            <span className="text-[12px] text-fg-dim">in progress…</span>
+          )}
+        </header>
+
+        {/* Repo list */}
+        <ul className="flex max-h-80 flex-col gap-1 overflow-y-auto">
+          {rows.map((r) => (
+            <li
+              key={r.id}
+              className="flex flex-col gap-0.5 rounded-lg px-3 py-2 odd:bg-bg-elevated/40"
+            >
+              <div className="flex items-center justify-between gap-3">
+                <span className="truncate text-[13px] text-fg">{r.name}</span>
+                <PhasePill phase={r.state.phase} />
+              </div>
+              {r.state.phase === "failed" && r.state.message && (
+                <p className="text-[11px] text-accent-attention">{r.state.message}</p>
+              )}
+            </li>
+          ))}
+        </ul>
+
+        {/* Summary */}
+        {summary && (
+          <div className="rounded-xl border border-border bg-bg-elevated/60 p-4">
+            <p className="text-[14px] font-medium text-fg">
+              {summary.ok} of {repos.length} pulled successfully
+            </p>
+            {summary.failed.length > 0 && (
+              <div className="mt-2">
+                <button
+                  type="button"
+                  onClick={() => setShowFailures((v) => !v)}
+                  className="text-[12px] text-fg-muted underline-offset-2 hover:underline"
+                >
+                  {showFailures ? "Hide" : "Show"} {summary.failed.length} failure{summary.failed.length !== 1 ? "s" : ""}
+                </button>
+                {showFailures && (
+                  <ul className="mt-2 flex flex-col gap-1.5">
+                    {summary.failed.map((f, i) => (
+                      <li key={i} className="text-[12px]">
+                        <span className="font-medium text-fg">{f.name}</span>
+                        {" — "}
+                        <span className="text-accent-attention">{f.message}</span>
+                      </li>
+                    ))}
+                  </ul>
+                )}
+              </div>
+            )}
+          </div>
+        )}
+
+        {timedOut && !summary && (
+          <p className="text-[13px] text-accent-attention">
+            The pull timed out. Some repos may have updated — check the dashboard.
+          </p>
+        )}
+
+        <footer className="flex justify-end">
+          <button
+            type="button"
+            disabled={!isDone}
+            onClick={onClose}
+            className="rounded-full bg-accent-pull px-5 py-2 text-[13px] font-medium text-white transition-opacity disabled:cursor-not-allowed disabled:opacity-40 hover:opacity-90"
+          >
+            {isDone ? "Done" : "Running…"}
+          </button>
+        </footer>
+      </div>
+    </div>
+  );
+}

--- a/components/Dashboard.tsx
+++ b/components/Dashboard.tsx
@@ -7,6 +7,7 @@ import type { GroupKind } from "./RepoCard";
 import { ThemeToggle } from "./ThemeToggle";
 import { RemoteReposSection } from "./RemoteReposSection";
 import { HealthBanner } from "./HealthBanner";
+import { BulkActionModal } from "./BulkActionModal";
 
 interface Props {
   initialRepos: RepoView[];
@@ -157,12 +158,19 @@ function bodyFor(kind: GroupKind, _n: number): string {
   }
 }
 
+interface BulkRunState {
+  bulkRunId: string;
+  repos: Array<{ id: number; name: string }>;
+}
+
 export function Dashboard({ initialRepos, csrfToken }: Props) {
   const [repos, setRepos] = useState<RepoView[]>(initialRepos);
   const [showSystem, setShowSystem] = useState(false);
   const [query, setQuery] = useState("");
   const [connected, setConnected] = useState(false);
   const [expandedRepoId, setExpandedRepoId] = useState<number | null>(null);
+  const [bulkRun, setBulkRun] = useState<BulkRunState | null>(null);
+  const [bulkInFlight, setBulkInFlight] = useState(false);
 
   useEffect(() => {
     if (expandedRepoId === null) return;
@@ -253,6 +261,37 @@ export function Dashboard({ initialRepos, csrfToken }: Props) {
     [groups],
   );
 
+  const behindCount = useMemo(
+    () => (groups.find((g) => g.kind === "pull")?.repos.length ?? 0),
+    [groups],
+  );
+
+  async function handlePullAll() {
+    if (bulkInFlight || behindCount === 0) return;
+    setBulkInFlight(true);
+    try {
+      const res = await fetch("/api/bulk/pull", {
+        method: "POST",
+        headers: { "x-csrf-token": csrfToken },
+      });
+      if (!res.ok) {
+        const body = (await res.json()) as { error?: string };
+        alert(body.error ?? "Pull All failed — try again");
+        return;
+      }
+      const data = (await res.json()) as { bulkRunId: string };
+      const behindRepos = groups.find((g) => g.kind === "pull")?.repos ?? [];
+      setBulkRun({
+        bulkRunId: data.bulkRunId,
+        repos: behindRepos.map((r) => ({ id: r.id, name: r.displayName })),
+      });
+    } catch {
+      alert("Could not start Pull All — check your connection");
+    } finally {
+      setBulkInFlight(false);
+    }
+  }
+
   return (
     <main className="grain relative mx-auto max-w-[1280px] px-4 py-8 sm:px-10 sm:py-14">
       <header className="mb-8 flex flex-col gap-5 sm:mb-12 sm:gap-6 sm:flex-row sm:items-end sm:justify-between">
@@ -298,6 +337,16 @@ export function Dashboard({ initialRepos, csrfToken }: Props) {
             />
             {connected ? "live" : "reconnecting"}
           </div>
+          {behindCount > 0 && (
+            <button
+              type="button"
+              disabled={bulkInFlight}
+              onClick={() => { void handlePullAll(); }}
+              className="flex h-9 items-center gap-1.5 rounded-full bg-accent-pull px-4 text-[13px] font-medium text-white transition-opacity hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-50"
+            >
+              Pull All ({behindCount})
+            </button>
+          )}
           <ThemeToggle />
         </div>
       </header>
@@ -335,6 +384,14 @@ export function Dashboard({ initialRepos, csrfToken }: Props) {
         <span>{repos.length} tracked</span>
         <span className="mono">localhost:7420</span>
       </footer>
+
+      {bulkRun && (
+        <BulkActionModal
+          bulkRunId={bulkRun.bulkRunId}
+          repos={bulkRun.repos}
+          onClose={() => setBulkRun(null)}
+        />
+      )}
     </main>
   );
 }

--- a/lib/bulk/store.ts
+++ b/lib/bulk/store.ts
@@ -1,0 +1,49 @@
+import { EventEmitter } from "node:events";
+
+// ---------------------------------------------------------------------------
+// Per-repo status within a bulk run
+// ---------------------------------------------------------------------------
+export type RepoRunStatus =
+  | { phase: "queued" }
+  | { phase: "pulling" }
+  | { phase: "done" }
+  | { phase: "failed"; message: string };
+
+export interface BulkRun {
+  repos: Array<{ id: number; name: string; path: string }>;
+  statuses: Map<number, RepoRunStatus>;
+  emitter: EventEmitter;
+  startedAt: number;
+}
+
+// ---------------------------------------------------------------------------
+// Singleton map on globalThis so it survives Next.js HMR
+// ---------------------------------------------------------------------------
+const bulkRunsKey = Symbol.for("gitdash.bulk.runs");
+type GlobalWithBulkRuns = typeof globalThis & { [bulkRunsKey]?: Map<string, BulkRun> };
+const g = globalThis as GlobalWithBulkRuns;
+
+function getBulkRuns(): Map<string, BulkRun> {
+  if (!g[bulkRunsKey]) {
+    g[bulkRunsKey] = new Map();
+  }
+  return g[bulkRunsKey]!;
+}
+
+export function getBulkRun(runId: string): BulkRun | undefined {
+  return getBulkRuns().get(runId);
+}
+
+export function setBulkRun(runId: string, run: BulkRun): void {
+  getBulkRuns().set(runId, run);
+}
+
+/** Remove entries older than 5 minutes */
+export function gcBulkRuns(): void {
+  const cutoff = Date.now() - 5 * 60 * 1000;
+  for (const [id, run] of getBulkRuns()) {
+    if (run.startedAt < cutoff) {
+      getBulkRuns().delete(id);
+    }
+  }
+}


### PR DESCRIPTION
Closes #159

## Summary

- Adds "Pull All (N)" button in the dashboard header, visible only when N > 0 repos are in the `behind` bucket
- `POST /api/bulk/pull` fast-forwards all behind repos concurrently (p-limit 4), returns a `bulkRunId`
- `GET /api/bulk/[runId]/stream` SSE stream emits per-repo `start`/`done`/`error` events plus a final `summary`
- `BulkActionModal` shows live status pills (queued / pulling / done / failed) per repo, summary count, collapsible failure list, and a 60s timeout safety net
- Shared in-memory bulk run state lives in `lib/bulk/store.ts` on `globalThis` via `Symbol.for("gitdash.bulk.runs")` to survive HMR

## Constraints honoured

- CSRF required on POST
- `git pull --ff-only` only — diverged repos fail gracefully and the run continues
- No shell (`bash -c`) — pure `spawn("git", [...])` 
- Hard cap: 422 if >50 repos qualify
- Plain-English errors: "Has changes the bulk pull can't safely combine — open the repo to handle" for ff-only failures
- All `JSON.parse` in the modal wrapped in try/catch

## Test plan

- [ ] Set 3 repos behind (e.g. `git reset --hard HEAD~1` then leave them). Click Pull All (3). Modal shows queued → pulling → done for each. All 3 advance to clean in the dashboard.
- [ ] With one of those repos diverged: bulk continues, summary shows 2 succeeded / 1 failed with the ff-only message.
- [ ] With 0 repos behind: button is hidden.
- [ ] Close button is disabled until all repos reach a terminal state.
- [ ] `npm run typecheck` and `npm run build` both pass clean (verified in CI above).

🤖 Generated with [Claude Code](https://claude.com/claude-code)