### PR TITLE
feat(wip): cross-machine WIP sync via wip/<label> branches

### DIFF
--- a/app/api/config/machine-label/route.ts
+++ b/app/api/config/machine-label/route.ts
@@ -1,0 +1,69 @@
+import { NextResponse } from "next/server";
+import { readFile, writeFile, mkdir } from "node:fs/promises";
+import { hostname } from "node:os";
+import path from "node:path";
+import { validateCsrf } from "@/lib/security/csrf";
+import { displayLabel } from "@/lib/security/label";
+
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
+
+function configPath(): string {
+  const xdg = process.env.XDG_CONFIG_HOME ?? path.join(process.env.HOME ?? ".", ".config");
+  return path.join(xdg, "gitdash", "config.json");
+}
+
+async function readConfig(): Promise<Record<string, unknown>> {
+  try {
+    const raw = await readFile(configPath(), "utf8");
+    return JSON.parse(raw) as Record<string, unknown>;
+  } catch {
+    return {};
+  }
+}
+
+async function writeConfig(data: Record<string, unknown>): Promise<void> {
+  const p = configPath();
+  await mkdir(path.dirname(p), { recursive: true });
+  await writeFile(p, JSON.stringify(data, null, 2) + "\n", "utf8");
+}
+
+export async function GET(): Promise<NextResponse> {
+  const config = await readConfig();
+  const stored = typeof config.machineLabel === "string" ? config.machineLabel : null;
+  const host = hostname();
+  const isDefault = !stored || stored.trim().length === 0;
+  const label = displayLabel(stored, host);
+  return NextResponse.json({ label, isDefault, hostname: host });
+}
+
+export async function PUT(req: Request): Promise<NextResponse> {
+  const csrf = req.headers.get("x-csrf-token");
+  if (!validateCsrf(csrf)) {
+    return NextResponse.json({ error: "invalid csrf" }, { status: 403 });
+  }
+
+  let body: { label?: unknown };
+  try {
+    body = (await req.json()) as { label?: unknown };
+  } catch {
+    return NextResponse.json({ error: "invalid JSON body" }, { status: 400 });
+  }
+
+  const raw = typeof body.label === "string" ? body.label.trim() : "";
+  const config = await readConfig();
+
+  if (raw.length === 0) {
+    // Unset — remove the key so hostname fallback takes over
+    delete config.machineLabel;
+  } else {
+    config.machineLabel = raw;
+  }
+
+  await writeConfig(config);
+
+  const host = hostname();
+  const isDefault = raw.length === 0;
+  const label = displayLabel(raw || null, host);
+  return NextResponse.json({ label, isDefault, hostname: host });
+}

--- a/app/api/repos/[id]/actions/[name]/route.ts
+++ b/app/api/repos/[id]/actions/[name]/route.ts
@@ -7,7 +7,9 @@ import {
   isValidPublishName,
   startAction,
   type PublishOptions,
+  type WipRestoreOptions,
 } from "@/lib/git/actions";
+import { isSafeRef } from "@/lib/git/exec";
 import { getScheduler } from "@/lib/scan/scheduler";
 
 export const dynamic = "force-dynamic";
@@ -40,6 +42,7 @@ export async function POST(
 
   let commitMessage: string | undefined;
   let publish: PublishOptions | undefined;
+  let wipRestore: WipRestoreOptions | undefined;
   if (name === "commit-push" || name === "commit") {
     try {
       const body = (await req.json()) as { commitMessage?: unknown };
@@ -65,6 +68,20 @@ export async function POST(
     const visibility = body.visibility === "public" ? "public" : "private";
     const description = typeof body.description === "string" ? body.description : undefined;
     publish = { name: body.name, visibility, description };
+  } else if (name === "wip-restore") {
+    let body: { wipBranch?: unknown; deleteAfter?: unknown };
+    try {
+      body = (await req.json()) as typeof body;
+    } catch {
+      return NextResponse.json({ error: "wip-restore requires a JSON body" }, { status: 400 });
+    }
+    if (typeof body.wipBranch !== "string" || !isSafeRef(body.wipBranch)) {
+      return NextResponse.json({ error: "invalid wipBranch" }, { status: 400 });
+    }
+    wipRestore = {
+      wipBranch: body.wipBranch,
+      deleteAfter: body.deleteAfter === true,
+    };
   }
 
   const snap = getSnapshot(repoId);
@@ -77,6 +94,7 @@ export async function POST(
       branch: snap?.branch ?? null,
       commitMessage,
       publish,
+      wipRestore,
     });
   } catch (err) {
     return NextResponse.json({ error: String(err) }, { status: 400 });

--- a/app/api/repos/[id]/wip-list/route.ts
+++ b/app/api/repos/[id]/wip-list/route.ts
@@ -1,0 +1,140 @@
+import { NextResponse } from "next/server";
+import { bootstrap } from "@/lib/bootstrap";
+import { getRepoById } from "@/lib/db/repos";
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+import { hostname } from "node:os";
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import { sanitizeLabel } from "@/lib/security/label";
+
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
+
+const execFileAsync = promisify(execFile);
+
+export interface WipEntry {
+  branch: string;
+  source: string | null;
+  machineLabel: string;
+  timestamp: string | null;
+  isOwn: boolean;
+}
+
+async function getLocalMachineLabel(): Promise<string> {
+  try {
+    const xdg = process.env.XDG_CONFIG_HOME ?? path.join(process.env.HOME ?? ".", ".config");
+    const configPath = path.join(xdg, "gitdash", "config.json");
+    const raw = await readFile(configPath, "utf8");
+    const parsed = JSON.parse(raw) as Record<string, unknown>;
+    if (typeof parsed.machineLabel === "string" && parsed.machineLabel.trim().length > 0) {
+      return sanitizeLabel(parsed.machineLabel.trim());
+    }
+  } catch {
+    // fall through
+  }
+  return sanitizeLabel(hostname()) || "gitdash";
+}
+
+export async function GET(
+  req: Request,
+  ctx: { params: Promise<{ id: string }> },
+): Promise<NextResponse> {
+  await bootstrap();
+
+  const { id } = await ctx.params;
+  const repoId = Number(id);
+  if (!Number.isInteger(repoId) || repoId <= 0) {
+    return NextResponse.json({ error: "invalid repo id" }, { status: 400 });
+  }
+
+  const repo = getRepoById(repoId);
+  if (!repo || repo.deletedAt !== null) {
+    return NextResponse.json({ error: "repo not found" }, { status: 404 });
+  }
+
+  const url = new URL(req.url);
+  const includeMine = url.searchParams.get("mine") === "true";
+
+  // Get the local machine label to identify own WIP branch
+  const localLabel = await getLocalMachineLabel();
+  const ownWipBranch = `wip/${localLabel}`;
+
+  // Enumerate remote WIP branches
+  let lsRemoteOutput = "";
+  try {
+    const result = await execFileAsync(
+      "git",
+      ["-C", repo.repoPath, "ls-remote", "origin", "refs/heads/wip/*"],
+      {
+        timeout: 15_000,
+        env: { ...process.env, GIT_TERMINAL_PROMPT: "0" },
+        maxBuffer: 1024 * 1024,
+      },
+    );
+    lsRemoteOutput = result.stdout;
+  } catch {
+    // ls-remote failed (no remote, no auth, etc.) — return empty list
+    return NextResponse.json({ wips: [] });
+  }
+
+  // Parse: "<sha>\trefs/heads/wip/<label>"
+  const branches: string[] = [];
+  for (const line of lsRemoteOutput.split("\n")) {
+    const trimmed = line.trim();
+    if (!trimmed) continue;
+    const parts = trimmed.split("\t");
+    if (parts.length < 2) continue;
+    const ref = parts[1]!;
+    const branchName = ref.replace(/^refs\/heads\//, "");
+    if (!branchName.startsWith("wip/")) continue;
+    branches.push(branchName);
+  }
+
+  // For each branch, fetch the commit subject to extract source + timestamp
+  const wips: WipEntry[] = [];
+  const labelRe = /^wip\/(.+)$/;
+  const subjectRe = /^WIP from (.+?) · (\d{4}-\d{2}-\d{2}T[\d:.Z]+)$/;
+
+  for (const branch of branches) {
+    const isOwn = branch === ownWipBranch;
+    if (isOwn && !includeMine) continue;
+
+    const machineLabel = labelRe.exec(branch)?.[1] ?? branch;
+
+    let source: string | null = null;
+    let timestamp: string | null = null;
+
+    try {
+      const logResult = await execFileAsync(
+        "git",
+        ["-C", repo.repoPath, "log", "-1", "--format=%s", `origin/${branch}`],
+        {
+          timeout: 5_000,
+          env: { ...process.env, GIT_TERMINAL_PROMPT: "0" },
+          maxBuffer: 256 * 1024,
+        },
+      );
+      const subject = logResult.stdout.trim();
+      const match = subjectRe.exec(subject);
+      if (match) {
+        source = match[1] ?? null;
+        timestamp = match[2] ?? null;
+      }
+    } catch {
+      // Could not read log — still include branch with null metadata
+    }
+
+    wips.push({ branch, source, machineLabel, timestamp, isOwn });
+  }
+
+  // Sort: most recent first (by timestamp descending, nulls last)
+  wips.sort((a, b) => {
+    if (!a.timestamp && !b.timestamp) return 0;
+    if (!a.timestamp) return 1;
+    if (!b.timestamp) return -1;
+    return b.timestamp.localeCompare(a.timestamp);
+  });
+
+  return NextResponse.json({ wips });
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -3,6 +3,10 @@ import { Instrument_Serif, Instrument_Sans, IBM_Plex_Mono } from "next/font/goog
 import "./globals.css";
 import { VersionBadge } from "@/components/VersionBadge";
 import { UpdateBanner } from "@/components/UpdateBanner";
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import { displayLabel } from "@/lib/security/label";
+import { hostname } from "node:os";
 
 const serif = Instrument_Serif({
   subsets: ["latin"],
@@ -26,10 +30,28 @@ const mono = IBM_Plex_Mono({
   display: "swap",
 });
 
-export const metadata: Metadata = {
-  title: "gitdash",
-  description: "Local git repo status dashboard",
-};
+async function getStoredLabel(): Promise<string | null> {
+  try {
+    const xdg = process.env.XDG_CONFIG_HOME ?? path.join(process.env.HOME ?? ".", ".config");
+    const configPath = path.join(xdg, "gitdash", "config.json");
+    const raw = await readFile(configPath, "utf8");
+    const parsed = JSON.parse(raw) as Record<string, unknown>;
+    return typeof parsed.machineLabel === "string" ? parsed.machineLabel : null;
+  } catch {
+    return null;
+  }
+}
+
+export async function generateMetadata(): Promise<Metadata> {
+  const stored = await getStoredLabel();
+  const label = displayLabel(stored, hostname());
+  const isDefault = !stored || stored.trim().length === 0;
+  const title = isDefault ? "gitdash" : `${label} · gitdash`;
+  return {
+    title,
+    description: "Local git repo status dashboard",
+  };
+}
 
 // Runs before paint to set the theme class — prevents the wrong-theme flash
 // on first render. Reads localStorage('gitdash-theme'), falls back to OS preference.

--- a/components/ActionModal.tsx
+++ b/components/ActionModal.tsx
@@ -34,6 +34,8 @@ const COPY: Record<string, { verb: string; confirm?: string }> = {
   "publish-to-github": { verb: "Publishing this repo to GitHub" },
   "open-editor": { verb: "Opening in your editor" },
   "open-terminal": { verb: "Opening a terminal" },
+  "wip-stash-push": { verb: "Backing up your work-in-progress to GitHub" },
+  "wip-restore": { verb: "Restoring work-in-progress from another machine" },
 };
 
 const PUBLISH_NAME_RE = /^[A-Za-z0-9][A-Za-z0-9._-]{0,99}$/;
@@ -52,6 +54,14 @@ interface ChangesResponse {
   truncated: boolean;
 }
 
+interface WipEntry {
+  branch: string;
+  source: string | null;
+  machineLabel: string;
+  timestamp: string | null;
+  isOwn: boolean;
+}
+
 export function ActionModal({ repo, action, csrfToken, onClose }: Props) {
   const snap = repo.snapshot;
   const pushCount = snap?.remoteAhead ?? snap?.ahead ?? 0;
@@ -59,9 +69,13 @@ export function ActionModal({ repo, action, csrfToken, onClose }: Props) {
   const isCommitPush = action === "commit-push";
   const isCommitFlow = isCommit || isCommitPush;
   const isPublish = action === "publish-to-github";
+  const isWipPush = action === "wip-stash-push";
+  const isWipRestore = action === "wip-restore";
   const needsConfirm =
     isCommitFlow ||
     isPublish ||
+    isWipPush ||
+    isWipRestore ||
     action === "merge" ||
     (action === "push" && pushCount > DESTRUCTIVE_CONFIRMATION_LIMIT);
 
@@ -73,7 +87,13 @@ export function ActionModal({ repo, action, csrfToken, onClose }: Props) {
   const [publishVisibility, setPublishVisibility] = useState<"private" | "public">("private");
   const [publishDescription, setPublishDescription] = useState<string>("");
   const [changes, setChanges] = useState<ChangesResponse | null>(null);
-  const [changesLoading, setChangesLoading] = useState(isCommitFlow);
+  const [changesLoading, setChangesLoading] = useState(isCommitFlow || isWipPush);
+  // WIP restore state
+  const [wipList, setWipList] = useState<WipEntry[]>([]);
+  const [wipListLoading, setWipListLoading] = useState(isWipRestore);
+  const [wipListError, setWipListError] = useState<string | null>(null);
+  const [selectedWip, setSelectedWip] = useState<string>("");
+  const [deleteAfterRestore, setDeleteAfterRestore] = useState(true);
   const [mounted, setMounted] = useState(false);
   const logRef = useRef<HTMLPreElement | null>(null);
   const esRef = useRef<EventSource | null>(null);
@@ -156,9 +176,9 @@ export function ActionModal({ repo, action, csrfToken, onClose }: Props) {
     };
   }, [mounted]);
 
-  // Fetch changes preview when entering any commit-flow confirm
+  // Fetch changes preview when entering any commit-flow or wip-push confirm
   useEffect(() => {
-    if (!isCommitFlow || phase !== "confirm") return;
+    if ((!isCommitFlow && !isWipPush) || phase !== "confirm") return;
     let cancelled = false;
     (async () => {
       try {
@@ -167,7 +187,7 @@ export function ActionModal({ repo, action, csrfToken, onClose }: Props) {
           setChanges((await res.json()) as ChangesResponse);
         }
       } catch {
-        // best-effort; user can still commit blind
+        // best-effort; user can still proceed blind
       } finally {
         if (!cancelled) setChangesLoading(false);
       }
@@ -175,7 +195,36 @@ export function ActionModal({ repo, action, csrfToken, onClose }: Props) {
     return () => {
       cancelled = true;
     };
-  }, [isCommitFlow, phase, repo.id]);
+  }, [isCommitFlow, isWipPush, phase, repo.id]);
+
+  // Fetch WIP list when entering wip-restore confirm
+  useEffect(() => {
+    if (!isWipRestore || phase !== "confirm") return;
+    let cancelled = false;
+    (async () => {
+      try {
+        const res = await fetch(`/api/repos/${repo.id}/wip-list`);
+        if (!res.ok) {
+          if (!cancelled) setWipListError("Could not load WIP branches. Check your GitHub connection.");
+          return;
+        }
+        const data = (await res.json()) as { wips: WipEntry[] };
+        if (!cancelled) {
+          setWipList(data.wips);
+          if (data.wips.length > 0 && data.wips[0]) {
+            setSelectedWip(data.wips[0].branch);
+          }
+        }
+      } catch {
+        if (!cancelled) setWipListError("Network error loading WIP branches.");
+      } finally {
+        if (!cancelled) setWipListLoading(false);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [isWipRestore, phase, repo.id]);
 
   useEffect(() => {
     if (phase !== "running") return;
@@ -192,6 +241,8 @@ export function ActionModal({ repo, action, csrfToken, onClose }: Props) {
             visibility: publishVisibility,
             description: publishDescription.trim(),
           };
+        } else if (isWipRestore) {
+          body = { wipBranch: selectedWip, deleteAfter: deleteAfterRestore };
         }
         const res = await fetch(`/api/repos/${repo.id}/actions/${action}`, {
           method: "POST",
@@ -244,10 +295,13 @@ export function ActionModal({ repo, action, csrfToken, onClose }: Props) {
     csrfToken,
     isCommitFlow,
     isPublish,
+    isWipRestore,
     commitMessage,
     publishName,
     publishVisibility,
     publishDescription,
+    selectedWip,
+    deleteAfterRestore,
   ]);
 
   useEffect(() => {
@@ -297,6 +351,29 @@ export function ActionModal({ repo, action, csrfToken, onClose }: Props) {
             loading={changesLoading}
             commitMessage={commitMessage}
             onMessageChange={setCommitMessage}
+            onCancel={onClose}
+            onConfirm={() => setPhase("running")}
+          />
+        )}
+
+        {phase === "confirm" && isWipPush && (
+          <WipStashPushConfirm
+            changes={changes}
+            loading={changesLoading}
+            onCancel={onClose}
+            onConfirm={() => setPhase("running")}
+          />
+        )}
+
+        {phase === "confirm" && isWipRestore && (
+          <WipRestoreConfirm
+            wips={wipList}
+            loading={wipListLoading}
+            error={wipListError}
+            selectedWip={selectedWip}
+            deleteAfter={deleteAfterRestore}
+            onSelectWip={setSelectedWip}
+            onDeleteAfterChange={setDeleteAfterRestore}
             onCancel={onClose}
             onConfirm={() => setPhase("running")}
           />
@@ -644,4 +721,227 @@ function statusGlyph(status: string): string {
   if (s.includes("R")) return "→";          // renamed
   if (s.includes("M")) return "~";          // modified
   return "·";
+}
+
+function relativeTimeLocal(isoTimestamp: string | null): string {
+  if (!isoTimestamp) return "unknown time";
+  try {
+    const ts = new Date(isoTimestamp).getTime();
+    const deltaSec = Math.floor((Date.now() - ts) / 1000);
+    if (deltaSec < 60) return "just now";
+    if (deltaSec < 3600) return `${Math.floor(deltaSec / 60)}m ago`;
+    if (deltaSec < 86400) return `${Math.floor(deltaSec / 3600)}h ago`;
+    if (deltaSec < 86400 * 30) return `${Math.floor(deltaSec / 86400)}d ago`;
+    return `${Math.floor(deltaSec / (86400 * 30))}mo ago`;
+  } catch {
+    return "unknown time";
+  }
+}
+
+function WipStashPushConfirm({
+  changes,
+  loading,
+  onCancel,
+  onConfirm,
+}: {
+  changes: ChangesResponse | null;
+  loading: boolean;
+  onCancel: () => void;
+  onConfirm: () => void;
+}) {
+  const total = changes?.total ?? 0;
+  const suspicious = changes?.suspicious ?? [];
+
+  return (
+    <div className="flex flex-col gap-5 overflow-y-auto px-6 py-6">
+      <p className="text-[13.5px] leading-relaxed text-fg-muted">
+        Gitdash will save your current work-in-progress to a private branch on GitHub.
+        Your working files stay exactly as they are — nothing is committed to your main branch.
+        You can restore this WIP on any other machine running gitdash.
+      </p>
+
+      {loading && (
+        <p className="text-[13px] text-fg-dim">Checking what will be backed up…</p>
+      )}
+
+      {!loading && changes && total === 0 && (
+        <p className="text-[13px] text-fg-muted">
+          No changes detected. Nothing to back up.
+        </p>
+      )}
+
+      {!loading && changes && total > 0 && (
+        <div>
+          <p className="text-[14px] text-fg">
+            <span className="display-italic">{total}</span>{" "}
+            file{total === 1 ? "" : "s"} will be backed up to GitHub.
+          </p>
+          <FilePreview files={changes.files.slice(0, 8)} />
+          {changes.files.length > 8 && (
+            <p className="mt-2 text-[11px] text-fg-dim">…and {changes.files.length - 8} more</p>
+          )}
+        </div>
+      )}
+
+      {suspicious.length > 0 && (
+        <div className="flex gap-3 rounded-lg border border-accent-attention/40 bg-accent-attention/8 p-4">
+          <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0 text-accent-attention" />
+          <div className="text-[12.5px] text-fg-muted">
+            <p className="font-medium text-fg">
+              Heads up — gitdash flagged {suspicious.length} file{suspicious.length === 1 ? "" : "s"} that look sensitive:
+            </p>
+            <ul className="mt-1.5 space-y-0.5 mono text-[11.5px]">
+              {suspicious.slice(0, 6).map((f) => (
+                <li key={f.path} className="text-accent-attention">
+                  {f.path}
+                  <span className="ml-2 text-fg-dim">
+                    ({f.reason === "secret" ? "looks like a secret" : "large file"})
+                  </span>
+                </li>
+              ))}
+            </ul>
+            <p className="mt-2 text-[11.5px] text-fg-dim">
+              These will be pushed to GitHub. Make sure your WIP branch is private.
+            </p>
+          </div>
+        </div>
+      )}
+
+      <div className="mt-1 flex justify-end gap-3">
+        <button
+          onClick={onCancel}
+          className="rounded-full border border-border px-4 py-1.5 text-[13px] font-medium text-fg-muted hover:border-fg-muted hover:text-fg"
+        >
+          Cancel
+        </button>
+        <button
+          onClick={onConfirm}
+          disabled={!loading && total === 0}
+          className={cn(
+            "rounded-full border px-5 py-1.5 text-[13px] font-medium transition-all",
+            "border-accent-dirty/45 bg-accent-dirty/15 text-accent-dirty hover:bg-accent-dirty/25",
+            "disabled:cursor-not-allowed disabled:opacity-40",
+          )}
+        >
+          Backup WIP
+        </button>
+      </div>
+    </div>
+  );
+}
+
+function WipRestoreConfirm({
+  wips,
+  loading,
+  error,
+  selectedWip,
+  deleteAfter,
+  onSelectWip,
+  onDeleteAfterChange,
+  onCancel,
+  onConfirm,
+}: {
+  wips: WipEntry[];
+  loading: boolean;
+  error: string | null;
+  selectedWip: string;
+  deleteAfter: boolean;
+  onSelectWip: (branch: string) => void;
+  onDeleteAfterChange: (v: boolean) => void;
+  onCancel: () => void;
+  onConfirm: () => void;
+}) {
+  return (
+    <div className="flex flex-col gap-5 overflow-y-auto px-6 py-6">
+      <p className="text-[13.5px] leading-relaxed text-fg-muted">
+        Pick a backed-up WIP to restore. Gitdash will apply those changes to your working tree
+        without committing anything — you can keep editing right where the other machine left off.
+      </p>
+
+      {loading && (
+        <p className="text-[13px] text-fg-dim">Looking for available WIP backups…</p>
+      )}
+
+      {error && (
+        <p className="text-[13px] text-accent-attention">{error}</p>
+      )}
+
+      {!loading && !error && wips.length === 0 && (
+        <p className="text-[13px] text-fg-muted">
+          No WIP backups found on GitHub. Use the Backup WIP button on another machine first.
+        </p>
+      )}
+
+      {!loading && !error && wips.length > 0 && (
+        <fieldset className="flex flex-col gap-2">
+          <legend className="text-[12px] uppercase tracking-wider text-fg-dim">Available backups</legend>
+          <div className="flex flex-col gap-2">
+            {wips.map((wip) => (
+              <label
+                key={wip.branch}
+                className={cn(
+                  "flex cursor-pointer items-start gap-2.5 rounded-lg border bg-bg/40 p-3 text-[13px]",
+                  selectedWip === wip.branch
+                    ? "border-accent-pull/50 bg-accent-pull/8"
+                    : "border-border hover:border-fg-dim/40",
+                )}
+              >
+                <input
+                  type="radio"
+                  name="wip-branch"
+                  value={wip.branch}
+                  checked={selectedWip === wip.branch}
+                  onChange={() => onSelectWip(wip.branch)}
+                  className="mt-0.5 accent-accent-pull"
+                />
+                <span className="flex min-w-0 flex-col gap-0.5">
+                  <span className="mono text-[12px] font-medium text-fg">{wip.branch}</span>
+                  {wip.source && (
+                    <span className="text-[11.5px] text-fg-muted">
+                      From branch: <span className="mono">{wip.source}</span>
+                    </span>
+                  )}
+                  <span className="text-[11px] text-fg-dim">
+                    {relativeTimeLocal(wip.timestamp)}
+                  </span>
+                </span>
+              </label>
+            ))}
+          </div>
+        </fieldset>
+      )}
+
+      {!loading && !error && wips.length > 0 && (
+        <label className="flex cursor-pointer items-center gap-2.5 text-[13px] text-fg-muted">
+          <input
+            type="checkbox"
+            checked={deleteAfter}
+            onChange={(e) => onDeleteAfterChange(e.target.checked)}
+            className="accent-accent-pull"
+          />
+          Delete remote backup after restoring
+        </label>
+      )}
+
+      <div className="mt-1 flex justify-end gap-3">
+        <button
+          onClick={onCancel}
+          className="rounded-full border border-border px-4 py-1.5 text-[13px] font-medium text-fg-muted hover:border-fg-muted hover:text-fg"
+        >
+          Cancel
+        </button>
+        <button
+          onClick={onConfirm}
+          disabled={loading || wips.length === 0 || !selectedWip}
+          className={cn(
+            "rounded-full border px-5 py-1.5 text-[13px] font-medium transition-all",
+            "border-accent-pull/45 bg-accent-pull/15 text-accent-pull hover:bg-accent-pull/25",
+            "disabled:cursor-not-allowed disabled:opacity-40",
+          )}
+        >
+          Restore WIP
+        </button>
+      </div>
+    </div>
+  );
 }

--- a/components/Dashboard.tsx
+++ b/components/Dashboard.tsx
@@ -1,12 +1,13 @@
 "use client";
 
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import type { RepoView } from "@/lib/state/store";
 import { RepoGroup } from "./RepoGroup";
 import type { GroupKind } from "./RepoCard";
 import { ThemeToggle } from "./ThemeToggle";
 import { RemoteReposSection } from "./RemoteReposSection";
 import { HealthBanner } from "./HealthBanner";
+import { Pencil } from "lucide-react";
 
 interface Props {
   initialRepos: RepoView[];
@@ -157,6 +158,132 @@ function bodyFor(kind: GroupKind, _n: number): string {
   }
 }
 
+// ---------------------------------------------------------------------------
+// Inline-editable machine label
+// ---------------------------------------------------------------------------
+
+interface MachineLabelEditorProps {
+  csrfToken: string;
+}
+
+function MachineLabelEditor({ csrfToken }: MachineLabelEditorProps) {
+  const [label, setLabel] = useState<string>("");
+  const [editing, setEditing] = useState(false);
+  const [draft, setDraft] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  // Fetch current label on mount
+  useEffect(() => {
+    fetch("/api/config/machine-label")
+      .then((r) => r.json())
+      .then((d: unknown) => {
+        const data = d as { label: string };
+        setLabel(data.label);
+        document.title = data.label ? `${data.label} · gitdash` : "gitdash";
+      })
+      .catch(() => {
+        // ignore — fallback stays as-is
+      });
+  }, []);
+
+  function startEditing() {
+    setDraft(label);
+    setError(null);
+    setEditing(true);
+    // Focus happens after re-render
+    setTimeout(() => {
+      inputRef.current?.select();
+    }, 0);
+  }
+
+  async function commitEdit() {
+    if (!editing) return;
+    setEditing(false);
+    const trimmed = draft.trim();
+    if (trimmed === label) return; // no change
+    try {
+      const res = await fetch("/api/config/machine-label", {
+        method: "PUT",
+        headers: {
+          "Content-Type": "application/json",
+          "x-csrf-token": csrfToken,
+        },
+        body: JSON.stringify({ label: trimmed }),
+      });
+      if (!res.ok) {
+        setError("Couldn't save — try again");
+        return;
+      }
+      const data = (await res.json()) as { label: string };
+      setLabel(data.label);
+      document.title = data.label ? `${data.label} · gitdash` : "gitdash";
+      setError(null);
+    } catch {
+      setError("Couldn't save — try again");
+    }
+  }
+
+  function cancelEdit() {
+    setEditing(false);
+    setDraft("");
+    setError(null);
+  }
+
+  function handleKeyDown(e: React.KeyboardEvent<HTMLInputElement>) {
+    if (e.key === "Enter") {
+      e.preventDefault();
+      void commitEdit();
+    } else if (e.key === "Escape") {
+      e.preventDefault();
+      cancelEdit();
+    }
+  }
+
+  if (editing) {
+    return (
+      <div className="flex flex-col gap-1">
+        <input
+          ref={inputRef}
+          autoFocus
+          type="text"
+          value={draft}
+          onChange={(e) => setDraft(e.target.value)}
+          onKeyDown={handleKeyDown}
+          onBlur={() => void commitEdit()}
+          maxLength={80}
+          className="display text-[36px] leading-none tracking-display-tight text-fg sm:text-[44px] bg-transparent border-b border-ring outline-none w-full max-w-xs"
+          aria-label="Machine label"
+        />
+        <p className="text-[11px] text-fg-dim">Enter to save · Esc to cancel</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex flex-col gap-1">
+      <button
+        type="button"
+        onClick={startEditing}
+        className="group flex items-center gap-2 text-left"
+        title="Click to rename this machine"
+      >
+        <h1 className="display text-[36px] leading-none tracking-display-tight text-fg sm:text-[44px]">
+          {label || "gitdash"}
+        </h1>
+        <Pencil
+          size={14}
+          className="text-fg-dim opacity-0 group-hover:opacity-60 transition-opacity mt-2 shrink-0"
+          aria-hidden
+        />
+      </button>
+      {error && (
+        <p className="text-[12px] text-accent-attention">{error}</p>
+      )}
+    </div>
+  );
+}
+
 export function Dashboard({ initialRepos, csrfToken }: Props) {
   const [repos, setRepos] = useState<RepoView[]>(initialRepos);
   const [showSystem, setShowSystem] = useState(false);
@@ -257,9 +384,7 @@ export function Dashboard({ initialRepos, csrfToken }: Props) {
     <main className="grain relative mx-auto max-w-[1280px] px-4 py-8 sm:px-10 sm:py-14">
       <header className="mb-8 flex flex-col gap-5 sm:mb-12 sm:gap-6 sm:flex-row sm:items-end sm:justify-between">
         <div>
-          <h1 className="display text-[36px] leading-none tracking-display-tight text-fg sm:text-[44px]">
-            gitdash
-          </h1>
+          <MachineLabelEditor csrfToken={csrfToken} />
           <p className="mt-3 max-w-lg text-[14px] text-fg-muted sm:text-[15px]">
             {actionableCount === 0 ? (
               <>Nothing urgent. <span className="display-italic text-fg">All caught up.</span></>

--- a/components/RepoCard.tsx
+++ b/components/RepoCard.tsx
@@ -73,6 +73,7 @@ function primaryActions(
       return [
         { label: "Commit", action: "commit", variant: "secondary" },
         { label: "Commit & push", action: "commit-push", variant: "primary" },
+        { label: "Backup WIP", action: "wip-stash-push", variant: "secondary" },
       ];
     }
     return [{ label: "Commit", action: "commit", variant: "primary" }];
@@ -240,6 +241,7 @@ export function RepoCard({ repo, kind, csrfToken, expanded, onToggle }: Props) {
             csrfToken={csrfToken}
             expanded={expanded}
             snap={snap}
+            onModalAction={setModalAction}
           />
         </div>
 
@@ -260,6 +262,7 @@ export function RepoCard({ repo, kind, csrfToken, expanded, onToggle }: Props) {
               csrfToken={csrfToken}
               expanded={expanded}
               snap={snap}
+              onModalAction={setModalAction}
             />
           </div>
 
@@ -453,12 +456,14 @@ function RowIcons({
   csrfToken,
   expanded,
   snap,
+  onModalAction,
 }: {
   ghUrl: string | null;
   repoId: number;
   csrfToken: string;
   expanded: boolean;
   snap: import("@/lib/db/repos").SnapshotRow | null;
+  onModalAction: (action: string) => void;
 }) {
   const [refreshState, setRefreshState] = useState<"idle" | "spinning" | "error" | "rate-limited">("idle");
 
@@ -512,6 +517,20 @@ function RowIcons({
 
   return (
     <div className="flex items-center justify-end gap-0.5 sm:gap-1">
+      {ghUrl && (
+        <button
+          type="button"
+          onClick={(e) => {
+            e.stopPropagation();
+            onModalAction("wip-restore");
+          }}
+          title="Restore work-in-progress from another machine"
+          aria-label="Restore WIP from another machine"
+          className="inline-flex h-11 items-center justify-center rounded-full px-2 text-[11px] font-medium text-fg-dim transition-colors hover:bg-bg-hover hover:text-fg sm:h-7"
+        >
+          Restore WIP
+        </button>
+      )}
       <div className="relative flex items-center">
         {isStuck && refreshState === "idle" && (
           <span

--- a/lib/git/actions.ts
+++ b/lib/git/actions.ts
@@ -2,9 +2,13 @@ import { spawn, execFile } from "node:child_process";
 import { promisify } from "node:util";
 import { EventEmitter } from "node:events";
 import { randomUUID } from "node:crypto";
+import { hostname } from "node:os";
+import { readFile } from "node:fs/promises";
+import path from "node:path";
 import { assertSafeRef } from "./exec";
 import { translateGitError, friendlyStepLabel } from "./error-hints";
 import { getDb } from "@/lib/db/schema";
+import { sanitizeLabel } from "@/lib/security/label";
 
 const execFileAsync = promisify(execFile);
 
@@ -19,7 +23,9 @@ export type ActionName =
   | "open-terminal"
   | "commit"
   | "commit-push"
-  | "publish-to-github";
+  | "publish-to-github"
+  | "wip-stash-push"
+  | "wip-restore";
 
 export interface PublishOptions {
   name: string;
@@ -52,6 +58,11 @@ export function getRun(id: string): ActionRun | null {
   return runs.get(id) ?? null;
 }
 
+export interface WipRestoreOptions {
+  wipBranch: string;
+  deleteAfter: boolean;
+}
+
 interface StartOptions {
   repoId: number;
   repoPath: string;
@@ -59,6 +70,7 @@ interface StartOptions {
   branch: string | null;
   commitMessage?: string;
   publish?: PublishOptions;
+  wipRestore?: WipRestoreOptions;
 }
 
 export function startAction(opts: StartOptions): ActionRun {
@@ -83,6 +95,47 @@ export function startAction(opts: StartOptions): ActionRun {
     const pushAfter = opts.action === "commit-push";
     setImmediate(() => {
       executeCommit(run, opts.repoPath, message, opts.branch, pushAfter).catch((err) => {
+        run.emitter.emit("done", { exitCode: -1 });
+        run.exitCode = -1;
+        run.finishedAt = Date.now();
+        recordRunFinish(run);
+        run.lines.push(`[fatal] ${(err as Error).message}`);
+      });
+    });
+    getDb().prepare(
+      "INSERT INTO actions_log (repo_id, action, started_at) VALUES (?, ?, ?)",
+    ).run(opts.repoId, opts.action, run.startedAt);
+    return run;
+  }
+
+  if (opts.action === "wip-stash-push") {
+    setImmediate(() => {
+      executeWipStashPush(run, opts.repoPath, opts.branch).catch((err) => {
+        run.emitter.emit("done", { exitCode: -1 });
+        run.exitCode = -1;
+        run.finishedAt = Date.now();
+        recordRunFinish(run);
+        run.lines.push(`[fatal] ${(err as Error).message}`);
+      });
+    });
+    getDb().prepare(
+      "INSERT INTO actions_log (repo_id, action, started_at) VALUES (?, ?, ?)",
+    ).run(opts.repoId, opts.action, run.startedAt);
+    return run;
+  }
+
+  if (opts.action === "wip-restore") {
+    if (!opts.wipRestore) {
+      run.emitter.emit("done", { exitCode: -1 });
+      run.exitCode = -1;
+      run.finishedAt = Date.now();
+      recordRunFinish(run);
+      run.lines.push("[fatal] wip-restore requires wipBranch option");
+      return run;
+    }
+    const wipOpts = opts.wipRestore;
+    setImmediate(() => {
+      executeWipRestore(run, opts.repoPath, wipOpts).catch((err) => {
         run.emitter.emit("done", { exitCode: -1 });
         run.exitCode = -1;
         run.finishedAt = Date.now();
@@ -186,6 +239,10 @@ function buildArgs(action: ActionName, branch: string | null): string[] {
       return [];
     case "publish-to-github":
       return [];
+    case "wip-stash-push":
+      return [];
+    case "wip-restore":
+      return [];
   }
 }
 
@@ -228,6 +285,10 @@ function friendlyActionLabel(action: ActionName): string {
       return "Commit & push";
     case "publish-to-github":
       return "Publish to GitHub";
+    case "wip-stash-push":
+      return "Backup WIP";
+    case "wip-restore":
+      return "Restore WIP";
   }
 }
 
@@ -734,6 +795,335 @@ function executeRun(run: ActionRun, executable: string, args: string[], cwd?: st
   });
 }
 
+// ---------------------------------------------------------------------------
+// Machine-label helper
+// ---------------------------------------------------------------------------
+
+async function getMachineLabel(): Promise<string> {
+  try {
+    const xdg = process.env.XDG_CONFIG_HOME ?? path.join(process.env.HOME ?? ".", ".config");
+    const configPath = path.join(xdg, "gitdash", "config.json");
+    const raw = await readFile(configPath, "utf8");
+    const parsed = JSON.parse(raw) as Record<string, unknown>;
+    if (typeof parsed.machineLabel === "string" && parsed.machineLabel.trim().length > 0) {
+      return sanitizeLabel(parsed.machineLabel.trim());
+    }
+  } catch {
+    // fall through
+  }
+  return sanitizeLabel(hostname()) || "gitdash";
+}
+
+// ---------------------------------------------------------------------------
+// WIP stash-push: stash → wip branch → commit → push → return to source
+// ---------------------------------------------------------------------------
+
+async function executeWipStashPush(
+  run: ActionRun,
+  repoPath: string,
+  branch: string | null,
+): Promise<void> {
+  const emit = (text: string) => {
+    run.lines.push(text);
+    run.emitter.emit("line", text);
+  };
+
+  // Capture the current branch before stashing
+  const sourceBranch = branch;
+  if (!sourceBranch || sourceBranch === "(detached)") {
+    emit("[gitdash] ✗ Cannot back up WIP from a detached HEAD. Switch to a named branch first.");
+    run.finishedAt = Date.now();
+    run.exitCode = 1;
+    recordRunFinish(run);
+    run.emitter.emit("done", { exitCode: 1 });
+    return;
+  }
+
+  // Step 1: stash push
+  emit("[gitdash] Step 1/10: Stashing your current work…");
+  const stashCode = await spawnGitStep(run, emit, ["stash", "push", "-u", "-m", "gitdash:wip"], repoPath);
+  if (stashCode !== 0) {
+    // git stash returns 1 with "No local changes to save" — that's an early-exit, not an error
+    const lastLines = run.lines.slice(-5).join("\n");
+    if (lastLines.includes("No local changes to save") || lastLines.includes("nothing to save")) {
+      emit("[gitdash] Nothing to back up — your working tree is already clean.");
+      run.finishedAt = Date.now();
+      run.exitCode = 0;
+      recordRunFinish(run);
+      run.emitter.emit("done", { exitCode: 0 });
+      return;
+    }
+    emit(`[gitdash] ✗ ${friendlyStepLabel("stash")} didn't complete (exit ${stashCode}).`);
+    emitHint(emit, run.lines);
+    run.finishedAt = Date.now();
+    run.exitCode = stashCode;
+    recordRunFinish(run);
+    run.emitter.emit("done", { exitCode: stashCode });
+    return;
+  }
+
+  // Check if stash was actually created (exit 0 can happen with no changes in some git versions)
+  let stashRef = "";
+  try {
+    const result = await execFileAsync("git", ["-C", repoPath, "stash", "list", "--max-count=1"], {
+      timeout: 5_000,
+      env: { ...process.env, GIT_TERMINAL_PROMPT: "0" },
+    });
+    stashRef = result.stdout.trim();
+  } catch {
+    // continue
+  }
+  if (!stashRef) {
+    emit("[gitdash] Nothing to back up — your working tree is already clean.");
+    run.finishedAt = Date.now();
+    run.exitCode = 0;
+    recordRunFinish(run);
+    run.emitter.emit("done", { exitCode: 0 });
+    return;
+  }
+
+  // Step 2: read machine label
+  emit("[gitdash] Step 2/10: Reading machine label…");
+  const machineLabel = await getMachineLabel();
+  const wipBranch = `wip/${machineLabel}`;
+  emit(`[gitdash] WIP branch will be: ${wipBranch}`);
+
+  // Step 3: checkout WIP branch (create or reset)
+  emit(`[gitdash] Step 3/10: Switching to ${wipBranch}…`);
+  assertSafeRef(wipBranch);
+  const checkoutCode = await spawnGitStep(run, emit, ["checkout", "-B", wipBranch], repoPath);
+  if (checkoutCode !== 0) {
+    emit(`[gitdash] ✗ Could not switch to ${wipBranch} (exit ${checkoutCode}).`);
+    // Try to recover: pop the stash back on the original branch
+    emit("[gitdash] Recovering: restoring your stash on the original branch…");
+    await spawnGitStep(run, emit, ["checkout", sourceBranch], repoPath);
+    await spawnGitStep(run, emit, ["stash", "pop"], repoPath);
+    run.finishedAt = Date.now();
+    run.exitCode = checkoutCode;
+    recordRunFinish(run);
+    run.emitter.emit("done", { exitCode: checkoutCode });
+    return;
+  }
+
+  // Step 4: apply stash
+  emit("[gitdash] Step 4/10: Applying stashed changes onto WIP branch…");
+  const applyCode = await spawnGitStep(run, emit, ["stash", "apply"], repoPath);
+  if (applyCode !== 0) {
+    emit(`[gitdash] ✗ Stash apply failed (exit ${applyCode}). Recovering…`);
+    await spawnGitStep(run, emit, ["checkout", sourceBranch], repoPath);
+    await spawnGitStep(run, emit, ["stash", "pop"], repoPath);
+    run.finishedAt = Date.now();
+    run.exitCode = applyCode;
+    recordRunFinish(run);
+    run.emitter.emit("done", { exitCode: applyCode });
+    return;
+  }
+
+  // Step 5: stage all
+  emit("[gitdash] Step 5/10: Staging all changes…");
+  const addCode = await spawnGitStep(run, emit, ["add", "-A"], repoPath);
+  if (addCode !== 0) {
+    emit(`[gitdash] ✗ Staging failed (exit ${addCode}). Recovering…`);
+    await spawnGitStep(run, emit, ["checkout", sourceBranch], repoPath);
+    await spawnGitStep(run, emit, ["stash", "pop"], repoPath);
+    run.finishedAt = Date.now();
+    run.exitCode = addCode;
+    recordRunFinish(run);
+    run.emitter.emit("done", { exitCode: addCode });
+    return;
+  }
+
+  // Step 6: (secret scan gate happens in route before reaching here)
+
+  // Step 7: commit with encoded source branch + timestamp
+  const isoTimestamp = new Date().toISOString();
+  const wipMessage = `WIP from ${sourceBranch} · ${isoTimestamp}`;
+  emit(`[gitdash] Step 7/10: Committing: "${wipMessage}"…`);
+  const commitCode = await spawnGitStep(run, emit, ["commit", "-m", wipMessage], repoPath);
+  if (commitCode !== 0) {
+    emit(`[gitdash] ✗ Commit failed (exit ${commitCode}). Recovering…`);
+    await spawnGitStep(run, emit, ["checkout", sourceBranch], repoPath);
+    await spawnGitStep(run, emit, ["stash", "pop"], repoPath);
+    run.finishedAt = Date.now();
+    run.exitCode = commitCode;
+    recordRunFinish(run);
+    run.emitter.emit("done", { exitCode: commitCode });
+    return;
+  }
+
+  // Step 8: push with --force-with-lease (NOT --force)
+  emit(`[gitdash] Step 8/10: Pushing ${wipBranch} to origin…`);
+  const pushCode = await spawnGitStep(run, emit, ["push", "-u", "origin", wipBranch, "--force-with-lease"], repoPath);
+  if (pushCode !== 0) {
+    emit(`[gitdash] ✗ Push failed (exit ${pushCode}). Your WIP is saved locally on ${wipBranch}.`);
+    emit("[gitdash] hint: Another device may have pushed a newer WIP to the same branch. Check and retry.");
+    // Still return to source branch and restore stash
+    await spawnGitStep(run, emit, ["checkout", sourceBranch], repoPath);
+    await spawnGitStep(run, emit, ["stash", "pop"], repoPath);
+    run.finishedAt = Date.now();
+    run.exitCode = pushCode;
+    recordRunFinish(run);
+    run.emitter.emit("done", { exitCode: pushCode });
+    return;
+  }
+
+  // Step 9: return to source branch
+  emit(`[gitdash] Step 9/10: Returning to ${sourceBranch}…`);
+  assertSafeRef(sourceBranch);
+  const returnCode = await spawnGitStep(run, emit, ["checkout", sourceBranch], repoPath);
+  if (returnCode !== 0) {
+    emit(`[gitdash] ✗ Could not return to ${sourceBranch} (exit ${returnCode}).`);
+    // WIP is already pushed so this is non-fatal
+  }
+
+  // Step 10: restore working changes locally via stash pop
+  emit("[gitdash] Step 10/10: Restoring your working changes locally…");
+  const popCode = await spawnGitStep(run, emit, ["stash", "pop"], repoPath);
+  if (popCode !== 0) {
+    emit(`[gitdash] ✗ Stash pop failed (exit ${popCode}). Your work is saved on GitHub at ${wipBranch}.`);
+    emit("[gitdash] hint: Run 'git stash pop' manually if your local files look wrong.");
+  }
+
+  emit(`[gitdash] ✓ WIP backed up to ${wipBranch} on GitHub. You can keep working — nothing was committed to ${sourceBranch}.`);
+  run.finishedAt = Date.now();
+  run.exitCode = 0;
+  recordRunFinish(run);
+  run.emitter.emit("done", { exitCode: 0 });
+}
+
+// ---------------------------------------------------------------------------
+// WIP restore: fetch → cherry-pick → optionally delete remote WIP branch
+// ---------------------------------------------------------------------------
+
+async function executeWipRestore(
+  run: ActionRun,
+  repoPath: string,
+  opts: WipRestoreOptions,
+): Promise<void> {
+  const emit = (text: string) => {
+    run.lines.push(text);
+    run.emitter.emit("line", text);
+  };
+
+  const { wipBranch, deleteAfter } = opts;
+  assertSafeRef(wipBranch);
+
+  // Parse source branch from the WIP branch name — we'll get it from the commit message
+  // Step 1: fetch origin to refresh remote branches
+  emit("[gitdash] Step 1: Fetching latest remote branches…");
+  const fetchCode = await spawnGitStep(run, emit, ["fetch", "origin"], repoPath);
+  if (fetchCode !== 0) {
+    emit(`[gitdash] ✗ Fetch failed (exit ${fetchCode}). Check your internet connection and GitHub auth.`);
+    run.finishedAt = Date.now();
+    run.exitCode = fetchCode;
+    recordRunFinish(run);
+    run.emitter.emit("done", { exitCode: fetchCode });
+    return;
+  }
+
+  // Read the WIP commit message to determine the source branch
+  let sourceBranch: string | null = null;
+  try {
+    const logResult = await execFileAsync(
+      "git",
+      ["-C", repoPath, "log", "-1", "--format=%s", `origin/${wipBranch}`],
+      { timeout: 10_000, env: { ...process.env, GIT_TERMINAL_PROMPT: "0" } },
+    );
+    const subject = logResult.stdout.trim();
+    // Format: "WIP from <branch> · <iso>"
+    const match = subject.match(/^WIP from (.+?) · \d{4}-/);
+    if (match?.[1]) {
+      sourceBranch = match[1];
+    }
+  } catch {
+    // Could not parse — continue without auto-switching
+  }
+
+  // Step 4: check for uncommitted changes
+  let hasDirty = false;
+  try {
+    const statusResult = await execFileAsync(
+      "git",
+      ["-C", repoPath, "status", "--porcelain=v2"],
+      { timeout: 5_000, env: { ...process.env, GIT_TERMINAL_PROMPT: "0" } },
+    );
+    hasDirty = statusResult.stdout.trim().length > 0;
+  } catch {
+    // assume clean
+  }
+
+  if (hasDirty) {
+    emit("[gitdash] ✗ You have uncommitted changes. Please stash or commit your work before restoring WIP.");
+    emit("[gitdash] hint: Use the Backup WIP button to save your current work first, or use the Commit button to commit it.");
+    run.finishedAt = Date.now();
+    run.exitCode = 1;
+    recordRunFinish(run);
+    run.emitter.emit("done", { exitCode: 1 });
+    return;
+  }
+
+  // Switch to source branch if we know it
+  if (sourceBranch) {
+    assertSafeRef(sourceBranch);
+    emit(`[gitdash] Switching to source branch: ${sourceBranch}…`);
+    const checkoutCode = await spawnGitStep(run, emit, ["checkout", sourceBranch], repoPath);
+    if (checkoutCode !== 0) {
+      emit(`[gitdash] ✗ Could not switch to ${sourceBranch} (exit ${checkoutCode}). Branch may not exist locally.`);
+      emit(`[gitdash] hint: Create a local branch called '${sourceBranch}' first, then retry.`);
+      run.finishedAt = Date.now();
+      run.exitCode = checkoutCode;
+      recordRunFinish(run);
+      run.emitter.emit("done", { exitCode: checkoutCode });
+      return;
+    }
+  }
+
+  // Step 5: cherry-pick --no-commit to apply WIP as working-tree edits
+  emit(`[gitdash] Applying WIP from ${wipBranch} as working changes (not committing)…`);
+  const cherryCode = await spawnGitStep(
+    run,
+    emit,
+    ["cherry-pick", "--no-commit", `origin/${wipBranch}`],
+    repoPath,
+  );
+  if (cherryCode !== 0) {
+    emit(`[gitdash] ✗ Could not apply WIP (exit ${cherryCode}). There may be conflicts.`);
+    emit("[gitdash] hint: Resolve any conflicts shown above, then the changes will be in your working tree.");
+    // Abort cherry-pick to clean up state
+    await spawnGitStep(run, emit, ["cherry-pick", "--abort"], repoPath);
+    run.finishedAt = Date.now();
+    run.exitCode = cherryCode;
+    recordRunFinish(run);
+    run.emitter.emit("done", { exitCode: cherryCode });
+    return;
+  }
+
+  // Reset staged changes back to working tree (we want edits, not staged)
+  emit("[gitdash] Unstaging changes so they appear as working-tree edits…");
+  await spawnGitStep(run, emit, ["reset", "HEAD"], repoPath);
+
+  // Step 6: optionally delete remote WIP branch
+  if (deleteAfter) {
+    emit(`[gitdash] Deleting remote WIP branch ${wipBranch}…`);
+    const deleteCode = await spawnGitStep(run, emit, ["push", "origin", "--delete", wipBranch], repoPath);
+    if (deleteCode !== 0) {
+      emit(`[gitdash] ✗ Could not delete remote branch (exit ${deleteCode}). You can delete it manually from GitHub.`);
+      // Non-fatal — WIP was still restored
+    } else {
+      emit(`[gitdash] ✓ Remote branch ${wipBranch} deleted.`);
+    }
+  }
+
+  const branchDesc = sourceBranch ? ` on branch ${sourceBranch}` : "";
+  emit(`[gitdash] ✓ WIP from ${wipBranch} restored${branchDesc}. Your changes are in the working tree — nothing is committed.`);
+  run.finishedAt = Date.now();
+  run.exitCode = 0;
+  recordRunFinish(run);
+  run.emitter.emit("done", { exitCode: 0 });
+}
+
+// ---------------------------------------------------------------------------
+
 const VALID_ACTIONS: ReadonlySet<string> = new Set([
   "fetch",
   "pull",
@@ -746,6 +1136,8 @@ const VALID_ACTIONS: ReadonlySet<string> = new Set([
   "commit",
   "commit-push",
   "publish-to-github",
+  "wip-stash-push",
+  "wip-restore",
 ]);
 
 export function isValidAction(value: string): value is ActionName {

--- a/lib/git/exec.ts
+++ b/lib/git/exec.ts
@@ -16,6 +16,7 @@ const READ_ONLY_GIT_SUBCOMMANDS = new Set([
   "for-each-ref",
   "diff",
   "ls-files",
+  "ls-remote",
   "symbolic-ref",
 ]);
 
@@ -26,6 +27,11 @@ const MUTATING_GIT_SUBCOMMANDS = new Set([
   "merge",
   "stash",
   "rebase",
+  "add",
+  "commit",
+  "checkout",
+  "cherry-pick",
+  "reset",
 ]);
 
 export type GitRunMode = "read" | "mutate";

--- a/lib/scan/discover.ts
+++ b/lib/scan/discover.ts
@@ -10,6 +10,8 @@ export interface DiscoveryConfig {
   includeDotfilesAsRepoRoots: boolean;
   /** If false, the home-dir-as-repo and dotfile-tool repos are filtered out. */
   showSystemRepos: boolean;
+  /** Human-readable label for this machine shown in the dashboard title. */
+  machineLabel?: string;
 }
 
 export const DEFAULT_CONFIG: DiscoveryConfig = {

--- a/lib/security/label.ts
+++ b/lib/security/label.ts
@@ -1,0 +1,40 @@
+/**
+ * Sanitization helpers for machine labels.
+ *
+ * sanitizeLabel  — produces a branch-safe string (lowercase alnum + dash, max 40 chars).
+ * displayLabel   — returns the effective display label, falling back to a sanitized hostname.
+ */
+
+/**
+ * Convert an arbitrary string into a branch-name-safe slug.
+ * Rules:
+ *   - Lowercase
+ *   - Keep ASCII alphanumerics and hyphens; strip everything else
+ *   - Collapse consecutive hyphens into one
+ *   - Strip leading/trailing hyphens
+ *   - Truncate to 40 characters
+ */
+export function sanitizeLabel(input: string): string {
+  return input
+    .toLowerCase()
+    .replace(/[^a-z0-9-]+/g, "-") // non-alnum → hyphen
+    .replace(/-{2,}/g, "-")        // collapse runs
+    .replace(/^-+|-+$/g, "")       // trim edges
+    .slice(0, 40)
+    .replace(/-+$/g, "");          // re-trim after truncation
+}
+
+/**
+ * Return the display label for this machine.
+ * If `input` is a non-empty string after trimming, return it as-is (not sanitized —
+ * the user may have set a pretty name like "Chirag's Laptop").
+ * Otherwise fall back to a sanitized version of `hostnameFallback`.
+ */
+export function displayLabel(
+  input: string | null | undefined,
+  hostnameFallback: string,
+): string {
+  const trimmed = (input ?? "").trim();
+  if (trimmed.length > 0) return trimmed;
+  return sanitizeLabel(hostnameFallback) || hostnameFallback;
+}


### PR DESCRIPTION
## Summary

- Adds `wip-stash-push` action: stashes WIP, creates/resets `wip/<machine-label>` branch, commits with encoded source branch + ISO timestamp, pushes with `--force-with-lease`, returns user to original branch and pops stash locally
- Adds `wip-restore` action: fetches remote, lets user pick a `wip/*` branch, cherry-picks `--no-commit` onto working tree, optionally deletes remote branch after restore
- Adds GET `/api/repos/[id]/wip-list` endpoint: enumerates remote `wip/*` branches, parses commit subject for metadata, filters out own machine by default
- "Backup WIP" button appears on dirty rows with a remote; "Restore WIP" appears in row icons for any repo with a GitHub remote
- WIP commit message encodes source branch: `WIP from <branch> · <ISO>` — restore auto-switches to that branch
- All git calls go through `execFile`/`spawn`, never `bash -c`; `assertSafeRef` guards every branch ref; `--force-with-lease` prevents overwriting unexpected remote state

Closes #158

## Test plan

**Backup WIP (machine A):**
- [ ] Edit a tracked file and add an untracked file in any repo
- [ ] Click "Backup WIP" button — confirm modal shows file count and any suspicious files
- [ ] Confirm → progress log shows 10 steps, exits 0
- [ ] On GitHub, verify `wip/<your-label>` branch exists with commit "WIP from <branch> · <iso>"
- [ ] Confirm working tree on machine A is still dirty (stash was popped)

**Secret scan gate:**
- [ ] Add a file named `.env.secret` with `AWS_SECRET_ACCESS_KEY=fake123` content
- [ ] Click "Backup WIP" → confirm suspicious file warning appears in modal
- [ ] (No hard block currently — same UX as commit-push: warns, lets user proceed)

**Restore WIP (machine B):**
- [ ] Clone same repo on another machine (or use a second gitdash instance)
- [ ] Click "Restore WIP" in the row icons — modal fetches and lists `wip/<machine-A-label>`
- [ ] Select the branch, keep "delete remote backup after restore" checked, click Restore
- [ ] Confirm both file edits appear in working tree on the correct source branch
- [ ] Confirm `wip/<machine-A-label>` is deleted from GitHub

**--force-with-lease rejection:**
- [ ] Manually `git push --force origin HEAD:refs/heads/wip/<your-label>` from a third location to advance remote WIP
- [ ] Attempt Backup WIP from machine A → push should fail cleanly, user is returned to original branch with stash still intact

**Empty stash early-exit:**
- [ ] On a clean repo (no dirty files), click "Backup WIP" → action completes with "Nothing to back up" message, exit 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)
