### PR TITLE
fix(autoheal): "Reload now" / "Try again" always work after budget exhausted (#166)

### DIFF
--- a/app/error.tsx
+++ b/app/error.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useEffect, useState } from "react";
-import { hardReload, isChunkLoadError, tryConsumeReloadBudget } from "@/lib/autoheal";
+import { clearReloadBudget, hardReload, isChunkLoadError, tryConsumeReloadBudget } from "@/lib/autoheal";
 
 // Page-level error boundary. Catches errors thrown inside the dashboard tree
 // (anything below RootLayout). Same auto-heal contract as global-error.tsx
@@ -59,14 +59,24 @@ export default function PageError({
       <div className="flex flex-wrap items-center justify-center gap-3">
         <button
           type="button"
-          onClick={() => hardReload()}
+          onClick={() => {
+            clearReloadBudget();
+            hardReload();
+          }}
           className="rounded-full bg-accent-clean px-5 py-2 text-[13px] font-semibold text-bg transition-colors hover:opacity-90"
         >
           Reload now
         </button>
         <button
           type="button"
-          onClick={() => reset()}
+          onClick={() => {
+            if (chunk) {
+              clearReloadBudget();
+              hardReload();
+            } else {
+              reset();
+            }
+          }}
           className="rounded-full border border-border px-5 py-2 text-[13px] font-medium text-fg-muted transition-colors hover:border-fg-muted hover:text-fg"
         >
           Try again

--- a/app/global-error.tsx
+++ b/app/global-error.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useEffect, useState } from "react";
-import { hardReload, isChunkLoadError, tryConsumeReloadBudget } from "@/lib/autoheal";
+import { clearReloadBudget, hardReload, isChunkLoadError, tryConsumeReloadBudget } from "@/lib/autoheal";
 
 // Root-level error boundary. Catches anything that escapes layout.tsx — e.g.
 // a render error in the dashboard tree or a chunk failure during initial
@@ -80,7 +80,10 @@ export default function GlobalError({
           <div style={{ display: "flex", gap: 12, justifyContent: "center" }}>
             <button
               type="button"
-              onClick={() => hardReload()}
+              onClick={() => {
+                clearReloadBudget();
+                hardReload();
+              }}
               style={{
                 background: "#3aa688",
                 color: "#0b0d0c",
@@ -96,7 +99,16 @@ export default function GlobalError({
             </button>
             <button
               type="button"
-              onClick={() => reset()}
+              onClick={() => {
+                if (chunk) {
+                  // For chunk errors, reset() just re-runs the same broken
+                  // bundle. Force a fresh fetch instead.
+                  clearReloadBudget();
+                  hardReload();
+                } else {
+                  reset();
+                }
+              }}
               style={{
                 background: "transparent",
                 color: "#9aa6a0",

--- a/lib/autoheal.ts
+++ b/lib/autoheal.ts
@@ -94,6 +94,21 @@ export function isChunkLoadError(err: unknown): boolean {
 }
 
 /**
+ * Reset the auto-reload budget. The buttons in error.tsx / global-error.tsx
+ * call this before doing a manual reload so a user who's already burned
+ * through the auto-reload cap isn't quietly punished — their click should
+ * always cause a real reload.
+ */
+export function clearReloadBudget(): void {
+  if (typeof window === "undefined") return;
+  try {
+    window.sessionStorage.removeItem(RELOAD_BUDGET_KEY);
+  } catch {
+    // sessionStorage unavailable — nothing to clear.
+  }
+}
+
+/**
  * Returns true if the caller is allowed to auto-reload right now. Increments
  * the budget. Returns false once the cap is hit so the UI can fall back to
  * "show the friendly error and let the human decide".


### PR DESCRIPTION
## Summary
- New \`clearReloadBudget()\` in \`lib/autoheal.ts\` — clears the sessionStorage budget key
- Both error boundaries (\`app/error.tsx\`, \`app/global-error.tsx\`): **Reload now** clears the budget then hard-reloads, so a manual click is never silently dropped
- **Try again** on chunk errors now hard-reloads instead of \`reset()\` — \`reset()\` just re-renders the same broken bundle and re-trips the boundary instantly

Restores the NORTH STAR contract on the auto-heal screen: a beginner's only recovery before this PR was DevTools → Clear site data, or opening an incognito window. Both buttons in the UI could fail silently.

## Test plan
- [ ] Trigger the chunk-error boundary 4+ times in 30s (rebuild gitdash a few times in quick succession with a tab open)
- [ ] After the budget exhausts, click **Reload now** → page actually reloads (not no-op)
- [ ] Click **Try again** in the same state → also reloads (not soft-reset that re-trips the boundary)
- [ ] Trigger a non-chunk error → **Try again** still does \`reset()\` (soft retry within the React tree)
- [ ] Auto-reload protection still works on the next genuine reload loop (budget is cleared but re-fills on the next \`tryConsumeReloadBudget\` call)

Closes #166

🤖 Generated with [Claude Code](https://claude.com/claude-code)