### PR TITLE
fix(ui): readable primary buttons in sign-in/clone/update flows (#168)

### DIFF
--- a/components/GhSignInModal.tsx
+++ b/components/GhSignInModal.tsx
@@ -171,7 +171,7 @@ export function GhSignInModal({ csrfToken, onClose, onSuccess }: Props) {
                   href={phase.verificationUri}
                   target="_blank"
                   rel="noopener noreferrer"
-                  className="mt-2 flex w-full items-center justify-center gap-2 rounded-lg bg-accent px-4 py-3 text-[14px] font-medium text-bg transition-colors hover:bg-accent-strong"
+                  className="mt-2 flex w-full items-center justify-center gap-2 rounded-full border border-accent-push/45 bg-accent-push/15 px-4 py-3 text-[14px] font-medium text-accent-push transition-colors hover:bg-accent-push/25"
                 >
                   Open GitHub in browser
                   <ExternalLink className="h-4 w-4" />
@@ -210,7 +210,7 @@ export function GhSignInModal({ csrfToken, onClose, onSuccess }: Props) {
             <button
               type="button"
               onClick={onClose}
-              className="mt-4 w-full rounded-lg bg-accent px-4 py-2 text-[14px] font-medium text-bg transition-colors hover:bg-accent-strong"
+              className="mt-4 w-full rounded-full border border-accent-push/45 bg-accent-push/15 px-4 py-2 text-[14px] font-medium text-accent-push transition-colors hover:bg-accent-push/25"
             >
               Done
             </button>
@@ -232,7 +232,7 @@ export function GhSignInModal({ csrfToken, onClose, onSuccess }: Props) {
                   startedRef.current = false;
                   setPhase({ kind: "starting" });
                 }}
-                className="flex-1 rounded-lg bg-accent px-4 py-2 text-[14px] font-medium text-bg transition-colors hover:bg-accent-strong"
+                className="flex-1 rounded-full border border-accent-push/45 bg-accent-push/15 px-4 py-2 text-[14px] font-medium text-accent-push transition-colors hover:bg-accent-push/25"
               >
                 Try again
               </button>

--- a/components/RemoteReposSection.tsx
+++ b/components/RemoteReposSection.tsx
@@ -148,7 +148,7 @@ export function RemoteReposSection({ csrfToken, refreshKey = 0 }: Props) {
               <button
                 type="button"
                 onClick={() => setSignInOpen(true)}
-                className="flex items-center gap-2 rounded-lg bg-accent px-4 py-2 text-[14px] font-medium text-bg transition-colors hover:bg-accent-strong"
+                className="flex items-center gap-2 rounded-full border border-accent-push/45 bg-accent-push/15 px-4 py-2 text-[14px] font-medium text-accent-push transition-colors hover:bg-accent-push/25"
               >
                 <Github className="h-4 w-4" />
                 Sign in to GitHub

--- a/components/UpdateBanner.tsx
+++ b/components/UpdateBanner.tsx
@@ -91,8 +91,8 @@ export function UpdateBanner() {
         type="button"
         onClick={() => hardReload()}
         className={cn(
-          "rounded-md bg-accent-positive px-3 py-1 text-sm font-medium",
-          "text-bg hover:opacity-90",
+          "rounded-full border border-accent-clean/45 bg-accent-clean/15 px-3 py-1 text-sm font-medium",
+          "text-accent-clean hover:bg-accent-clean/25",
         )}
       >
         Reload now


### PR DESCRIPTION
## Summary
6-line fix. Five primary buttons in user-facing flows used phantom Tailwind classes (\`bg-accent\`, \`bg-accent-strong\`, \`bg-accent-positive\`, \`text-bg\`) that don't resolve in this codebase, rendering as dark-on-dark and unreadable.

Swapped each to the established tinted-button pattern already used by the working **Connect GitHub** button (\`border-accent-X/45 + bg-accent-X/15 + text-accent-X\`).

## Test plan
- [ ] Open the dashboard, click any sign-in flow that surfaces \`GhSignInModal\` — **Open GitHub in browser** is readable
- [ ] After sign-in completes, **Done** is readable
- [ ] If sign-in fails, the retry button is readable
- [ ] Open the "on GitHub, not on this machine" section, **Sign in to GitHub** is readable
- [ ] Trigger a version-mismatch in UpdateBanner, **Reload now** is readable

Closes #168

🤖 Generated with [Claude Code](https://claude.com/claude-code)